### PR TITLE
Fix: Handle missing output file

### DIFF
--- a/lib/oxidized/output/file.rb
+++ b/lib/oxidized/output/file.rb
@@ -33,6 +33,7 @@ class OxidizedFile < Output
         IO.readlines File.join(cfg_dir, node)
       else
         path = Dir.glob File.join(cfg_dir, '**', node) # fetch node in all groups
+        return nil if path[0].nil?
         open(path[0], 'r').readlines
       end
     end


### PR DESCRIPTION
If we try to fetch a config and no output file can be found, return nil.

Previously, it would try to find the output file by doing a recursive glob search in the config dir.  It would then try to open the file for reading regardless of whether any file was found.

I ran into this when I fired up oxidized for the first time and tried to access a switch config on oxidized-web before it had a chance to collect it.

In this scenario, you get a stack trace on the switch config page (e.g. `http://oxidized.example.com:8888/node/fetch/switch-001.example.com`):

```
Puma caught this error: undefined method `join' for #<String:0x007f3a3c4283f8> (NoMethodError)
/usr/lib64/ruby/gems/2.2.0/gems/sinatra-1.4.5/lib/sinatra/show_exceptions.rb:37:in `rescue in call'
/usr/lib64/ruby/gems/2.2.0/gems/sinatra-1.4.5/lib/sinatra/show_exceptions.rb:21:in `call'
/usr/lib64/ruby/gems/2.2.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:180:in `call'
/usr/lib64/ruby/gems/2.2.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:2014:in `call'
/usr/lib64/ruby/gems/2.2.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:1478:in `block in call'
/usr/lib64/ruby/gems/2.2.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:1788:in `synchronize'
/usr/lib64/ruby/gems/2.2.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:1478:in `call'
/usr/lib64/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/urlmap.rb:66:in `block in call'
/usr/lib64/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/urlmap.rb:50:in `each'
/usr/lib64/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/urlmap.rb:50:in `call'
/usr/lib64/ruby/gems/2.2.0/gems/rack-1.6.0/lib/rack/builder.rb:153:in `call'
/usr/lib64/ruby/gems/2.2.0/gems/puma-2.11.1/lib/puma/server.rb:507:in `handle_request'
/usr/lib64/ruby/gems/2.2.0/gems/puma-2.11.1/lib/puma/server.rb:375:in `process_client'
/usr/lib64/ruby/gems/2.2.0/gems/puma-2.11.1/lib/puma/server.rb:262:in `block in run'
/usr/lib64/ruby/gems/2.2.0/gems/puma-2.11.1/lib/puma/thread_pool.rb:104:in `call'
/usr/lib64/ruby/gems/2.2.0/gems/puma-2.11.1/lib/puma/thread_pool.rb:104:in `block in spawn_thread'
```