### PR TITLE
some ironware devices are fixed config => no modules

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -55,6 +55,7 @@ class IronWare < Oxidized::Model
   end
   
   cmd 'show module' do |cfg|
+    cfg.gsub! /^((Invalid input)|(Type \?)).*$/, '' # some ironware devices are fixed config
     comment cfg
   end
 


### PR DESCRIPTION
without this patch, ironware stackables show this text at the bottom:

```
Invalid input -> module
Type ? for a list
```