### PR TITLE
Backup full ASA configuration (include passwords)

### DIFF
--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -23,7 +23,7 @@ class ASA < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show running-config' do |cfg|
+  cmd 'more system:running-config' do |cfg|
     cfg = cfg.each_line.to_a[3..-1].join
     cfg.gsub! /^: [^\n]*\n/, ''
     cfg


### PR DESCRIPTION
At the old version it didn't backup things like ldap passwords, which ended up in output marked as '****'.

pre: ldap-login-password *****
now: ldap-login-password wBGqqqCY5SjZ8hY