### PR TITLE
smooth over ironware broken encoding

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -32,7 +32,7 @@ class IronWare < Oxidized::Model
   end
 
   cmd 'show chassis' do |cfg|
-    cfg.gsub! /\xFF/n, '' # ugly hack - avoids JSON.dump utf-8 breakage on 1.9..
+    cfg.encode!("UTF-8", :invalid => :replace) #sometimes ironware returns broken encoding
     cfg.gsub! /(^((.*)Current temp(.*))$)/, '' #remove unwanted lines current temperature
     cfg.gsub! /Speed = [A-Z]{3} \(\d{2}\%\)/, '' #remove unwanted lines Speed Fans
     cfg.gsub! /current speed is [A-Z]{3} \(\d{2}\%\)/, ''


### PR DESCRIPTION
ironware occasionally outputs trash.  the gsub to delete \xFF from the input stream breaks ruby.  Better to fix the encoding for the input stream rather than delete arbitrary octets