### PR TITLE
Add model for Cisco small business switches

### DIFF
--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -1,0 +1,48 @@
+class CiscoSMB < Oxidized::Model
+
+  # Cisco Small Business 200, 300, 500, and ESW2 series switches
+  # http://www.cisco.com/c/en/us/support/switches/small-business-300-series-managed-switches/products-release-notes-list.html
+
+  prompt /^\r?([\w.@()-]+[#>]\s?)$/
+  comment  '! '
+
+  cmd :all do |cfg|
+    lines = cfg.each_line.to_a[1..-2]
+    # Remove \r from beginning of response
+    lines[0].gsub!(/^\r.*?/, '') if lines.length > 0
+    lines.join
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /username (\S+) privilege (\d+) (\S+).*/, '<secret hidden>'
+    cfg
+  end
+
+  cmd 'show version' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show inventory' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg = cfg.each_line.to_a[0..-1].join
+    cfg.gsub! /^Current configuration : [^\n]*\n/, ''
+    cfg.sub! /^(ntp clock-period).*/, '! \1'
+    cfg.gsub! /^\ tunnel\ mpls\ traffic-eng\ bandwidth[^\n]*\n*(
+                  (?:\ [^\n]*\n*)*
+                  tunnel\ mpls\ traffic-eng\ auto-bw)/mx, '\1'
+    cfg
+  end
+
+  cfg :telnet, :ssh do
+    username /^User Name:/
+    password /^\r?Password:$/
+    post_login 'terminal datadump' # Disable pager
+    post_login 'terminal width 0'
+    pre_logout 'exit'
+  end
+
+end


### PR DESCRIPTION
This new model should support Cisco Small Business 200, 300, 500, and ESW2 series switches. It appears [the same firmware](http://www.cisco.com/c/en/us/support/switches/small-business-300-series-managed-switches/products-release-notes-list.html) is used throughout.

I'm not sure what to name the model. I can't find a name for the operating system from any Cisco documentation. It's currently Cisco300 because I have a 300 series switch.

```
#show version
SW version    1.3.7.18 ( date  12-Jan-2014 time  18:02:59 )
Boot version    1.3.5.06 ( date  21-Jul-2013 time  15:12:10 )
HW version    V02
```

This model strips the extra '\r' on the first line at the beginning of a response.

```
"\r\n\r\r\n\r\n\r\nUser Name:"
"admin\r\n\rPassword:"
```

Closes #40.
