### PR TITLE
Dot's in hostnames are frowned upon, but allowed

### DIFF
--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -2,7 +2,7 @@ class Procurve < Oxidized::Model
 
   # some models start lines with \r 
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  prompt /^\r?([\w -]+\eE)?([\w-]+# )$/
+  prompt /^\r?([\w -]+\eE)?([\w\-\.]+# )$/
 
   comment  '! '
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -2,7 +2,7 @@ class Procurve < Oxidized::Model
 
   # some models start lines with \r 
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  prompt /^\r?([\w -]+\eE)?([\w\.-]+# )$/
+  prompt /^\r?([\w -]+\eE)?([\w.-]+# )$/
 
   comment  '! '
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -2,7 +2,7 @@ class Procurve < Oxidized::Model
 
   # some models start lines with \r 
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  prompt /^\r?([\w -]+\eE)?([\w\-\.]+# )$/
+  prompt /^\r?([\w -]+\eE)?([\w\.-]+# )$/
 
   comment  '! '
 


### PR DESCRIPTION
```
AMS01.LI17.RM.SW01(config)# hostname "AMS01.LI17.RM.SW01"
Note: To be compliant with RFC 1123, the hostname must contain only letters,
      numbers and hyphens, and must not start or end with a hyphen.
```