### PR TITLE
lib/oxidized/jobs.rb:29 NaN (FloatDomainError)

### DIFF
--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -26,7 +26,7 @@ module Oxidized
     end
 
     def new_count
-      @want = ((@nodes.size * @duration) / @interval).to_i
+      @want = (@nodes.size * @duration) / @interval
       @want = 1 if @want < 1
       @want = @nodes.size if @want > @nodes.size
       @want = @max if @want > @max

--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -10,7 +10,7 @@ module Oxidized
       @nodes     = nodes
       @last      = Time.now.utc
       @durations = Array.new @nodes.size, AVERAGE_DURATION
-      duration AVERAGE_DURATION
+      @duration  = AVERAGE_DURATION
       super()
     end
 
@@ -26,7 +26,7 @@ module Oxidized
     end
 
     def new_count
-      @want = (@nodes.size * @duration) / @interval
+      @want = ((@nodes.size * @duration) / @interval).to_i
       @want = 1 if @want < 1
       @want = @nodes.size if @want > @nodes.size
       @want = @max if @want > @max


### PR DESCRIPTION
```
sudo -u oxidized -H /usr/local/bin/oxidized -d
NaN
/usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/jobs.rb:29:in `to_i': NaN (FloatDomainError)
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/jobs.rb:29:in `new_count'
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/jobs.rb:25:in `duration'
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/jobs.rb:13:in `initialize'
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/worker.rb:7:in `new'
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/worker.rb:7:in `initialize'
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/core.rb:19:in `new'
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/core.rb:19:in `initialize'
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/core.rb:11:in `new'
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/core.rb:11:in `new'
	from /usr/local/share/gems/gems/oxidized-0.7.1/lib/oxidized/cli.rb:9:in `run'
	from /usr/local/share/gems/gems/oxidized-0.7.1/bin/oxidized:9:in `<top (required)>'
	from /usr/local/bin/oxidized:23:in `load'
	from /usr/local/bin/oxidized:23:in `<main>'
```