### PR TITLE
expose git repo name and commit oid in hook mechanism and env-vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -471,6 +471,8 @@ OX_NODE_MSG
 OX_NODE_GROUP
 OX_JOB_STATUS
 OX_JOB_TIME
+OX_REPO_COMMITREF
+OX_REPO_NAME
 ```
 
 Exec hook recognizes following configuration keys:

--- a/extra/oxidized-report-git-commits
+++ b/extra/oxidized-report-git-commits
@@ -27,6 +27,11 @@
 #    async: true
 #    timeout: 120
 # 
+#
+# The script takes a single argument, namely a git working directory name,
+# e.g.  "~/gitdir/".  This is only used as a staging directory and should
+# not be set to be the same as the git repo directory.
+#
 
 PATH=${PATH}:/usr/local/bin:/usr/local/sbin
 export PATH

--- a/extra/oxidized-report-git-commits
+++ b/extra/oxidized-report-git-commits
@@ -1,0 +1,75 @@
+#!/bin/sh
+# 
+# A script to maintain a local working copy of an oxidized configuration
+# repository and mail out diffs for configuration changes
+# 
+# Copyright 2016 Nick Hilliard <nick@foobar.org>, All Rights Reserved
+# 
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# usage: add the following hook to the oxidized config file:
+# 
+# hooks:
+#  email_output:
+#    type: exec
+#    events: [post_store, node_fail]
+#    cmd: 'update-local-repo.sh ~/gitdir/ | mail -s "Oxidized updates for ${OX_NODE_NAME}" update-recipient@example.com'
+#    async: true
+#    timeout: 120
+# 
+
+PATH=${PATH}:/usr/local/bin:/usr/local/sbin
+export PATH
+
+gitdir=$1
+
+if [ X${OX_REPO_COMMITREF} = "X" ]; then
+	echo \$OX_REPO_COMMITREF not set
+	exit 64
+fi
+
+if [ X${OX_REPO_NAME} = "X" ]; then
+	echo \$OX_REPO_NAME not set
+	exit 64
+fi
+	
+if [ ! -d ${gitdir}/.git ]; then
+	git clone -q ${OX_REPO_NAME} ${gitdir}
+
+	ret=$?
+	if [ X"${ret}" != X0 ] && [ X"${ret}" != X1 ]; then
+		echo git clone failed: aborting.
+		exit 128
+	fi
+fi
+
+cd ${gitdir}
+
+git pull -q > /dev/null 2>&1 
+ret=$?
+if [ X"${ret}" != X0 ] && [ X"${ret}" != X1 ]; then
+	echo git pull failed: aborting.
+	exit 128
+fi
+
+# Git is probably working at this stage, so safe to emit more info
+
+echo "Node name: ${OX_NODE_NAME}"
+echo "Group Name: ${OX_NODE_GROUP}"
+echo "Job Time: ${OX_JOB_TIME}"
+echo "Git Commit ID: ${OX_REPO_COMMITREF}"
+echo "Git Repo: ${OX_REPO_NAME}"
+echo "Local working dir: ${gitdir}"
+echo ""
+
+git diff --no-color ${OX_REPO_COMMITREF}~1..${OX_REPO_COMMITREF}

--- a/lib/oxidized/hook/exec.rb
+++ b/lib/oxidized/hook/exec.rb
@@ -71,6 +71,8 @@ class Exec < Oxidized::Hook
         "OX_NODE_MSG" => ctx.node.msg.to_s,
         "OX_NODE_GROUP" => ctx.node.group.to_s,
         "OX_EVENT" => ctx.event.to_s,
+        "OX_REPO_COMMITREF" => ctx.commitref.to_s,
+        "OX_REPO_NAME" => ctx.node.repo.to_s,
       )
     end
     if ctx.job

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -5,7 +5,7 @@ module Oxidized
   class MethodNotFound < OxidizedError; end
   class ModelNotFound  < OxidizedError; end
   class Node
-    attr_reader :name, :ip, :model, :input, :output, :group, :auth, :prompt, :vars, :last
+    attr_reader :name, :ip, :model, :input, :output, :group, :auth, :prompt, :vars, :last, :repo
     attr_accessor :running, :user, :msg, :from, :stats, :retry
     alias :running? :running
     def initialize opt
@@ -24,6 +24,7 @@ module Oxidized
       @vars           = opt[:vars]
       @stats          = Stats.new
       @retry          = 0
+      @repo           = CFG.output.git.repo
 
       # model instance needs to access node instance
       @model.node = self

--- a/lib/oxidized/output/file.rb
+++ b/lib/oxidized/output/file.rb
@@ -2,6 +2,8 @@ module Oxidized
 class OxidizedFile < Output
   require 'fileutils'
 
+  attr_reader :commitref
+
   def initialize
     @cfg = CFG.output.file
   end
@@ -22,6 +24,7 @@ class OxidizedFile < Output
     FileUtils.mkdir_p file
     file = File.join file, node
     open(file, 'w') { |fh| fh.write outputs.to_cfg }
+    @commitref = file
   end
 
   def fetch node, group

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -7,6 +7,8 @@ class Git < Output
     raise OxidizedError, 'rugged not found: sudo gem install rugged'
   end
 
+  attr_reader :commitref
+
   def initialize
     @cfg = CFG.output.git
   end
@@ -27,6 +29,7 @@ class Git < Output
     @user  = (opt[:user]  or @cfg.user)
     @email = (opt[:email] or @cfg.email)
     @opt   = opt
+    @commitref = nil
     repo   = @cfg.repo
 
     outputs.types.each do |type|
@@ -63,7 +66,7 @@ class Git < Output
     end
   end
 
-  #give a hash of all oid revision for the givin node, and the date of the commit
+  #give a hash of all oid revision for the given node, and the date of the commit
     def version node, group
       begin
         repo = @cfg.repo
@@ -176,7 +179,7 @@ class Git < Output
     if tree_old != tree_new
       repo.config['user.name']  = user
       repo.config['user.email'] = email
-      Rugged::Commit.create(repo,
+      @commitref = Rugged::Commit.create(repo,
         :tree       => index.write_tree(repo),
         :message    => msg,
         :parents    => repo.empty? ? [] : [repo.head.target].compact,

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -39,11 +39,13 @@ module Oxidized
         msg = "update #{node.name}"
         msg += " from #{node.from}" if node.from
         msg += " with message '#{node.msg}'" if node.msg
-        if node.output.new.store node.name, job.config,
+        output = node.output.new
+        if output.store node.name, job.config,
                               :msg => msg, :user => node.user, :group => node.group
           Log.info "Configuration updated for #{node.group}/#{node.name}"
           Oxidized.Hooks.handle :post_store, :node => node,
-                                             :job => job
+                                             :job => job,
+                                             :commitref => output.commitref
         end
         node.reset
       else


### PR DESCRIPTION
this patch exposes the git repo name and the commit ID of the relevant commit in the hook mechanism.  The information is subsequently presented as environment variables.