### PR TITLE
only send username when username is set at all

### DIFF
--- a/lib/oxidized/input/telnet.rb
+++ b/lib/oxidized/input/telnet.rb
@@ -19,8 +19,10 @@ module Oxidized
       opt['Output_log'] = CFG.input.debug?.to_s + '-telnet' if CFG.input.debug?
 
       @telnet  = Net::Telnet.new opt
-      expect username
-      @telnet.puts @node.auth[:username]
+      if !@node.auth[:username].nil? and @node.auth[:username].length > 0
+        expect username
+        @telnet.puts @node.auth[:username]
+      end
       expect password
       @telnet.puts @node.auth[:password]
       begin

--- a/lib/oxidized/input/telnet.rb
+++ b/lib/oxidized/input/telnet.rb
@@ -19,7 +19,7 @@ module Oxidized
       opt['Output_log'] = CFG.input.debug?.to_s + '-telnet' if CFG.input.debug?
 
       @telnet  = Net::Telnet.new opt
-      if !@node.auth[:username].nil? and @node.auth[:username].length > 0
+      if @node.auth[:username] and @node.auth[:username].length > 0
         expect username
         @telnet.puts @node.auth[:username]
       end


### PR DESCRIPTION
Some of my switches don’t expect any username on telnet. This change
allows me to leave the username field effectively empty for a switch.