### PR TITLE
Added feature to disable polling based on interval

### DIFF
--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -8,7 +8,7 @@ module Oxidized
       @max       = max
       # Set interval to 1 if interval is 0 (=disabled) so we don't break 
       # the 'ceil' function
-      @interval  = @interval == 0 ? 1 : interval
+      @interval  = interval == 0 ? 1 : interval
       @nodes     = nodes
       @last      = Time.now.utc
       @durations = Array.new @nodes.size, AVERAGE_DURATION

--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -8,8 +8,7 @@ module Oxidized
       @max       = max
       # Set interval to 1 if interval is 0 (=disabled) so we don't break 
       # the 'ceil' function
-      @interval  = 1 if @interval == 0
-      @interval  = interval
+      @interval  = @interval == 0 ? 1 : interval
       @nodes     = nodes
       @last      = Time.now.utc
       @durations = Array.new @nodes.size, AVERAGE_DURATION

--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -6,6 +6,9 @@ module Oxidized
 
     def initialize max, interval, nodes
       @max       = max
+      # Set interval to 1 if interval is 0 (=disabled) so we don't break 
+      # the 'ceil' function
+      @interval  = 1 if @interval == 0
       @interval  = interval
       @nodes     = nodes
       @last      = Time.now.utc

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -18,7 +18,9 @@ module Oxidized
         # ask for next node in queue non destructive way
         nextnode = @nodes.first
         unless nextnode.last.nil?
-          break if nextnode.last.end + Oxidized.config.interval > Time.now.utc
+          # Set unobtainable value for 'last' if interval checking is disabled
+          last = Oxidized.config.interval == 0 ? Time.now.utc + 10 : nextnode.last.end
+          break if last + Oxidized.config.interval > Time.now.utc
         end
         # shift nodes and get the next node
         node = @nodes.get


### PR DESCRIPTION
Set 'interval' to '0' to disable polling based on interval. Useful if you only want to poll based on external api requests. 

Solves ytti/oxidized#433