### PR TITLE
Added support for multiple outputs

### DIFF
--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -155,11 +155,13 @@ module Oxidized
     end
 
     def resolve_output opt
-      output = (opt[:output] or Oxidized.config.output.default)
-      if not Oxidized.mgr.output[output]
-        Oxidized.mgr.add_output output or raise MethodNotFound, "#{output} not found for node #{ip}"
+      outputs = (opt[:output] or Oxidized.config.output.default)
+      outputs.split(/\s*,\s*/).map do |output|
+        if not Oxidized.mgr.output[output]
+          Oxidized.mgr.add_output output or raise MethodNotFound, "#{output} not found for node #{ip}"
+        end
+        Oxidized.mgr.output[output]
       end
-      Oxidized.mgr.output[output]
     end
 
     def resolve_model opt
@@ -182,3 +184,4 @@ module Oxidized
 
   end
 end
+

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -58,7 +58,8 @@ module Oxidized
     def fetch node, group
       with_lock do
         i = find_node_index node
-        output = self[i].output.new
+        # Use first output type
+        output = self[i].output[0].new
         raise Oxidized::NotSupported unless output.respond_to? :fetch
         output.fetch node, group
       end
@@ -155,7 +156,8 @@ module Oxidized
     def version node, group
       with_lock do
         i = find_node_index node
-        output = self[i].output.new
+        # Use first output type
+        output = self[i].output[0].new
         raise Oxidized::NotSupported unless output.respond_to? :fetch
         output.version node, group
       end
@@ -164,7 +166,8 @@ module Oxidized
     def get_version node, group, oid
       with_lock do
         i = find_node_index node
-        output = self[i].output.new
+        # Use first output type
+        output = self[i].output[0].new
         raise Oxidized::NotSupported unless output.respond_to? :fetch
         output.get_version node, group, oid
       end
@@ -173,7 +176,8 @@ module Oxidized
     def get_diff node, group, oid1, oid2
       with_lock do
         i = find_node_index node
-        output = self[i].output.new
+        # Use first output type
+        output = self[i].output[0].new
         raise Oxidized::NotSupported unless output.respond_to? :fetch
         output.get_diff node, group, oid1, oid2
       end
@@ -181,3 +185,4 @@ module Oxidized
 
   end
 end
+

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -39,13 +39,16 @@ module Oxidized
         msg = "update #{node.name}"
         msg += " from #{node.from}" if node.from
         msg += " with message '#{node.msg}'" if node.msg
-        output = node.output.new
-        if output.store node.name, job.config,
+
+        node.output.each do |output| 
+          output = output.new
+          if output.store node.name, job.config,
                               :msg => msg, :user => node.user, :group => node.group
-          Oxidized.logger.info "Configuration updated for #{node.group}/#{node.name}"
-          Oxidized.Hooks.handle :post_store, :node => node,
+            Oxidized.logger.info "Configuration updated for #{node.group}/#{node.name}"
+            Oxidized.Hooks.handle :post_store, :node => node,
                                              :job => job,
                                              :commitref => output.commitref
+          end
         end
         node.reset
       else
@@ -68,3 +71,4 @@ module Oxidized
 
   end
 end
+


### PR DESCRIPTION
ytti/oxidized#425

Pretty much implemented as per the pointers provided in the issue, but with some minor modifications to make it work. I also had to modify lib/oxidized/nodes.rb to make api calls work. Since you wouldnt want the api to, for exampel, 'fetch' from multiple outputs I just made it so it uses the first output in the array. So if you use multiple outputs, the first one you state in the 'defaults:' line will be used by the api. 
