### PR TITLE
Add Ubiquiti AirOS model

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@
  * Huawei VRP
  * Juniper JunOS
  * Juniper ScreenOS (Netscreen)
+ * Ubiquiti AirOS
 
 # Install
 

--- a/lib/oxidized/model/airos.rb
+++ b/lib/oxidized/model/airos.rb
@@ -1,0 +1,20 @@
+class Airos < Oxidized::Model
+  # Ubiquiti AirOS circa 5.x
+  
+  prompt /^[^#]+# /
+  
+  cmd 'cat /etc/board.info' do |cfg|
+    cfg.split("\n").map { |line| "# #{line}" }.join("\n") + "\n"
+  end
+  
+  cmd 'cat /tmp/system.cfg'
+  
+  cmd :secret do |cfg|
+    cfg.gsub! /^(users\.\d+\.password|snmp\.community)=.+/, "# \\1=<hidden>"
+    cfg
+  end
+
+  cfg :ssh do
+    exec true
+  end
+end


### PR DESCRIPTION
This model supports [Ubiquiti AirOS](http://dl.ubnt.com/guides/airOS/airOS_UG.pdf) 5.x devices, specifically including all the AirMax M devices. I don't have any AirMax AC devices to check but that'll probably work too.
