### PR TITLE
MRV master-os: Ignore configuration timestamps

### DIFF
--- a/lib/oxidized/model/masteros.rb
+++ b/lib/oxidized/model/masteros.rb
@@ -12,6 +12,7 @@ comment '!'
 
   cmd :all do |cfg|
     cfg.each_line.to_a[1..-2].join
+    cfg.gsub! /^(! Configuration ).*/, '!'
   end 
 
   cmd 'show inventory' do |cfg|


### PR DESCRIPTION
- Fixes configuration timestamps in config; "! Configuration saved on", "! Configuration generated on"