### PR TITLE
Add back ability to use passwordless enable on EOS

### DIFF
--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -28,8 +28,11 @@ class EOS < Oxidized::Model
     if vars :enable
       post_login do
         send "enable\n"
-        expect /[pP]assword:\s?$/
-        send vars(:enable) + "\n"
+        # Interpret enable: true as meaning we won't be prompted for a password
+        unless vars(:enable).is_a? TrueClass
+          expect /[pP]assword:\s?$/
+          send vars(:enable) + "\n"
+        end
         expect /^.+[#>]\s?$/
       end
       post_login 'terminal length 0'
@@ -38,4 +41,3 @@ class EOS < Oxidized::Model
   end
 
 end
-


### PR DESCRIPTION
This commit adds the ability to go into Privileged EXEC mode when no password is required by setting `enable: true`.

By default, in Arista EOS you aren't prompted for a password when entering Privileged EXEC (or privilege mode 15) mode. In PR #86, oxidized began always expecting a password.

An unquoted `true` in YAML is a boolean. So when `var(:enabled)` is `TrueClass`, we interpret this as meaning that the user wishes to go into Privileged EXEC mode and does not require a password.