### PR TITLE
Improve job queuing

### DIFF
--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -26,7 +26,7 @@ module Oxidized
     end
 
     def new_count
-      @want = ((@nodes.size * @duration) / @interval).to_i
+      @want = ((@nodes.size * @duration) / @interval).ceil
       @want = 1 if @want < 1
       @want = @nodes.size if @want > @nodes.size
       @want = @max if @want > @max

--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -20,6 +20,11 @@ module Oxidized
     end
 
     def duration last
+      if @durations.size > @nodes.size
+        @durations.slice! @nodes.size...@durations.size
+      elsif @durations.size < @nodes.size
+        @durations.fill AVERAGE_DURATION, @durations.size...@nodes.size
+      end
       @durations.push(last).shift
       @duration = @durations.inject(:+).to_f / @nodes.size #rolling average
       new_count

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -147,6 +147,7 @@ module Oxidized
         rescue  Oxidized::NodeNotFound
         end
       end
+      sort_by! { |x| x.last.nil? ? Time.new(0) : x.last.end }
     end
 
     public


### PR DESCRIPTION
Several bug fixes:
* Durations array size not being updated when nodes size changes
* Use the ceiling on number of threads, so we overestimate instead of not collecting fast enough
* Sort nodes on reload, to prevent collection stalling