### PR TITLE
show version option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
 language: ruby
+sudo: false
+cache: bundler
 rvm:
   - 2.1.6

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    oxidized (0.11.0)
+    oxidized (0.12.2)
       asetus (~> 0.1)
       net-ssh (~> 3.0, >= 3.0.2)
       rugged (~> 0.21, >= 0.21.4)

--- a/lib/oxidized.rb
+++ b/lib/oxidized.rb
@@ -3,6 +3,7 @@ module Oxidized
 
   Directory = File.expand_path(File.join(File.dirname(__FILE__), '../'))
 
+  require 'oxidized/version'
   require 'oxidized/string'
   require 'oxidized/config'
   require 'oxidized/config/vars'

--- a/lib/oxidized/cli.rb
+++ b/lib/oxidized/cli.rb
@@ -43,6 +43,10 @@ module Oxidized
       opts = Slop.new(:help=>true) do
         on 'd', 'debug', 'turn on debugging'
         on 'daemonize',  'Daemonize/fork the process'
+        on 'v', 'version', 'show version' do
+          puts Oxidized::VERSION
+          Kernel.exit
+        end
       end
       [opts.parse!, opts]
     end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'oxidized/cli'
+
+describe Oxidized::CLI do
+  let(:asetus) { mock() }
+
+  after  { ARGV.replace @original }
+  before { @original = ARGV }
+
+  %w[-v --version].each do |option|
+    describe option do
+      before { ARGV.replace [option] }
+
+      it 'prints the version and exits' do
+        Oxidized::Config.expects(:load).returns(asetus)
+        Kernel.expects(:exit)
+
+        proc {
+          Oxidized::CLI.new
+        }.must_output "#{Oxidized::VERSION}\n"
+      end
+    end
+  end
+end


### PR DESCRIPTION
```
$ oxidized -h
Usage: oxidized [options]
    -d, --debug          turn on debugging
        --daemonize      Daemonize/fork the process
    -v, --version        show version
    -h, --help           Display this help message.
$ oxidized --version
0.12.2
```

---

There's also 2 commits not exactly related to this feature. If you think I should remove those, just let me know. :smiley: 