### PR TITLE
Added EXPOSE and VOLUME directives

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,3 +13,6 @@ RUN apt-get -y autoremove
 
 ADD extra/oxidized.runit /etc/service/oxidized/run
 ADD extra/auto-reload-config.runit /etc/service/auto-reload-config/run
+
+VOLUME ["/root/.config/oxidized"]
+EXPOSE 8888/tcp


### PR DESCRIPTION
This describes the exposed ports and the volume according to the `README.md` documentation. 

Though it is possible to mount volumes and expose ports using `docker run`, for several docker management tools it is not possible to expose ports or mount volumes when they are not defined in the `Dockerfile`.