### PR TITLE
Add support for ssh tunnel

### DIFF
--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -23,8 +23,8 @@ module Oxidized
       secure = Oxidized.config.input.ssh.secure
       @log = File.open(Oxidized::Config::Log + "-#{@node.ip}-ssh", 'w') if Oxidized.config.input.debug?
       port = vars(:ssh_port) || 22
-      if proxy_host = vars(:proxy)
-        proxy =  Net::SSH::Proxy::Command.new("ssh #{proxy_host} nc %h %p")
+      if proxy_host = vars(:ssh_proxy)
+        proxy =  Net::SSH::Proxy::Command.new("ssh #{proxy_host} -W %h:%p")
       end
       ssh_opts = {
         :port => port.to_i,


### PR DESCRIPTION
Newer versions of ssh (>=5.4) support the -W option which makes the
use of netcat obsolete. The -W flag is useful is you want to hop
through a router/switch since they rarely have netcat support.

To use, the ssh_tunnel var needs to be set:
ie:
vars:
  ssh_encryption: "blowfish-cbc,3des-cbc"
  ssh_kex: "diffie-hellman-group1-sha1"
  ssh_tunnel: yes

Some distro's (like RHEL6) have the -W flag backported to their ssh
implementation.