### PR TITLE
MRV MasterOS: Ignore config saved/generation dates, match the prompt

### DIFF
--- a/lib/oxidized/model/masteros.rb
+++ b/lib/oxidized/model/masteros.rb
@@ -2,35 +2,38 @@ class MasterOS < Oxidized::Model
 
   # MRV MasterOS model #
 
-comment '!' 
+
+  comment '!'
+  prompt /.*#\s/
 
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /username (\S+) password encrypted (\S+) class (\S+).*/, '<secret hidden>'
-    cfg 
-  end 
+    cfg
+  end
 
   cmd :all do |cfg|
+    cfg.gsub! /^(! Configuration ).*/, '!'
     cfg.each_line.to_a[1..-2].join
-  end 
+  end
 
   cmd 'show inventory' do |cfg|
     cfg = cfg.each_line.to_a[0..-2].join
-    comment cfg 
-  end 
+    comment cfg
+  end
 
   cmd 'show plugins' do |cfg|
-    comment cfg 
-  end 
+    comment cfg
+  end
 
   cmd 'show hw-config' do |cfg|
-    comment cfg 
-  end 
+    comment cfg
+  end
 
   cmd 'show running-config' do |cfg|
     cfg = cfg.each_line.to_a[3..-1].join
-    cfg 
-  end 
+    cfg
+  end
 
   cfg :telnet, :ssh do
     post_login 'no pager'
@@ -38,9 +41,9 @@ comment '!'
       post_login do
         send "enable\n"
         send vars(:enable) + "\n"
-      end 
-    end 
+      end
+    end
     pre_logout 'exit'
-  end 
+  end
 
 end


### PR DESCRIPTION
- Fixes an issue where the prompt wasn't getting match
- Ignores lines containing "! Configuration saved on" and "! Configuration generated on" timestamps