### PR TITLE
match more 'uptime' line in 'show version' and delete 'show chassis' 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# 0.6.0
+- FEATURE: support cumulus linux (by @FlorianDoublet)
+- FEATURE: support HP Comware SMB siwtches (by @sid3windr)
+- FEATURE: remove secret additions (by @rodecker)
+- FEATURE: option to put all groups in single repo (by @ytti)
+- FEATURE: expand path in source: csv: (so that ~/foo/bar works) (by @ytti)
+- BUGFIX: screenos fixes (by @rixxxx)
+- BUGFIX: ironware fixes (by @FlorianDoublet)
+- BUGFIX: powerconnect fixes (by @sid3windr)
+- BUGFIX: don't ask interactive password in new net/ssh (by @ytti)
+
 # 0.5.0
 - FEATURE: Mikrotik RouterOS model (by @emjemj)
 - FEATURE: add support for Cisco VSS (by @MrRJ45)
@@ -22,7 +33,7 @@
 - BUGFIX: allow node to be removed while it is being collected
 - BUGFIX: if model returns non string value, return empty string
 - BUGFIX: better prompt for Arista EOS model (by @rodecker)
-- BUGFIX: improved configuration handling for Arista EOS model (by @rodecker) 
+- BUGFIX: improved configuration handling for Arista EOS model (by @rodecker)
 
 # 0.3.0
 - FEATURE: *FIXME* bunch of stuff I did for richih, docs needed

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -23,7 +23,9 @@ module Oxidized
       @log = File.open(CFG.input.debug?.to_s + '-ssh', 'w') if CFG.input.debug?
       @ssh = Net::SSH.start @node.ip, @node.auth[:username],
                             :password => @node.auth[:password], :timeout => CFG.timeout,
-                            :paranoid => secure
+                            :paranoid => secure,
+                            :auth_methods => %w(publickey password),
+                            :number_of_password_prompts => 0
       unless @exec
         shell_open @ssh
         begin

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -25,7 +25,28 @@ class IronWare < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    cfg.gsub! /(^((.*)uptime(.*))$)/, '' #remove unwanted line system uptime
+    cfg.gsub! /(^((.*)[Ss]ystem uptime(.*))$)/, '' #remove unwanted line system uptime
+    cfg.gsub! /uptime is .*/,''
+
+    comment cfg
+  end
+
+  cmd 'show chassis' do |cfg|
+    cfg.gsub! "\xFF", '' # ugly hack - avoids JSON.dump utf-8 breakage on 1.9..
+    cfg.gsub! /(^((.*)Current temp(.*))$)/, '' #remove unwanted lines current temperature
+    cfg.gsub! /Speed = [A-Z]{3} \(\d{2}\%\)/, '' #remove unwanted lines Speed Fans
+    cfg.gsub! /current speed is [A-Z]{3} \(\d{2}\%\)/, ''
+    cfg.gsub! /Fan controlled temperature: \d{2}\.\d deg-C/, 'Fan controlled temperature: XX.X d deg-C'
+    if cfg.include? "TEMPERATURE"
+      sc = StringScanner.new cfg
+      out = ''
+      temps = ''
+      out << sc.scan_until(/.*TEMPERATURE/)
+      temps << sc.scan_until(/.*Fans/)
+      out << sc.rest
+      cfg = out
+    end
+    
     comment cfg
   end
   

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -25,13 +25,7 @@ class IronWare < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    cfg.gsub! /(^((.*)system uptime(.*))$)/, '' #remove unwanted line system uptime
-    comment cfg
-  end
-
-  cmd 'show chassis' do |cfg|
-    cfg.gsub! "\xFF", '' # ugly hack - avoids JSON.dump utf-8 breakage on 1.9..
-    cfg.gsub! /(^((.*)Current temp(.*))$)/, '' #remove unwanted lines current temperature
+    cfg.gsub! /(^((.*)uptime(.*))$)/, '' #remove unwanted line system uptime
     comment cfg
   end
   

--- a/lib/oxidized/model/screenos.rb
+++ b/lib/oxidized/model/screenos.rb
@@ -33,7 +33,10 @@ class ScreenOS  < Oxidized::Model
 
   cfg :telnet, :ssh do
     post_login 'set console page 0'
-    pre_logout 'exit'
+    pre_logout do
+      send "exit\n"
+      send "n"
+    end
   end
 
 end

--- a/lib/oxidized/model/screenos.rb
+++ b/lib/oxidized/model/screenos.rb
@@ -4,7 +4,7 @@ class ScreenOS  < Oxidized::Model
 
   comment  '! '
 
-  prompt /^[\w.\(\)-]+->\s?$/
+  prompt /^[\w.:\(\)-]+->\s?$/
 
   cmd :all do |cfg|
     cfg.each_line.to_a[2..-2].join

--- a/lib/oxidized/model/screenos.rb
+++ b/lib/oxidized/model/screenos.rb
@@ -4,7 +4,7 @@ class ScreenOS  < Oxidized::Model
 
   comment  '! '
 
-  prompt '/^([\w.-\(\)]+->\s?)$/'
+  prompt /^[\w.\(\)-]+->\s?$/
 
   cmd :all do |cfg|
     cfg.each_line.to_a[2..-2].join

--- a/lib/oxidized/source/csv.rb
+++ b/lib/oxidized/source/csv.rb
@@ -18,7 +18,7 @@ class CSV < Source
 
   def load
     nodes = []
-    open(@cfg.file).each_line do |line|
+    open(File.expand_path @cfg.file).each_line do |line|
       next if line.match /^\s*#/
       data  = line.chomp.split @cfg.delimiter
       next if data.empty?

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -17,5 +17,5 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'asetus',  '~> 0.1'
   s.add_runtime_dependency 'slop',    '~> 3.5'
   s.add_runtime_dependency 'net-ssh', '~> 2.8'
-  s.add_runtime_dependency 'rugged',  '~> 0.21.4'
+  s.add_runtime_dependency 'rugged',  '~> 0.21', '>= 0.21.4'
 end

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name              = 'oxidized'
-  s.version           = '0.5.0'
+  s.version           = '0.6.0'
   s.licenses          = %w( Apache-2.0 )
   s.platform          = Gem::Platform::RUBY
   s.authors           = [ 'Saku Ytti', 'Samer Abdel-Hafez' ]


### PR DESCRIPTION
In some devices the older "uptime" regexp was not efficient, and I deleted 'show chassis' because there is to much differents temperature lines per devices and I think here it's useless (It's more for monitoring).