### PR TITLE
use different path for debug logging

### DIFF
--- a/lib/oxidized/input/ftp.rb
+++ b/lib/oxidized/input/ftp.rb
@@ -18,7 +18,7 @@ module Oxidized
     def connect node
       @node       = node
       @node.model.cfg['ftp'].each { |cb| instance_exec(&cb) }
-      @log = File.open(CFG.input.debug?.to_s + '-ftp', 'w') if CFG.input.debug?
+      @log = File.open(Oxidized::Config::Crash + "-#{@node.ip}-ftp", 'w') if CFG.input.debug?
       @ftp = Net::FTP.new @node.ip, @node.auth[:username], @node.auth[:password]
       connected?
     end

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -20,7 +20,7 @@ module Oxidized
       @output     = ''
       @node.model.cfg['ssh'].each { |cb| instance_exec(&cb) }
       secure = CFG.input.ssh.secure
-      @log = File.open(CFG.input.debug?.to_s + '-ssh', 'w') if CFG.input.debug?
+      @log = File.open(Oxidized::Config::Crash + "-#{@node.ip}-ssh", 'w') if CFG.input.debug?
       port = vars(:ssh_port) || 22
       @ssh = Net::SSH.start @node.ip, @node.auth[:username], :port => port.to_i,
                             :password => @node.auth[:password], :timeout => CFG.timeout,

--- a/lib/oxidized/input/telnet.rb
+++ b/lib/oxidized/input/telnet.rb
@@ -16,7 +16,7 @@ module Oxidized
               'Port'    => port.to_i,
               'Timeout' => @timeout,
               'Model'   => @node.model }
-      opt['Output_log'] = CFG.input.debug?.to_s + '-telnet' if CFG.input.debug?
+      opt['Output_log'] = Oxidized::Config::Crash + "-#{@node.ip}-telnet" if CFG.input.debug?
 
       @telnet  = Net::Telnet.new opt
       if @node.auth[:username] and @node.auth[:username].length > 0


### PR DESCRIPTION
When I try to run oxidized as a different user, I get permission errors
for oxidized tries to write debug logs (e.g. true-telnet) in current
working directory which in my case is not writable for the
non-privileged user. I think this can be improved by this change.

1) Why would you use CFG.input.debug?.to_s (which in this case will
always be ‘true’) as a prefix at all
2) let’s use the crash directory for the debug output, as we know this
is available and choose a more descriptive name