### PR TITLE
Fixing Cisco ASA models

### DIFF
--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -16,11 +16,10 @@ class ASA < Oxidized::Model
     cfg
   end
 
-  cmd 'show clock' do |cfg|
-    comment cfg
-  end
-
   cmd 'show version' do |cfg|
+    # avoid commits due to uptime / ixo-router01 up 2 mins 28 secs / ixo-router01 up 1 days 2 hours
+    cfg = cfg.each_line.select { |line| not line.match /\s+up\s+\d+\s+/ }
+    cfg = cfg.join
     comment cfg
   end
 


### PR DESCRIPTION
Cisco ASA hostnames might contain additional characters, hostname portion taken from the IOS model.

The clock will change on each run and thus create a new git commit for every run. Also show version includes a line with the current uptime on my ASA for which applies the same as for show clock. Also thanks to 

Also thanks to @terrorobe for helping me with the debugging. ;-)
