### PR TITLE
Add support for MRV Master-OS

### DIFF
--- a/lib/oxidized/model/masteros.rb
+++ b/lib/oxidized/model/masteros.rb
@@ -1,0 +1,46 @@
+class MasterOS < Oxidized::Model
+
+  # MRV MasterOS model #
+
+comment '!' 
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /username (\S+) password encrypted (\S+) class (\S+).*/, '<secret hidden>'
+    cfg 
+  end 
+
+  cmd :all do |cfg|
+    cfg.each_line.to_a[1..-2].join
+  end 
+
+  cmd 'show inventory' do |cfg|
+    cfg = cfg.each_line.to_a[0..-2].join
+    comment cfg 
+  end 
+
+  cmd 'show plugins' do |cfg|
+    comment cfg 
+  end 
+
+  cmd 'show hw-config' do |cfg|
+    comment cfg 
+  end 
+
+  cmd 'show running-config' do |cfg|
+    cfg = cfg.each_line.to_a[3..-1].join
+    cfg 
+  end 
+
+  cfg :telnet, :ssh do
+    post_login 'no pager'
+    if vars :enable
+      post_login do
+        send "enable\n"
+        send vars(:enable) + "\n"
+      end 
+    end 
+    pre_logout 'exit'
+  end 
+
+end


### PR DESCRIPTION
This model adds support for MRV Master-OS on Opti-Driver with software release 5.5.1.  I don't have access to other platforms running Master-OS to check, but it should probably work there as well.