### PR TITLE
Procurve filter control sequences and run `show system information`

### DIFF
--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -1,32 +1,38 @@
 class Procurve < Oxidized::Model
 
-  # FIXME: this is way too unsafe
-  prompt /.*?(\w+# ).*/m
+  # some models start lines with \r 
+  # previous command is repeated followed by "\eE", which sometimes ends up on last line
+  prompt /^\r?([\w -]+\eE)?([\w-]+# )$/
 
   comment  '! '
 
+  # replace all used vt100 control sequences
+  expect /\e\[\??\d+(;\d+)*[A-Za-z]/ do |data, re|
+    data.gsub re, ''
+  end
+
   expect /Press any key to continue/ do
-     send ' '
-     ""
+    send ' '
+    ""
   end
 
   cmd :all do |cfg|
     cfg = cfg.each_line.to_a[1..-3].join
-    cfg = cfg.gsub /\r/, ''
-    new_cfg = ''
-    cfg.each_line do |line|
-      line.sub! /^\e.*(\e.*)/, '\1'  #leave last escape
-      line.sub! /\e\[24;1H/, ''      #remove last escape, is it always this?
-      new_cfg << line
-    end
-    new_cfg
+    cfg = cfg.gsub /^\r/, ''
   end
 
   cmd 'show version' do |cfg|
     comment cfg
   end
 
+  # not supported on all models
   cmd 'show system-information' do |cfg|
+    cfg = cfg.split("\n")[0..-8].join("\n")
+    comment cfg
+  end
+
+  # not supported on all models
+  cmd 'show system information' do |cfg|
     cfg = cfg.split("\n")[0..-8].join("\n")
     comment cfg
   end

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -21,6 +21,13 @@ class Procurve < Oxidized::Model
     cfg = cfg.gsub /^\r/, ''
   end
 
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(snmp-server host).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(radius-server host).*/, '\\1 <configuration removed>'
+    cfg
+  end
+
   cmd 'show version' do |cfg|
     comment cfg
   end


### PR DESCRIPTION
Fixes #356.

Noticed that `show system-information` works on 2510 and 2610, but you need to use `show system information` on 2900/2910/3800/5400.

The carriage return (`\r`) only appears on 2510 and 2610, and only as the first character of a line -> added `^` to existing `cfg.gsub`.