### PR TITLE
Fix terminal length issues with older powerconnect switches

### DIFF
--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -39,6 +39,7 @@ class PowerConnect < Oxidized::Model
       end
     end
 
+    post_login "terminal datadump"
     post_login "terminal length 0"
     pre_logout "logout"
     

--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -42,6 +42,7 @@ class PowerConnect < Oxidized::Model
     post_login "terminal datadump"
     post_login "terminal length 0"
     pre_logout "logout"
+    pre_logout "exit"
     
   end
 


### PR DESCRIPTION
Fixes the issue mentioned in #89 by sending both commands and allowing one of them to fail.