### PR TITLE
Document remove_secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,6 +292,30 @@ vars:
    enable: S3cre7
 ```
 
+### Removing secrets
+
+To strip out secrets from configurations before storing them, Oxidized needs the the remove_secrets flag. You can globally enable this by adding the following snippet to the global sections of the configuration file.
+
+```
+vars:
+  remove_secret: true
+```
+
+Device models can contain substitution filters to remove potentially sensitive data from configs.
+
+As a partial example from ios.rb:
+
+```  
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    (...)    
+    cfg
+  end
+```
+The above strips out snmp community strings from your saved configs.
+
+**NOTE:** Removing secrets reduces the usefulness as a full configuration backup, but it may make sharing configs easier.
+
 ### Source: CSV
 
 One line per device, colon seperated.


### PR DESCRIPTION
Hopefully this addresses https://github.com/ytti/oxidized/issues/362

I too had a difficult time figuring out how to enable this feature and felt added documentation would be helpful.

My concern is more about making the configs more widely viewable (via librenms and github), but I did not feel comfortable putting reversible password hashes (ios type 7) in a more shared context.

 