### PR TITLE
Changed prompt (too strict)

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -1,6 +1,6 @@
 class IronWare < Oxidized::Model
 
-  prompt /^((\w*)@(.*)([>#])+)$/
+  prompt /^(\S*)([>#])+$/
   comment  '! '
   
   #to handle pager without enable


### PR DESCRIPTION
For some devices, prompt is too strict (the begin of the prompt could be BR-SSH@ ... for example)