### PR TITLE
Add a pre_logout for some devices

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -57,7 +57,10 @@ class IronWare < Oxidized::Model
       end
     end
     post_login 'skip-page-display'
+    post_login 'terminal length 0'
     pre_logout 'logout'
+    pre_logout 'exit'
+    pre_logout 'exit'
   end
 
 end


### PR DESCRIPTION
On an ironware device, 'logout' is not recognized, but also with just one " pre_logout 'exit' " it doesn't work.
I don't know if add two pre_logout is the best way to handle it, but actually I don't see an other way to do it.
Added an other post_login to handle pager.