### PR TITLE
create the groups inside the file directory configured

### DIFF
--- a/lib/oxidized/output/file.rb
+++ b/lib/oxidized/output/file.rb
@@ -19,11 +19,11 @@ class OxidizedFile < Output
   def store node, outputs, opt={}
     file = @cfg.directory
     if opt[:group]
-      file = File.join File.dirname(file), opt[:group]
+      file = File.join file, opt[:group]
     end
     FileUtils.mkdir_p file
     file = File.join file, node
-    open(file, 'w') { |fh| fh.write outputs.to_cfg }
+    File.open(file, 'w') { |fh| fh.write outputs.to_cfg }
     @commitref = file
   end
 

--- a/spec/output/file_spec.rb
+++ b/spec/output/file_spec.rb
@@ -1,0 +1,52 @@
+require 'spec_helper'
+require 'oxidized/output/file'
+
+describe Oxidized::OxidizedFile do
+  subject { Oxidized::OxidizedFile.new }
+  let(:config) { 'this is a command output\nModel: mx960' }
+  let(:outputs) { mock('output') }
+  let(:file) { "#{directory}/#{node}" }
+  let(:base) { '/directory' }
+  let(:node) { 'node' }
+  let(:fh) { mock('fh') }
+
+  before do
+    Oxidized.stubs(:asetus).returns(Asetus.new)
+    Oxidized.config.output.file.directory = base
+  end
+
+  describe '#store' do
+    before do
+      outputs.expects(:to_cfg).returns(config)
+      fh.expects(:write).with(config)
+      FileUtils.expects(:mkdir_p).with(directory)
+      File.expects(:open).with(file, 'w').yields(fh)
+    end
+
+    describe 'without a group' do
+      let(:directory) { base }
+
+      before do
+        File.expects(:join).with(directory, node).returns("#{directory}/#{node}")
+      end
+
+      it 'should store a file without a group' do
+        subject.store(node, outputs, {})
+      end
+    end
+
+    describe 'with a group' do
+      let(:directory) { "#{base}/#{group}" }
+      let(:group) { 'group' }
+
+      before do
+        File.expects(:join).with(base, group).returns(directory)
+        File.expects(:join).with(directory, node).returns(file)
+      end
+
+      it 'should store a file in the group directory' do
+        subject.store(node, outputs, { group: group })
+      end
+    end
+  end
+end

--- a/spec/output/file_spec.rb
+++ b/spec/output/file_spec.rb
@@ -32,6 +32,7 @@ describe Oxidized::OxidizedFile do
 
       it 'should store a file without a group' do
         subject.store(node, outputs, {})
+        subject.commitref.must_equal(file)
       end
     end
 
@@ -46,6 +47,7 @@ describe Oxidized::OxidizedFile do
 
       it 'should store a file in the group directory' do
         subject.store(node, outputs, { group: group })
+        subject.commitref.must_equal(file)
       end
     end
   end


### PR DESCRIPTION
![captura_de_tela_022516_043032_pm](https://cloud.githubusercontent.com/assets/27297/13332351/4ce1e69c-dbe0-11e5-88da-36736a07e039.jpg)

---

the `File#dirname` was causing the groups directories to be created alongside the directory specified in the `file.directory` config instead of inside of it.