### PR TITLE
Strip CPU Fan Speed

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -56,7 +56,7 @@ class AOSW < Oxidized::Model
       next if line.match /Output \d Config/i
       next if line.match /(Tachometers|Temperatures|Voltages)/
       next if line.match /((Card|CPU) Temperature|Chassis Fan|VMON1[0-9])/
-      next if line.match /[0-9]+ (RPM|mV|C)$/
+      next if line.match /[0-9]+ (RPM|RPMs|mV|C)$/
       out << line.strip
     end
     out = comment out.join "\n"


### PR DESCRIPTION
On a 6000 series `show inventory` contains a line like `M3mk1 CPU Fan Speed       6490 RPMs`
- this should be stripped