### PR TITLE
ironware prompt matches normal config

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -1,6 +1,6 @@
 class IronWare < Oxidized::Model
 
-  prompt /^.+[>#]\s?$/
+  prompt /^.*(telnet|ssh)\@.+[>#]\s?$/i
   comment  '! '
   
   #to handle pager without enable


### PR DESCRIPTION
The current ironware prompt regexp ```^.+[>#]\s?$``` will match the following line:

```
snmp-server contact The NOC <noc@example.com>
```

This causes the ironware model to truncate the configuration to whatever chunk ssh has returned.  The attached commit is guaranteed to work if the input connection is telnet or ssh. It won't work on a console link, but that's not supported by oxidised anyway.
