### PR TITLE
Ignore save-config warning after exit in XOS

### DIFF
--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -37,6 +37,7 @@ class XOS < Oxidized::Model
   cfg :telnet, :ssh do
     post_login 'disable clipaging'
     pre_logout 'exit'
+    pre_logout 'n'
   end
 
 end


### PR DESCRIPTION
With the current code Oxidized will get stuck at exit and timeout if there are unsaved configuration in XOS. This will ignore the warning and exit without saving the running configuration.