### PR TITLE
Added function to get configuration of all partitions running on a F5

### DIFF
--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -41,6 +41,8 @@ class TMOS < Oxidized::Model
     comment cfg
   end
 
+  cmd('cat /config/partitions/*/bigip.conf') { |cfg| comment cfg }
+
   cfg :ssh do
     exec true  # don't run shell, run each command in exec channel
   end


### PR DESCRIPTION
The configuration pull was missing the config for the different partitions.