### PR TITLE
Some minor tweaks for Oxidized

### DIFF
--- a/extra/nagios_check_failing_nodes.rb
+++ b/extra/nagios_check_failing_nodes.rb
@@ -23,12 +23,12 @@ json.each do |node|
   end
 end
 
-if pending
-  puts '[WARN] Pending backup: ' + pending_nodes.join(',')
-  exit 1
-elsif critical
+if critical
   puts '[CRIT] Unable to backup: ' + critical_nodes.join(',')
   exit 2
+elsif pending
+  puts '[WARN] Pending backup: ' + pending_nodes.join(',')
+  exit 1
 else
   puts '[OK] Backup of all nodes completed successfully.'
   exit 0

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -9,6 +9,9 @@ module Oxidized
     attr_accessor :running, :user, :msg, :from, :stats, :retry
     alias :running? :running
     def initialize opt
+      if CFG.debug == true or opt[:debug] == true
+        puts 'resolving DNS for %s...' % opt[:name]
+      end
       @name           = opt[:name]
       @ip             = IPAddr.new(opt[:ip]).to_s rescue nil
       @ip           ||= Resolv.new.getaddress @name

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -70,7 +70,7 @@ module Oxidized
         Log.send(level, '%s raised %s%s with msg "%s"' % [self.ip, err.class, resc, err.message])
         return false
       rescue => err
-        file = Oxidized::Config::Crash + '.' + self.ip.to_s
+        file = Oxidized::Config::Crash + '.' + opt[:name]
         open file, 'w' do |fh|
           fh.puts Time.now.utc
           fh.puts err.message + ' [' + err.class.to_s + ']'

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -70,7 +70,7 @@ module Oxidized
         Log.send(level, '%s raised %s%s with msg "%s"' % [self.ip, err.class, resc, err.message])
         return false
       rescue => err
-        file = Oxidized::Config::Crash + '.' + opt[:name]
+        file = Oxidized::Config::Crash + '.' + self.ip.to_s
         open file, 'w' do |fh|
           fh.puts Time.now.utc
           fh.puts err.message + ' [' + err.class.to_s + ']'


### PR DESCRIPTION
We're migrating to Oxidized at work (from Rancid) and I've made some minor changes to the code. Perhaps they can be useful for others as well.

- It seemed like Oxidized was hanging when we started it, after some troubleshooting we figured it was resolving DNS names (some of the DNS names were not available in the dev environment where we were testing). This patch ads optional debug output when resolving the DNS names.

- ~~Log crashes on hostname instead of on IP (in my opinion more easy to correlate, we manage >1000 devices)~~

- Changes Nagios plugin to prefer CRITICAL state if any critical hosts were found. It used to prefer PENDING (warning) even though there could be both, in which case CRITICAL should win.

I'm not very familiar with Ruby so please let me know if I could improve anything.