### PR TITLE
broken ironware cli occasionally swallows text

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -71,6 +71,7 @@ class IronWare < Oxidized::Model
         send vars(:enable) + "\n"
       end
     end
+    post_login ''
     post_login 'skip-page-display'
     post_login 'terminal length 0'
     pre_logout 'logout'

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -1,6 +1,6 @@
 class IronWare < Oxidized::Model
 
-  prompt /^.+[>#]\s?$/
+  prompt /^.*(telnet|ssh)\@.+[>#]\s?$/i
   comment  '! '
   
   #to handle pager without enable


### PR DESCRIPTION
the ironware cli is pretty broken and occasionally swallows text without trace. In this instance, when oxidised is run against ironware 7.4 on TIX24 platform with no autoenable, ironware swallows the initial ```skip-page-display``` and then ```show running-configuration``` fails as it hangs on the pager.

this patch should be an effective nop in all other instances where the ironware model is called.