### PR TITLE
Last Stats Persistance

### DIFF
--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -111,7 +111,7 @@ module Oxidized
         @stats.store job
       end
     end
-    
+
     def reset
       @user = @msg = @from = nil
       @retry = 0

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -19,7 +19,8 @@ module Oxidized
       @auth           = resolve_auth opt
       @prompt         = resolve_prompt opt
       @vars           = opt[:vars]
-      @stats          = Stats.new
+      @stats          = Stats.new @name, @group
+      @force          = false
       @retry          = 0
 
       # model instance needs to access node instance
@@ -101,19 +102,16 @@ module Oxidized
       h
     end
 
-    def last= job
-      if job
-        ostruct = OpenStruct.new
-        ostruct.start  = job.start
-        ostruct.end    = job.end
-        ostruct.status = job.status
-        ostruct.time   = job.time
-        @last = ostruct
-      else
-        @last = nil
-      end
+    def last
+      @stats.fetch
     end
 
+    def last= job
+      if job
+        @stats.store job
+      end
+    end
+    
     def reset
       @user = @msg = @from = nil
       @retry = 0

--- a/lib/oxidized/node/stats.rb
+++ b/lib/oxidized/node/stats.rb
@@ -1,7 +1,11 @@
 module Oxidized
   class Node
     class Stats
+      require 'sequel'
+      
       MAX_STAT = 10
+
+      @@last_store = Hash.new # somewhere to store last information with no sql db
 
       # @param [Job] job job whose information add to stats
       # @return [void]
@@ -14,6 +18,7 @@ module Oxidized
         @stats[job.status] ||= []
         @stats[job.status].shift if @stats[job.status].size > MAX_STAT
         @stats[job.status].push stat
+        store job
       end
 
       # @param [Symbol] status stats for specific status
@@ -21,12 +26,81 @@ module Oxidized
       def get status=nil
         status ? @stats[status] : @stats
       end
+      
+      def fetch
+        if sqlcfg.empty?
+        # no sql config - fetch from memory
+          r = nil
+          unless @@last_store[@group].nil?
+            r = OpenStruct.new(@@last_store[@group][@name]) unless @@last_store[@group][@name].nil?
+          end
+        else
+          # sql config - fetch from db
+          db = connect
+          check_stats_table db
+          stats = db[(sqlcfg.table + '_stats').to_sym].where(:name => @name, :group => @group).select( :start, :end, :time, :status).all
+          if stats.empty?
+            r = nil
+          else
+            r = OpenStruct.new(stats.first)
+          end
+          db.disconnect
+        end
+        r
+      end
+
+      def store job
+        if sqlcfg.empty?
+          # no sql config - store in memory
+          @@last_store[@group] = Hash.new if @@last_store[@group].nil?
+          @@last_store[@group][@name] = { :start => job.start, :end => job.end, :time => job.time, :status => job.status }
+        else
+          # sql config - persist in db
+          db = connect
+          check_stats_table db
+          begin
+            query = db[(sqlcfg.table + '_stats').to_sym].insert( :name => @name, :group => @group, :start => job.start, :end => job.end, :time => job.time, :status => job.status.to_s )
+          rescue Sequel::UniqueConstraintViolation
+            query = db[(sqlcfg.table + '_stats').to_sym].where( :name => @name, :group => @group).update(:start => job.start, :end => job.end, :time => job.time, :status => job.status.to_s )
+          end
+          db.disconnect
+        end
+      end
 
       private
 
       def initialize
         @stats = {}
+        @name = name
+        @group = group
       end
+
+      def sqlcfg
+        CFG.source.sql
+      end
+
+      def connect
+        Sequel.connect(:adapter  => sqlcfg.adapter,
+                   :host     => sqlcfg.host?,
+                   :user     => sqlcfg.user?,
+                   :password => sqlcfg.password?,
+                   :database => sqlcfg.database)
+        rescue Sequel::AdapterNotFound => error
+          raise OxidizedError, "SQL adapter gem not installed: " + error.message
+      end
+
+      def check_stats_table db
+        db.create_table? (sqlcfg.table + '_stats').to_sym do
+                primary_key [ :name, :group ],  :name=>'full_name'
+                String      :name
+                String      :group
+                DateTime    :start
+                DateTime    :end
+                Float       :time
+                String      :status
+        end
+      end
+
 
     end
   end

--- a/lib/oxidized/node/stats.rb
+++ b/lib/oxidized/node/stats.rb
@@ -100,8 +100,7 @@ module Oxidized
                 String      :status
         end
       end
-
-
+      
     end
   end
 end

--- a/lib/oxidized/node/stats.rb
+++ b/lib/oxidized/node/stats.rb
@@ -28,9 +28,9 @@ module Oxidized
       end
       
       def fetch
+        r = nil
         if sqlcfg.empty?
         # no sql config - fetch from memory
-          r = nil
           unless @@last_store[@group].nil?
             r = OpenStruct.new(@@last_store[@group][@name]) unless @@last_store[@group][@name].nil?
           end
@@ -39,11 +39,7 @@ module Oxidized
           db = connect
           check_stats_table db
           stats = db[(sqlcfg.table + '_stats').to_sym].where(:name => @name, :group => @group).select( :start, :end, :time, :status).all
-          if stats.empty?
-            r = nil
-          else
-            r = OpenStruct.new(stats.first)
-          end
+          r = OpenStruct.new(stats.first) unless stats.empty?
           db.disconnect
         end
         r

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -72,8 +72,8 @@ module Oxidized
           n.user = opt['user']
           n.msg  = opt['msg']
           n.from = opt['from']
-          # set last job to nil so that the node is picked for immediate update
-          n.last = nil
+          # set node to force - will schedule job regardless of interval
+          n.force = true
           put n
         end
       end

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -15,14 +15,12 @@ module Oxidized
       @jobs.work
       while @jobs.size < @jobs.want
         Log.debug "Jobs #{@jobs.size}, Want: #{@jobs.want}"
-        # ask for next node in queue non destructive way
-        nextnode = @nodes.first
-        unless nextnode.last.nil?
-          break if nextnode.last.end + CFG.interval > Time.now.utc
-        end
-        # shift nodes and get the next node
         node = @nodes.get
+        unless node.force or node.last.nil?
+          break if node.last.end + CFG.interval > Time.now.utc
+        end
         node.running? ? next : node.running = true
+        node.force = false if node.force
         @jobs.push Job.new node
       end
     end


### PR DESCRIPTION
As mentioned in Issue #177 I have re-written the storage for persisting node last stats. This should hopefully close Issue #39 if this code is approved :)

This has been working fine for a few days, and I've had no issues. I am still learning Ruby as I go so there may be better ways of doing some of these things.

Firstly, this checks for a SQL Source config. If this exists we use the same connection details, and Sequel to connect. We use the table name of the devices table + '_stats' to store this data. If there is no SQL config, we fall back to storing in memory, in a class instance (the best way I could figure of doing this).

Node::Stats has some new functions, the main two are fetch and store. These do the work needed for retrieving or persisting the data.

On the node class, "last" and "last=" call these fetch and store functions. I've tried to implement this with minimal changes to the code.

One positive effect seems that when storing in a database that the DateTime is still UTC, but it now includes the servers timezone, eg. +0100 for the UK at the moment. This may help with Issue ytti/oxidized-web#16

I've also added the attribute "force" to a node, so we now set that if we want a node to run next. This is because we dont really want to updating the database to nil to force a refresh.

Comments, and thoughts? :)