### PR TITLE
a callback to push config changes to a remote repository

### DIFF
--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -1,0 +1,16 @@
+class GithubRepo < Oxidized::Hook
+  def validate_cfg!
+    cfg.has_key?('remote_repo') or raise 'remote_repo is required'
+  end
+
+  def run_hook(ctx)
+    credentials =  Rugged::Credentials::SshKeyFromAgent.new(username: 'git')
+    repo = Rugged::Repository.new(Oxidized::CFG.output.git.repo)
+    log "Pushing local repository(#{repo.path})..."
+    remote = repo.remotes['origin'] || repo.remotes.create('origin', cfg.remote_repo)
+    log "to remote: #{remote.url}"
+    remote.push(['refs/heads/master'], credentials: credentials)
+  rescue Exception => e
+    log e.backtrace.join('\n')
+  end
+end


### PR DESCRIPTION
To register the callback following lines must be added to oxidized's config file.
```
hooks:
  github_repo_hook:
    type: githubrepo
    events: [post_store]
    remote_repo: <remote repository url>
```
After this whenever a new commit made in the local git repository GithubRepo hook will push it to the remote repository. The assumption is ssh access to the remote repository is configured in the host machine.