### PR TITLE
IPOS model improvements to fix superfluous diffs

### DIFF
--- a/lib/oxidized/model/ipos.rb
+++ b/lib/oxidized/model/ipos.rb
@@ -7,18 +7,43 @@ class IPOS < Oxidized::Model
   comment '! '
 
   cmd 'show chassis' do |cfg|
-    comment cfg
+    comment cfg.each_line.to_a[0..-2].join
   end
 
-  cmd 'show hardware detail' do |cfg|
-    comment cfg
+  cmd 'show hardware' do |cfg|
+    comment cfg.each_line.to_a[0..-2].join
   end
 
   cmd 'show release' do |cfg|
-    comment cfg
+    comment cfg.each_line.to_a[0..-2].join
   end
 
-  cmd 'show config'
+  cmd 'show configuration' do |cfg|
+    # SEOS regularly adds some odd line breaks in random places
+    # when showing the config, triggering changes.
+    cfg.gsub! "\r\n", "\n"
+
+    cfg = cfg.each_line.to_a
+
+    # Keeps the issued command commented but removes the uncommented "Building configuration..."
+    # and "Current configuration:" lines as well as the last prompt at the end.
+    cfg = cfg[4..-2].unshift comment cfg[0]
+
+    # Later IPOS releases add this line in addition to the usual "last changed" line.
+    # It's touched regularly (as often as multiple times per minute) by the OS without actual visible config changes.
+    cfg = cfg.reject { |line| line.match "Configuration last changed by system user" }
+
+    # Earlier IPOS releases lack the "changed by system user" line and instead overwrite
+    # the single "last changed by user" line. Because the line has a timestamp it will
+    # trigger constant changes if not removed. By doing so there will only be a single
+    # extra change trigged after an actual config change by a user but still have the
+    # real user.
+    cfg = cfg.reject { |line| line.match "Configuration last changed by user '%LICM%' at" }
+    cfg = cfg.reject { |line| line.match "Configuration last changed by user '<NO USER>' at" }
+    cfg = cfg.reject { |line| line.match "Configuration last changed by user '' at" }
+
+    cfg.join
+  end
 
   cfg :telnet do
     username /^login:/
@@ -34,4 +59,3 @@ class IPOS < Oxidized::Model
   end
 
 end
-


### PR DESCRIPTION
This patch normalizes output from various SEOS/IPOS releases to reduce or eliminate (depends on model/release) diff noise. "detail" has been removed from "show hardware detail" as it adds a large amount of constantly changing values. The other changes are explained in the patch.

There are also some minor changes to give each section a more consistent title in form of the show command used and removal of uncommented non-config lines printed by "show configuration".

The resulting output is attached below. Everything that may be sensitive like versions, serials, dates and actual config has been retracted.

ios.rb and junos.rb has been used as a reference but I don't have experience with Ruby, so comments on the code if anything looks weird are welcome.

```
! show chassis
! Current platform is SSR 8010
!  (Flags: A-Active Card      B-Standby Card)
!
!  Slot : Configured Type      Installed Type       Operational State     Flags
! --------------------------------------------------------------------------
! RPSW1 : n/a                  rpsw-v2              IS                    B
! RPSW2 : n/a                  rpsw-v2              IS                    A
! ALSW1 : n/a                  alsw                 IS                    B
! ALSW2 : n/a                  alsw                 IS                    A
!     1 : 10ge-10-port         10ge-10-port         IS
!     2 : none                 none                 n/a
!     3 : none                 none                 n/a
!     4 : none                 none                 n/a
!     5 : none                 none                 n/a
!     6 : none                 none                 n/a
!     7 : none                 none                 n/a
!     8 : none                 none                 n/a
!     9 : none                 none                 n/a
!    10 : none                 none                 n/a
! show hardware
! Slot  Type                 Serial No      Rev     Mfg Date    Payload
! ----- -------------------- -------------- ------- ----------- -------
! N/A   backplane            A0A0A0A0A0     R1A     01-JAN-1970 N/A
! FT1   ft                   A0A0A0A0A0     R1A     01-JAN-1970 N/A
! FT2   ft                   A0A0A0A0A0     R1A     01-JAN-1970 N/A
! PM1   pm                   A0A0A0A0A0     R1A     01-JAN-1970 N/A
! PM2   pm                   A0A0A0A0A0     R1A     01-JAN-1970 N/A
! PM3   pm                   A0A0A0A0A0     R1A     01-JAN-1970 N/A
! PM4   pm                   A0A0A0A0A0     R1A     01-JAN-1970 N/A
! PM5   pm                   A0A0A0A0A0     R1A     01-JAN-1970 N/A
! PM6   pm                   A0A0A0A0A0     R1A     01-JAN-1970 N/A
! RPSW1 rpsw-v2              A0A0A0A0A0     R1A     01-JAN-1970 OK
! RPSW2 rpsw-v2              A0A0A0A0A0     R1A     01-JAN-1970 OK
! ALSW1 alsw                 A0A0A0A0A0     R1A     01-JAN-1970 OK
! ALSW2 alsw                 A0A0A0A0A0     R1A     01-JAN-1970 OK
! 1     10ge-10-port         A0A0A0A0A0     R1A     01-JAN-1970 OK
! show release
! Active RP (slot RPSW2)
!
! Installed releases:
!
! p02: active (will be booted after next reload)
! ----------------------------------------------
! Version IPOS-1.2.3.4.5-Release
! Built on Mon Jan 01 10:00:00 PDT 2016
! Copyright (C) 1998-2016, Ericsson AB. All rights reserved.
!
!
! p02: diagnostics
! ----------------
! Version IPOS-1.2.3.4.5-Release
! Built on Mon Jan 01 10:00:00 PDT 2016
! Copyright (C) 1998-2016, Ericsson AB. All rights reserved.
!
!
! p02: VPF Hypervisor
! -------------------
! Version details-1.2.3-Release
! Built on Mon Jan 01 10:00:00 PST 2016
! Copyright (C) 1998-2016, Ericsson AB. All rights reserved.
!
!
! p01: alternate
! --------------
! Version IPOS-1.2.3.4.5-Release
! Built on Mon Jan 01 10:00:00 PDT 2016
! Copyright (C) 1998-2016, Ericsson AB. All rights reserved.
!
!
! p01: diagnostics
! ----------------
! Version IPOS-1.2.3.4.5-Release
! Built on Mon Jan 01 10:00:00 PDT 2016
! Copyright (C) 1998-2016, Ericsson AB. All rights reserved.
!
!
! p01: VPF Hypervisor
! -------------------
! Version details-1.2.3-Release
! Built on Mon Jan 01 10:00:00 PST 2016
! Copyright (C) 1998-2016, Ericsson AB. All rights reserved.
!
!
! show configuration
!
!
<RUNNING CONFIG>
!
!
!
end
```
