### PR TITLE
Edgeswitch prompt detect not working

### DIFF
--- a/lib/oxidized/model/edgeswitch.rb
+++ b/lib/oxidized/model/edgeswitch.rb
@@ -18,8 +18,7 @@ class EdgeSwitch < Oxidized::Model
   cfg :telnet, :ssh do
     post_login 'enable'
     post_login 'terminal length 0'
-    pre_logout 'exit'
-    pre_logout 'exit'
+    pre_logout 'quit'
   end
 
 end

--- a/lib/oxidized/model/edgeswitch.rb
+++ b/lib/oxidized/model/edgeswitch.rb
@@ -4,7 +4,7 @@ class EdgeSwitch < Oxidized::Model
 
   comment '!'
 
-  prompt /[(]\w*\s\w*[)][\s#>]*[\s#>]/
+  prompt /\(.*\)\s[#>]/
 
   cmd 'show running-config' do |cfg|
     cfg.each_line.reject { |line| line.match /System Up Time.*/ or line.match /Current SNTP Synchronized Time.*/ }.join


### PR DESCRIPTION
The prompt detection was not working on my edgeswitch.  The old regex was a little odd, so I don't know if there is some corner case I'm not accounting for.
My prompts
```
(palmer-elevator.sw) >
```
```
(palmer-elevator.sw) #
```