### PR TITLE
force the F5 TMOS shell to do not ask questions

### DIFF
--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -22,19 +22,19 @@ class TMOS < Oxidized::Model
 
   cmd('cat /config/bigip.license') { |cfg| comment cfg }
 
-  cmd 'tmsh list' do |cfg|
+  cmd 'tmsh -q list' do |cfg|
     cfg.gsub!(/state (up|down)/, '')
     cfg.gsub!(/errors (\d+)/, '')
     cfg
   end
 
-  cmd('tmsh list net route all') { |cfg| comment cfg }
+  cmd('tmsh -q list net route all') { |cfg| comment cfg }
 
   cmd('/bin/ls --full-time --color=never /config/ssl/ssl.crt') { |cfg| comment cfg }
 
   cmd('/bin/ls --full-time --color=never /config/ssl/ssl.key') { |cfg| comment cfg }
 
-  cmd 'tmsh show running-config sys db all-properties' do |cfg|
+  cmd 'tmsh -q show running-config sys db all-properties' do |cfg|
     cfg.gsub!(/sys db configsync.localconfigtime {[^}]+}/m, '')
     cfg.gsub!(/sys db gtm.configtime {[^}]+}/m, '')
     cfg.gsub!(/sys db ltm.configtime {[^}]+}/m, '')


### PR DESCRIPTION
If the devices have the pager enabled, the `tmsh list` commands never finish waiting for the pager.

```
config # tmsh -h
 usage: tmsh <options ...> <commmand>
  -q the shell will not ask the user any questions, this option
     does not have an affect in interactive mode
```