### PR TITLE
multiple remotes for groups in GithubRepo hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,14 +535,15 @@ This hook configures the repository `remote` and _push_ the code when the specif
   * `username`: username for repository auth.
   * `password`: password for repository auth.
 
-When using groups repositories, the remotes should be passed in the `groups` config for each group.
+When using groups repositories, each group must have its own `remote` in the `remote_repo` config.
 
 ``` yaml
-vars: {}
-groups:
-  routers: git@git.intranet:oxidized/routers.git
-  switches: git@git.intranet:oxidized/switches.git
-  firewalls: git@git.intranet:oxidized/firewalls.git
+hooks:
+  push_to_remote:
+    remote_repo:
+      routers: git@git.intranet:oxidized/routers.git
+      switches: git@git.intranet:oxidized/switches.git
+      firewalls: git@git.intranet:oxidized/firewalls.git
 ```
 
 
@@ -550,7 +551,7 @@ groups:
 
 ``` yaml
 hooks:
-  push_to_gitlab:
+  push_to_remote:
     type: githubrepo
     events: [node_success, post_store]
     remote_repo: git@git.intranet:oxidized/test.git

--- a/README.md
+++ b/README.md
@@ -525,6 +525,39 @@ hooks:
     timeout: 120
 ```
 
+### githubrepo
+
+This hook configures the repository `remote` and _push_ the code when the specified event is triggerd. If the `username` and `password` are not provided, the `Rugged::Credentials::SshKeyFromAgent` will be used.
+
+`githubrepo` hook recognizes following configuration keys:
+
+  * `remote_repo`: the remote repository to be pushed to.
+  * `username`: username for repository auth.
+  * `password`: password for repository auth.
+
+When using groups repositories, the remotes should be passed in the `groups` config for each group.
+
+``` yaml
+vars: {}
+groups:
+  routers: git@git.intranet:oxidized/routers.git
+  switches: git@git.intranet:oxidized/switches.git
+  firewalls: git@git.intranet:oxidized/firewalls.git
+```
+
+
+## Hook configuration example
+
+``` yaml
+hooks:
+  push_to_gitlab:
+    type: githubrepo
+    events: [node_success, post_store]
+    remote_repo: git@git.intranet:oxidized/test.git
+    username: user
+    password: pass
+```
+
 # Ruby API
 
 The following objects exist in Oxidized.

--- a/README.md
+++ b/README.md
@@ -354,13 +354,40 @@ output:
 
 This uses the rugged/libgit2 interface. So you should remember that normal Git hooks will not be executed.
 
-```
+
+For a single repositories for all devices:
+
+``` yaml
 output:
   default: git
   git:
     user: Oxidized
     email: o@example.com
     repo: "/var/lib/oxidized/devices.git"
