### PR TITLE
Add new config param: 'rest_hide_enable', to hide enable password from REST API

### DIFF
--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -28,9 +28,9 @@ module Oxidized
       asetus.default.retries           = 3
       asetus.default.prompt            = /^([\w.@-]+[#>]\s?)$/
       asetus.default.rest              = '127.0.0.1:8888' # or false to disable
-      asetus.default.rest_hide_enable  = false        # to don't break actual setup, we set to false
-      asetus.default.vars              = {}             # could be 'enable'=>'enablePW'
-      asetus.default.groups            = {}             # group level configuration
+      asetus.default.rest_hide_enable  = false            # so don't break current setup, setting it to false
+      asetus.default.vars              = {}               # could be 'enable'=>'enablePW'
+      asetus.default.groups            = {}               # group level configuration
 
       asetus.default.input.default    = 'ssh, telnet'
       asetus.default.input.debug      = false # or String for session log file

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -17,19 +17,20 @@ module Oxidized
       asetus = Asetus.new(name: 'oxidized', load: false, key_to_s: true)
       Oxidized.asetus = asetus
 
-      asetus.default.username      = 'username'
-      asetus.default.password      = 'password'
-      asetus.default.model         = 'junos'
-      asetus.default.interval      = 3600
-      asetus.default.use_syslog    = false
-      asetus.default.debug         = false
-      asetus.default.threads       = 30
-      asetus.default.timeout       = 20
-      asetus.default.retries       = 3
-      asetus.default.prompt        = /^([\w.@-]+[#>]\s?)$/
-      asetus.default.rest          = '127.0.0.1:8888' # or false to disable
-      asetus.default.vars          = {}             # could be 'enable'=>'enablePW'
-      asetus.default.groups        = {}             # group level configuration
+      asetus.default.username          = 'username'
+      asetus.default.password          = 'password'
+      asetus.default.model             = 'junos'
+      asetus.default.interval          = 3600
+      asetus.default.use_syslog        = false
+      asetus.default.debug             = false
+      asetus.default.threads           = 30
+      asetus.default.timeout           = 20
+      asetus.default.retries           = 3
+      asetus.default.prompt            = /^([\w.@-]+[#>]\s?)$/
+      asetus.default.rest              = '127.0.0.1:8888' # or false to disable
+      asetus.default.rest_hide_enable  = false        # to don't break actual setup, we set to false
+      asetus.default.vars              = {}             # could be 'enable'=>'enablePW'
+      asetus.default.groups            = {}             # group level configuration
 
       asetus.default.input.default    = 'ssh, telnet'
       asetus.default.input.debug      = false # or String for session log file

--- a/lib/oxidized/core.rb
+++ b/lib/oxidized/core.rb
@@ -22,7 +22,9 @@ module Oxidized
           raise OxidizedError, 'oxidized-web not found: sudo gem install oxidized-web - \
           or disable web support by setting "rest: false" in your configuration'
         end
-        @rest        = API::Web.new nodes, Oxidized.config.rest
+        @rest        = API::Web.new nodes,
+                                    Oxidized.config.rest,
+                                    Oxidized.config.rest_hide_enable
         @rest.run
       end
       run


### PR DESCRIPTION
Add configuration parameter 'rest_hide_enable' like:

``` yaml
use_syslog: false
threads: 30
timeout: 40
retries: 3
prompt: !ruby/regexp /^([\w.@-]+[#>]\s?)$/
rest: 0.0.0.0:8888
rest_hide_enable: true
```

I didn't update README to don't disrupt users.

This param is set at false to don't break setup using clear password.

This commit go with this PR: https://github.com/ytti/oxidized-web/pull/99

BE CAREFUL: the third argument in core.rb on line 27 needs to update oxidized-web. It needs strict version requirement in gemspec. Using oxidized-web without linked PR breaks oxidized.

Tib
