### PR TITLE
Issue-419 fix

### DIFF
--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -2,6 +2,8 @@ class TMOS < Oxidized::Model
 
   comment  '# '
 
+  prompt /^.*Sync|Pending.*#/
+
   cmd :secret do |cfg|
     cfg.gsub!(/^([\s\t]*)secret \S+/, '\1secret <secret removed>')
     cfg.gsub!(/^([\s\t]*\S*)password \S+/, '\1password <secret removed>')
@@ -46,7 +48,11 @@ class TMOS < Oxidized::Model
   cmd('cat /config/partitions/*/bigip.conf') { |cfg| comment cfg }
 
   cfg :ssh do
-    exec true  # don't run shell, run each command in exec channel
+    post_login '/run util bash'
+    pre_logout do
+      send "exit\r\n"
+      send "quit\r\n"
+    end
   end
 
 end


### PR DESCRIPTION
In order to solve the TMOS issue of externally authenticated users not being placed in the bash shell automatically, I've made some adjustments to tmos.rb.  I've tested these against a system running tmos 12.x with a local account and also with an external account.  I don't have access to an 11.x system for testing.
- disable "exec true" .  Otherwise post_login and pre_logout are not processed.
- create a prompt string.  The prompt as defined should match either a bash shell or a tmsh shell
