### PR TITLE
Set terinal to disable the 'more' prompt

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -39,6 +39,12 @@ class FortiOS < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
+    post_login "config system console\n"
+    post_login "set output standard\n"
+    post_login "end\n"
+    pre_logout "config system console\n"
+    pre_logout "unset output\n"
+    pre_logout "end\n"
     pre_logout "exit\n"
   end
 


### PR DESCRIPTION
Creating a backup on our fortigate fails because it waits for 'more'. This disables that setting and unsets it afterwards.