### PR TITLE
Some Git libraries cant see initial commit

### DIFF
--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -99,6 +99,7 @@ class Git < Output
         :parents    => repo.empty? ? [] : [repo.head.target].compact,
         :update_ref => 'HEAD',
       )
+      index.write
     end
   end
 end


### PR DESCRIPTION
Using some libraries, in this case pygit2 the initial commit cannot be seen, a change and new commit fixes this.

Adding index.write appears to be a simple fix, as confirmed in this rugged issue:

https://github.com/libgit2/rugged/issues/441