### PR TITLE
cfg.repo needs to be fixed up with File.expand_path on init

### DIFF
--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -19,6 +19,7 @@ class Git < Output
       CFGS.save :user
       raise NoConfig, 'no output git config, edit ~/.config/oxidized/config'
     end
+    @cfg.repo = File.expand_path @cfg.repo
   end
 
   def store file, outputs, opt={}
@@ -26,7 +27,7 @@ class Git < Output
     @user  = (opt[:user]  or @cfg.user)
     @email = (opt[:email] or @cfg.email)
     @opt   = opt
-    repo   = File.expand_path @cfg.repo
+    repo   = @cfg.repo
 
     outputs.types.each do |type|
       type_cfg = ''


### PR DESCRIPTION
... otherwise only git write will work; http read still pulls off the unexpanded path name.