### PR TITLE
Configurable PID file

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,6 +446,7 @@ vars:
   enable: S3cr3tx
 groups: {}
 rest: 127.0.0.1:8888
+pid: /var/run/oxidized.pid
 input:
   default: ssh, telnet
   debug: false

--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ vars:
   enable: S3cr3tx
 groups: {}
 rest: 127.0.0.1:8888
-pid: /var/run/oxidized.pid
+pid: ~/.config/oxidized/oxidized.pid
 input:
   default: ssh, telnet
   debug: false

--- a/lib/oxidized/cli.rb
+++ b/lib/oxidized/cli.rb
@@ -24,7 +24,7 @@ module Oxidized
       Config.load(@opts)
       Oxidized.setup_logger
 
-      @pidfile = File.join(Oxidized::Config::Root, 'pid')
+      @pidfile = Oxidized.config.pid
     end
 
     def crash error

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -30,7 +30,7 @@ module Oxidized
       asetus.default.rest          = '127.0.0.1:8888' # or false to disable
       asetus.default.vars          = {}             # could be 'enable'=>'enablePW'
       asetus.default.groups        = {}             # group level configuration
-      asetus.default.pid           = '/var/run/oxidized.pid' # location of PID file
+      asetus.default.pid           = '~/.config/oxidized/oxidized.pid' # location of PID file
 
       asetus.default.input.default    = 'ssh, telnet'
       asetus.default.input.debug      = false # or String for session log file

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -30,6 +30,7 @@ module Oxidized
         asetus.default.rest          = '127.0.0.1:8888' # or false to disable
       asetus.default.vars          = {}             # could be 'enable'=>'enablePW'
       asetus.default.groups        = {}             # group level configuration
+      asetus.default.pid           = '/var/run/oxidized.pid' # location of PID file
 
       asetus.default.input.default    = 'ssh, telnet'
       asetus.default.input.debug      = false # or String for session log file


### PR DESCRIPTION
Allows a user to configure the PID file location without setting ENVs et cetera. Useful for init scripts, for example.

Furthermore, it is best practice to for PID files to be stored in /var/run; and setting the home dir env to /var/run doesn't seem the best solution to comply