### PR TITLE
Add keyboard-interactive SSH auth to fix Arista login failures

### DIFF
--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -24,7 +24,7 @@ module Oxidized
       @ssh = Net::SSH.start @node.ip, @node.auth[:username],
                             :password => @node.auth[:password], :timeout => CFG.timeout,
                             :paranoid => secure,
-                            :auth_methods => %w(none publickey password),
+                            :auth_methods => %w(none publickey password keyboard-interactive),
                             :number_of_password_prompts => 0
       unless @exec
         shell_open @ssh


### PR DESCRIPTION
On some Arista devices, Net::SSH will return authentication failure even though command-line ssh works fine. Need to add keyboard-interactive to auth_methods when calling Net::SSH to fix this.