### PR TITLE
Issue-439

### DIFF
--- a/lib/oxidized/model/panos.rb
+++ b/lib/oxidized/model/panos.rb
@@ -11,7 +11,14 @@ class PanOS < Oxidized::Model
   end
 
   cmd 'show system info' do |cfg|
-    cfg.gsub! /^(up)?time:\ .*\n/, ''
+    cfg.gsub! /^(up)?time:\ .*$/, ''
+    cfg.gsub! /^app-.*?:\ .*$/, ''
+    cfg.gsub! /^av-.*?:\ .*$/, ''
+    cfg.gsub! /^threat-.*?:\ .*$/, ''
+    cfg.gsub! /^wildfire-.*?:\ .*$/, ''
+    cfg.gsub! /^wf-private.*?:\ .*$/, ''
+    cfg.gsub! /^url-filtering.*?:\ .*$/, ''
+    cfg.gsub! /^global-.*?:\ .*$/, ''
     comment cfg
   end
 


### PR DESCRIPTION
I have the same issue on my Palo Alto Firewalls that some of the lines in 'show system info' change every 15 minutes and others change at least daily.

modifications remove the frequently changing lines from the config.