### PR TITLE
stop Aruba changing diff each 'show inventory'

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -1,7 +1,8 @@
 class AOSW < Oxidized::Model
 
-  # AOSW - Alcatel-Lucent OS - Wireless 
-  # Used in Alcatel OAW-4750 WLAN controller (Aruba)
+  # AOSW Aruba Wireless
+  # Used in Alcatel OAW-4750 WLAN controller
+  # Also Dell controllers
 
   comment  '# '
   prompt /^\([^)]+\) #/
@@ -17,6 +18,8 @@ class AOSW < Oxidized::Model
 
   cmd 'show inventory' do |cfg|
     cfg = cfg.each_line.take_while { |line| not line.match /Output \d Config/i }
+    # drop the temperature, fan speed and voltage, which change each run
+    cfg.gsub! /[0-9]+ (RPM|mV|C)\n/, ''
     comment cfg.join
   end
 


### PR DESCRIPTION
also change the boilerplate to be more realistic about the OEM relationship.

example problem:
```
commit 0ff2101fe45f4c7940ad13e6ca33337130a9b602
Author: Oxidized <oxidized@XXX.com>
Date:   Tue Jan 20 01:26:20 2015 -0800

    update ldnwifi-ctl.corp.XXX.com
---
 ldnwifi-ctl.corp.XXX.com | 12 ++++++------
 1 file changed, 6 insertions(+), 6 deletions(-)

diff --git a/ldnwifi-ctl.corp.XXX.com b/ldnwifi-ctl.corp.XXX.com
index 6a1c0cb..a034c4b 100644
--- a/ldnwifi-ctl.corp.XXX.com
+++ b/ldnwifi-ctl.corp.XXX.com
@@ -25,17 +25,17 @@
 # CPLD Version                    : (Rev: 1.3)
 # Aruba3400 Card Temperatures		:
 # 				: Card Temperature          34 C
-# 				: CPU Temperature           46 C
+# 				: CPU Temperature           45 C
 # Aruba3400 Fan Tachometers		:
 # 				: Chassis Fan A             4067 RPM
 # 				: Chassis Fan B             4000 RPM
-# 				: Chassis Fan C             3934 RPM
-# 				: Chassis Fan D             3934 RPM
+# 				: Chassis Fan C             4000 RPM
+# 				: Chassis Fan D             4067 RPM
 # Aruba3400 Card Voltages		:
 # 				: VMON1 3300mV              3348 mV
-# 				: VMON2 2500mV              2544 mV
-# 				: VMON3 AB 1800mV           1798 mV
-# 				: VMON4 CD 1800mV           1804 mV
+# 				: VMON2 2500mV              2550 mV
+# 				: VMON3 AB 1800mV           1792 mV
+# 				: VMON4 CD 1800mV           1806 mV
 # 				: VMON5 1200mV              1222 mV
 # 				: VMON6 1000mV               998 mV
 # 
```