### PR TITLE
Patch for ironware 07.2.02kT3e3 version

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -23,6 +23,7 @@ class IronWare < Oxidized::Model
 
   cmd 'show version' do |cfg|
     cfg.gsub! /(^((.*)[Ss]ystem uptime(.*))$)/, '' #remove unwanted line system uptime
+    cfg.gsub! /(^((.*)[Tt]he system started at(.*))$)/, ''
     cfg.gsub! /[Uu]p\s?[Tt]ime is .*/,''
 
     comment cfg


### PR DESCRIPTION
Patch Oxidized ironware.rb to remove another uptime line.

In version 07.2.02, Ironware OS updates this line by 2 or 3 second randomly...

In production, I have 183 version with this kind of diff:

> -! The system started at 08:10:25 GMT+01 Thu Oct 02 2014
> +! The system started at 08:10:27 GMT+01 Thu Oct 02 2014
> 