+```
+
+And for groups repositories:
+
+``` yaml
+output:
+  default: git
+  git:
+    user: Oxidized
+    email: o@example.com
+    repo:
+      first: "/var/lib/oxidized/first.git"
+      second: "/var/lib/oxidized/second.git"
+```
+
+If you would like to use groups and a single repository, you can force this with the `single_repo` config.
+
+``` yaml
+output:
+  default: git
+  git:
+    single_repo: true
+    repo: "/var/lib/oxidized/devices.git"
+
 ```
 
 ### Output types

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -55,15 +55,10 @@ class GithubRepo < Oxidized::Hook
   end
 
   def remote_repo(node)
-    if node.group.nil? || single_repo?
+    if node.group.nil? || cfg.remote_repo.is_a?(String)
       cfg.remote_repo
     else
       cfg.remote_repo[node.group]
     end
   end
-
-  def single_repo?
-    Oxidized.config.output.git.single_repo?
-  end
-
 end

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -63,7 +63,7 @@ class GithubRepo < Oxidized::Hook
   end
 
   def single_repo?
-    Oxidized.config.git.single_repo?
+    Oxidized.config.output.git.single_repo?
   end
 
 end

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -4,9 +4,9 @@ class GithubRepo < Oxidized::Hook
   end
 
   def run_hook(ctx)
-    repo = Rugged::Repository.new(Oxidized.config.output.git.repo)
+    repo = Rugged::Repository.new(ctx.node.repo)
     log "Pushing local repository(#{repo.path})..."
-    remote = repo.remotes['origin'] || repo.remotes.create('origin', cfg.remote_repo)
+    remote = repo.remotes['origin'] || repo.remotes.create('origin', remote_repo(ctx.node))
     log "to remote: #{remote.url}"
 
     fetch_and_merge_remote(repo)
@@ -52,6 +52,18 @@ class GithubRepo < Oxidized::Hook
       log "Using ssh auth", :debug
       Rugged::Credentials::SshKeyFromAgent.new(username: 'git')
     end
+  end
+
+  def remote_repo(node)
+    if node.group.nil? || single_repo?
+      cfg.remote_repo
+    else
+      Oxidized.config.groups[node.group].remote_repo
+    end
+  end
+
+  def single_repo?
+    Oxidized.config.git.single_repo?
   end
 
 end

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -1,6 +1,6 @@
 class GithubRepo < Oxidized::Hook
   def validate_cfg!
-    cfg.has_key?('remote_repo') or raise KeyError, 'remote_repo is required'
+    raise KeyError, 'hook.remote_repo is required' unless cfg.has_key?('remote_repo')
   end
 
   def run_hook(ctx)

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -58,7 +58,7 @@ class GithubRepo < Oxidized::Hook
     if node.group.nil? || single_repo?
       cfg.remote_repo
     else
-      Oxidized.config.groups[node.group].remote_repo
+      cfg.remote_repo[node.group]
     end
   end
 

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -171,14 +171,12 @@ module Oxidized
     end
 
     def resolve_repo
-      git = Oxidized.config.output.git
-      cfg_repo = git.repo
+      remote_repo = Oxidized.config.output.git.repo
 
-      if group && !git.single_repo?
-        basedir = File.dirname(cfg_repo)
-        File.join(basedir, "#{group}.git")
+      if Oxidized.config.output.git.single_repo? || @group.nil? || remote_repo.is_a?(String)
+        remote_repo
       else
-        cfg_repo
+        remote_repo[@group]
       end
     end
 

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -24,7 +24,7 @@ module Oxidized
       @vars           = opt[:vars]
       @stats          = Stats.new
       @retry          = 0
-      @repo           = Oxidized.config.output.git.repo
+      @repo           = resolve_repo
 
       # model instance needs to access node instance
       @model.node = self
@@ -168,6 +168,18 @@ module Oxidized
         Oxidized.mgr.add_model model or raise ModelNotFound, "#{model} not found for node #{ip}"
       end
       Oxidized.mgr.model[model].new
+    end
+
+    def resolve_repo
+      git = Oxidized.config.output.git
+      cfg_repo = git.repo
+
+      if group && !git.single_repo?
+        basedir = File.dirname(cfg_repo)
+        File.join(basedir, "#{group}.git")
+      else
+        cfg_repo
+      end
     end
 
   end

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -12,7 +12,8 @@ describe Oxidized::CLI do
       before { ARGV.replace [option] }
 
       it 'prints the version and exits' do
-        Oxidized::Config.expects(:load).returns(asetus)
+        Oxidized::Config.expects(:load)
+        Oxidized.expects(:setup_logger)
         Kernel.expects(:exit)
 
         proc {

--- a/spec/githubrepo_spec.rb
+++ b/spec/githubrepo_spec.rb
@@ -126,7 +126,6 @@ describe GithubRepo do
       before do
         Rugged::Credentials::SshKeyFromAgent.expects(:new).with(username: 'git').returns(credentials)
         Rugged::Repository.expects(:new).with(repository).returns(repo)
-        Oxidized.config.output.git.single_repo = single_repo
 
         repo.expects(:remotes).twice.returns(remotes)
         remotes.expects(:[]).with('origin').returns(nil)
@@ -138,7 +137,6 @@ describe GithubRepo do
       describe 'and there are several repositories' do
         let(:create_remote) { 'ggrroouupp#remote_repo' }
         let(:repository) { './ggrroouupp.git' }
-        let(:single_repo) { nil }
 
         before do
           Oxidized.config.hooks.github_repo_hook.remote_repo.ggrroouupp = 'ggrroouupp#remote_repo'
@@ -153,10 +151,10 @@ describe GithubRepo do
       describe 'and has a single repository' do
         let(:create_remote) { 'github_repo_hook#remote_repo' }
         let(:repository) { 'foo.git' }
-        let(:single_repo) { true }
 
         before do
           Oxidized.config.hooks.github_repo_hook.remote_repo = 'github_repo_hook#remote_repo'
+          Oxidized.config.output.git.single_repo = true
         end
 
         it 'will push to the correct repository' do

--- a/spec/githubrepo_spec.rb
+++ b/spec/githubrepo_spec.rb
@@ -12,6 +12,7 @@ describe Oxidized::Node do
   before(:each) do
     Oxidized.asetus = Asetus.new
     Oxidized.config.output.git.repo = 'foo.git'
+    Oxidized.config.log = '/dev/null'
     Oxidized.setup_logger
   end
 

--- a/spec/githubrepo_spec.rb
+++ b/spec/githubrepo_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'rugged'
 require 'oxidized/hook/githubrepo'
 
-describe Oxidized::GithubRepo do
+describe GithubRepo do
   let(:credentials) { mock() }
   let(:remote) { mock() }
   let(:remotes) { mock() }
@@ -15,6 +15,18 @@ describe Oxidized::GithubRepo do
     Oxidized.config.output.git.repo = 'foo.git'
     Oxidized.config.log = '/dev/null'
     Oxidized.setup_logger
+  end
+
+  describe '#validate_cfg!' do
+    before do
+      gr.expects(:respond_to?).with(:validate_cfg!).returns(false) # `cfg=` call
+    end
+
+    it 'raise a error when `remote_repo` is not configured' do
+      Oxidized.config.hooks.github_repo_hook = { type: 'githubrepo' }
+      gr.cfg = Oxidized.config.hooks.github_repo_hook
+      proc { gr.validate_cfg! }.must_raise(KeyError)
+    end
   end
 
   describe "#fetch_and_merge_remote" do

--- a/spec/githubrepo_spec.rb
+++ b/spec/githubrepo_spec.rb
@@ -2,9 +2,10 @@ require 'spec_helper'
 require 'rugged'
 require 'oxidized/hook/githubrepo'
 
-describe Oxidized::Node do
+describe Oxidized::GithubRepo do
   let(:credentials) { mock() }
   let(:remote) { mock() }
+  let(:remotes) { mock() }
   let(:repo_head) { mock() }
   let(:repo) { mock() }
   let(:gr) { GithubRepo.new }
@@ -69,31 +70,80 @@ describe Oxidized::Node do
   end
 
   describe "#run_hook" do
-    before(:each) do
-      remote.expects(:url).returns('https://github.com/username/foo.git')
-      remote.expects(:push).with(['refs/heads/master'], credentials: credentials).returns(true)
+    let(:group) { nil }
+    let(:ctx) { OpenStruct.new(node: node) }
+    let(:node) do
+      Oxidized::Node.new(ip: '127.0.0.1', group: group, model: 'junos', output: 'output')
+    end
+
+    before do
       repo_head.expects(:name).twice.returns('refs/heads/master')
       repo.expects(:head).twice.returns(repo_head)
       repo.expects(:path).returns('foo.git')
-      repo.expects(:remotes).returns({'origin' => remote})
       repo.expects(:fetch).with('origin', ['refs/heads/master'], credentials: credentials).returns(Hash.new(0))
-      Rugged::Repository.expects(:new).with('foo.git').returns(repo)
     end
 
-    it "will push to the remote repository using https" do
-      Oxidized.config.hooks.github_repo_hook.remote_repo = 'https://github.com/username/foo.git'
-      Oxidized.config.hooks.github_repo_hook.username = 'username'
-      Oxidized.config.hooks.github_repo_hook.password = 'password'
-      Rugged::Credentials::UserPassword.expects(:new).with(username: 'username', password: 'password').returns(credentials)
-      gr.cfg = Oxidized.config.hooks.github_repo_hook
-      gr.run_hook(nil).must_equal true
+    describe 'when there is only one repository and no groups' do
+      before do
+        remote.expects(:url).returns('https://github.com/username/foo.git')
+        remote.expects(:push).with(['refs/heads/master'], credentials: credentials).returns(true)
+        repo.expects(:remotes).returns({'origin' => remote})
+        Rugged::Repository.expects(:new).with('foo.git').returns(repo)
+      end
+
+      it "will push to the remote repository using https" do
+        Oxidized.config.hooks.github_repo_hook.remote_repo = 'https://github.com/username/foo.git'
+        Oxidized.config.hooks.github_repo_hook.username = 'username'
+        Oxidized.config.hooks.github_repo_hook.password = 'password'
+        Rugged::Credentials::UserPassword.expects(:new).with(username: 'username', password: 'password').returns(credentials)
+        gr.cfg = Oxidized.config.hooks.github_repo_hook
+        gr.run_hook(ctx).must_equal true
+      end
+
+      it "will push to the remote repository using ssh" do
+        Oxidized.config.hooks.github_repo_hook.remote_repo = 'git@github.com:username/foo.git'
+        Rugged::Credentials::SshKeyFromAgent.expects(:new).with(username: 'git').returns(credentials)
+        gr.cfg = Oxidized.config.hooks.github_repo_hook
+        gr.run_hook(ctx).must_equal true
+      end
     end
 
-    it "will push to the remote repository using ssh" do
-      Oxidized.config.hooks.github_repo_hook.remote_repo = 'git@github.com:username/foo.git'
-      Rugged::Credentials::SshKeyFromAgent.expects(:new).with(username: 'git').returns(credentials)
-      gr.cfg = Oxidized.config.hooks.github_repo_hook
-      gr.run_hook(nil).must_equal true
+    describe "when there are groups" do
+      let(:group) { 'ggrroouupp' }
+
+      before do
+        Rugged::Credentials::SshKeyFromAgent.expects(:new).with(username: 'git').returns(credentials)
+        Rugged::Repository.expects(:new).with(repository).returns(repo)
+        Oxidized.config.groups.ggrroouupp.remote_repo = 'ggrroouupp#remote_repo'
+        Oxidized.config.hooks.github_repo_hook.remote_repo = 'github_repo_hook#remote_repo'
+        Oxidized.config.output.git.single_repo = single_repo
+
+        repo.expects(:remotes).twice.returns(remotes)
+        remotes.expects(:[]).with('origin').returns(nil)
+        remotes.expects(:create).with('origin', 'ggrroouupp#remote_repo').returns(remote)
+        remote.expects(:url).returns('url')
+        remote.expects(:push).with(['refs/heads/master'], credentials: credentials).returns(true)
+      end
+
+      describe 'when there are several repositories' do
+        let(:repository) { './ggrroouupp.git' }
+        let(:single_repo) { nil }
+
+        it 'will push to the node group repository' do
+          gr.cfg = Oxidized.config.hooks.github_repo_hook
+          gr.run_hook(ctx).must_equal true
+        end
+      end
+
+      describe 'when is a single repository' do
+        let(:repository) { 'foo.git' }
+        let(:single_repo) { true }
+
+        it 'will push to the correct repository' do
+          gr.cfg = Oxidized.config.hooks.github_repo_hook
+          gr.run_hook(ctx).must_equal true
+        end
+      end
     end
   end
 end

--- a/spec/githubrepo_spec.rb
+++ b/spec/githubrepo_spec.rb
@@ -12,7 +12,6 @@ describe GithubRepo do
 
   before(:each) do
     Oxidized.asetus = Asetus.new
-    Oxidized.config.output.git.repo = 'foo.git'
     Oxidized.config.log = '/dev/null'
     Oxidized.setup_logger
   end
@@ -97,6 +96,7 @@ describe GithubRepo do
 
     describe 'when there is only one repository and no groups' do
       before do
+        Oxidized.config.output.git.repo = 'foo.git'
         remote.expects(:url).returns('https://github.com/username/foo.git')
         remote.expects(:push).with(['refs/heads/master'], credentials: credentials).returns(true)
         repo.expects(:remotes).returns({'origin' => remote})
@@ -139,6 +139,7 @@ describe GithubRepo do
         let(:repository) { './ggrroouupp.git' }
 
         before do
+          Oxidized.config.output.git.repo.ggrroouupp = repository
           Oxidized.config.hooks.github_repo_hook.remote_repo.ggrroouupp = 'ggrroouupp#remote_repo'
         end
 
@@ -153,6 +154,7 @@ describe GithubRepo do
         let(:repository) { 'foo.git' }
 
         before do
+          Oxidized.config.output.git.repo = repository
           Oxidized.config.hooks.github_repo_hook.remote_repo = 'github_repo_hook#remote_repo'
           Oxidized.config.output.git.single_repo = true
         end

--- a/spec/githubrepo_spec.rb
+++ b/spec/githubrepo_spec.rb
@@ -132,12 +132,13 @@ describe GithubRepo do
 
         repo.expects(:remotes).twice.returns(remotes)
         remotes.expects(:[]).with('origin').returns(nil)
-        remotes.expects(:create).with('origin', 'ggrroouupp#remote_repo').returns(remote)
+        remotes.expects(:create).with('origin', create_remote).returns(remote)
         remote.expects(:url).returns('url')
         remote.expects(:push).with(['refs/heads/master'], credentials: credentials).returns(true)
       end
 
       describe 'when there are several repositories' do
+        let(:create_remote) { 'ggrroouupp#remote_repo' }
         let(:repository) { './ggrroouupp.git' }
         let(:single_repo) { nil }
 
@@ -148,6 +149,7 @@ describe GithubRepo do
       end
 
       describe 'when is a single repository' do
+        let(:create_remote) { 'github_repo_hook#remote_repo' }
         let(:repository) { 'foo.git' }
         let(:single_repo) { true }
 

--- a/spec/githubrepo_spec.rb
+++ b/spec/githubrepo_spec.rb
@@ -126,8 +126,6 @@ describe GithubRepo do
       before do
         Rugged::Credentials::SshKeyFromAgent.expects(:new).with(username: 'git').returns(credentials)
         Rugged::Repository.expects(:new).with(repository).returns(repo)
-        Oxidized.config.groups.ggrroouupp.remote_repo = 'ggrroouupp#remote_repo'
-        Oxidized.config.hooks.github_repo_hook.remote_repo = 'github_repo_hook#remote_repo'
         Oxidized.config.output.git.single_repo = single_repo
 
         repo.expects(:remotes).twice.returns(remotes)
@@ -137,10 +135,14 @@ describe GithubRepo do
         remote.expects(:push).with(['refs/heads/master'], credentials: credentials).returns(true)
       end
 
-      describe 'when there are several repositories' do
+      describe 'and there are several repositories' do
         let(:create_remote) { 'ggrroouupp#remote_repo' }
         let(:repository) { './ggrroouupp.git' }
         let(:single_repo) { nil }
+
+        before do
+          Oxidized.config.hooks.github_repo_hook.remote_repo.ggrroouupp = 'ggrroouupp#remote_repo'
+        end
 
         it 'will push to the node group repository' do
           gr.cfg = Oxidized.config.hooks.github_repo_hook
@@ -148,10 +150,14 @@ describe GithubRepo do
         end
       end
 
-      describe 'when is a single repository' do
+      describe 'and has a single repository' do
         let(:create_remote) { 'github_repo_hook#remote_repo' }
         let(:repository) { 'foo.git' }
         let(:single_repo) { true }
+
+        before do
+          Oxidized.config.hooks.github_repo_hook.remote_repo = 'github_repo_hook#remote_repo'
+        end
 
         it 'will push to the correct repository' do
           gr.cfg = Oxidized.config.hooks.github_repo_hook

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Oxidized::Node do
   before(:each) do
     Oxidized.stubs(:asetus).returns(Asetus.new)
+    Oxidized.config.output.git.repo = '/tmp/repository.git'
 
     Oxidized::Node.any_instance.stubs(:resolve_output)
     @node = Oxidized::Node.new(name: 'example.com',
@@ -39,6 +40,30 @@ describe Oxidized::Node do
 
       status, _ = @node.run
       status.must_equal :success
+    end
+  end
+
+  describe '#repo' do
+    it 'when there is no groups' do
+      @node.repo.must_equal '/tmp/repository.git'
+    end
+
+    describe 'when there are groups' do
+      let(:node) do
+        Oxidized::Node.new({
+          ip: '127.0.0.1', group: 'ggrroouupp', model: 'junos'
+        })
+      end
+
+      it 'with only one repository' do
+        Oxidized.config.output.git.single_repo = true
+        node.repo.must_equal '/tmp/repository.git'
+      end
+
+      it 'with more than one repository' do
+        Oxidized.config.output.git.single_repo = false
+        node.repo.must_equal '/tmp/ggrroouupp.git'
+      end
     end
   end
 end


### PR DESCRIPTION
While was possible to create a repository per group, I couldn't find a way to configure a specific `remote` for each group.
~~So, this was the best way I found to configure it:~~
Thanks to @ElvinEfendi this is the config now:

## with groups and multiple repositories

``` yaml
---
 output:
    default: git
    git:
      user: Oxidized
      email: oxidized@example.com
    repo:
      routers: /var/lib/oxidized/routers.git
      firewalls: /var/lib/oxidized/firewalls.git
hooks:
  push_to_remote:
    remote_repo:
      routers: git@git.intranet:oxidized/routers.git
      firewalls: git@git.intranet:oxidized/firewalls.git
```

## single repository

### 
``` yaml
---
 output:
    default: git
    git:
      user: Oxidized
      email: oxidized@example.com
    repo: /var/lib/oxidized/repository.git
hooks:
  push_to_remote:
    remote_repo: git@git.intranet:oxidized/repository.git
```

Note also that you can still use the `single_repo` with groups.