### PR TITLE
Use a more compatible Foundry/Brocade syntax for turning off paging

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -26,7 +26,7 @@ class IronWare < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
-    post_login 'terminal length 0'
+    post_login 'skip-page-display'
     pre_logout 'exit'
   end
 


### PR DESCRIPTION
Unfortunately, older Foundry/Brocade hardware doesn't support "terminal
length 0" and you have to use the much clunkier "skip-page-display"
instead. This especially affects older FastIron era devices.
