### PR TITLE
Removal of SNTP and Uptime comments

### DIFF
--- a/lib/oxidized/model/edgeswitch.rb
+++ b/lib/oxidized/model/edgeswitch.rb
@@ -7,7 +7,7 @@ class EdgeSwitch < Oxidized::Model
   prompt /[(]\w*\s\w*[)][\s#>]*[\s#>]/
 
   cmd 'show running-config' do |cfg|
-    comment cfg
+    comment cfg.each_line.reject { |line| line.match /System Up Time.*/ or line.match /Current SNTP Synchronized Time.*/ }.join
   end
 
   cfg :telnet do


### PR DESCRIPTION
Addition of line reject to remove SNTP sync and uptime codes that
change consistently into EdgeSwitch model file