### PR TITLE
config root env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,21 @@ Oxidized configuration is in YAML format. Configuration files are subsequently s
 
 To initialize a default configuration in your home directory ```~/.config/oxidized/config```, simply run ```oxidized``` once. If you don't further configure anything from the output and source sections, it'll extend the examples on a subsequent ```oxidized``` execution. This is useful to see what options for a specific source or output backend are available.
 
+You can set the env variable `OXIDIZED_HOME` to change its home directory.
+
+```
+OXIDIZED_HOME=/etc/oxidized
+
+$ tree -L 1 /etc/oxidized
+/etc/oxidized/
+├── config
+├── log-router-ssh
+├── log-router-telnet
+├── pid
+├── router.db
+└── repository.git
+```
+
 ## Source
 
 Oxidized supports ```CSV```, ```SQLite``` and ```HTTP``` as source backends. The CSV backend reads nodes from a rancid compatible router.db file. The SQLite backend will fire queries against a database and map certain fields to model items. The HTTP backend will fire queries against a http/https url. Take a look at the [Cookbook](#cookbook) for more details.

--- a/extra/oxidized.init.d
+++ b/extra/oxidized.init.d
@@ -1,0 +1,87 @@
+#!/bin/sh
+# chkconfig: - 99 01
+# description: Oxidized - Network Device Configuration Backup Tool
+# processname: /opt/ruby-2.1/bin/oxidized
+
+# Source function library
+. /etc/rc.d/init.d/functions
+
+name="oxidized"
+desc="Oxidized"
+cmd=oxidized
+args="--daemonize"
+lockfile=/var/lock/subsys/$name
+pidfile=/etc/oxidized/pid
+
+export OXIDIZED_HOME=/etc/oxidized
+
+# Source sysconfig configuration
+[ -r /etc/sysconfig/$name ] && . /etc/sysconfig/$name
+
+start() {
+    echo -n $"Starting $desc: "
+    daemon ${cmd} ${args}
+    retval=$?
+    if [ $retval = 0 ]
+    then
+        echo_success
+        touch $lockfile
+    else
+        echo_failure
+    fi
+    echo
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $desc: "
+    killproc -p $pidfile
+    retval=$?
+    [ $retval -eq 0 ] && rm -f $lockfile
+    rm -f $pidfile
+    echo
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+  echo -n $"Reloading config..."
+  curl -s http://localhost:8888/reload?format=json -O /dev/null
+  echo
+}
+
+rh_status() {
+    status -p $pidfile $cmd
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 0
+        $1
+        ;;
+    status)
+        rh_status
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|restart|reload|status}"
+        exit 2
+esac

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -3,7 +3,7 @@ module Oxidized
   class NoConfig < OxidizedError; end
   class InvalidConfig < OxidizedError; end
   class Config
-    Root      = File.join ENV['HOME'], '.config', 'oxidized'
+    Root      = ENV['OXIDIZED_HOME'] || File.join(ENV['HOME'], '.config', 'oxidized')
     Crash     = File.join Root, 'crash'
     Log       = File.join Root, 'log'
     InputDir  = File.join Directory, %w(lib oxidized input)
@@ -27,7 +27,7 @@ module Oxidized
       asetus.default.timeout       = 20
       asetus.default.retries       = 3
       asetus.default.prompt        = /^([\w.@-]+[#>]\s?)$/
-        asetus.default.rest          = '127.0.0.1:8888' # or false to disable
+      asetus.default.rest          = '127.0.0.1:8888' # or false to disable
       asetus.default.vars          = {}             # could be 'enable'=>'enablePW'
       asetus.default.groups        = {}             # group level configuration
 

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -12,7 +12,8 @@ describe Oxidized::CLI do
       before { ARGV.replace [option] }
 
       it 'prints the version and exits' do
-        Oxidized::Config.expects(:load).returns(asetus)
+        Oxidized::Config.expects(:load)
+        Oxidized.expects(:setup_logger)
         Kernel.expects(:exit)
 
         proc {


### PR DESCRIPTION
this provides a way to isolate the oxidized without touching the user home directory, useful for init.d scripts and others.

```
OXIDIZED_HOME=/etc/oxidized

$ tree -L 1 /etc/oxidized
/etc/oxidized/
├── config
├── log-router-ssh
├── log-router-telnet
├── pid
├── router.db
└── repository.git
```

There is also a `init.d` script template for CentOS and friends. :smiley: 