### PR TITLE
Add support for HP Comware SMB switches

### DIFF
--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -21,6 +21,17 @@ class Comware < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
+    # enable command-line mode on SMB comware switches (HP V1910, V1920)
+    # autodetection is hard, because the 'summary' command is paged, and
+    # the pager cannot be disabled before _cmdline-mode on.
+    if vars :comware_cmdline
+      post_login do
+        send "_cmdline-mode on\n"
+        send "y\n"
+        send vars(:comware_cmdline) + "\n"
+      end
+    end
+
     post_login 'screen-length disable'
     post_login 'undo terminal monitor'
     pre_logout 'quit'


### PR DESCRIPTION
Some SMB HP switches (V1910, V1920) run Comware, but have the CLI hidden behind a "secret" toggle - it needs to be activated by _cmdline-mode on. The password to enable it varies per model, so this patch introduces a new var, comware_cmdline to contain the password.

Unfortunately we cannot easily autodetect this, as only the "summary" command can give us the model number, but this command is paged and we cannot disable the pager until we are in the full CLI.

Tested on HP V1910-24G-POE.