### PR TITLE
Add 'nomore' to NOS model for sh run command

### DIFF
--- a/lib/oxidized/model/nos.rb
+++ b/lib/oxidized/model/nos.rb
@@ -29,7 +29,7 @@ class NOS < Oxidized::Model
     comment cfg.each_line.reject { |line| line.match /Time/ or line.match /speed/ }
   end
 
-  cmd 'show running-config'
+  cmd 'show running-config | nomore'
 
   cfg :telnet do
     username /^.* login: /


### PR DESCRIPTION
With my version of NOS, I have not 'skip-page-display' like ironware models.