### PR TITLE
model/comware: ignore lines with uptime (ingore case!) for real

### DIFF
--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -38,7 +38,7 @@ class Comware < Oxidized::Model
   end
 
   cmd 'display version' do |cfg|
-    cfg = cfg.each_line.select {|l| not l.match /uptime/ }.join
+    cfg = cfg.each_line.select {|l| not l.match /uptime/i }.join
     comment cfg
   end
 


### PR DESCRIPTION
Our switch (model comware) contains the line uptime twice (with different case). This patch will ignore both lines correctly.

Example output from switch:
```
# HP Comware Platform Software
# Comware Software, Version 5.20.99, Release 2106
# Copyright (c) 2010-2013 Hewlett-Packard Development Company, L.P.
# HP 6125G Blade Switch uptime is 32 weeks, 5 days, 21 hours, 43 minutes
#
#
# Slot 1 (M):
# Uptime is 32 weeks,5 days,19 hours,59 minutes
# HP 6125G Blade Switch with 1 Processor
# 1024M bytes SDRAM
# 256M bytes Nand Flash Memory
```