### PR TITLE
NOS v7 has an 'up' date field in the show chassis command that is the…

### DIFF
--- a/lib/oxidized/model/nos.rb
+++ b/lib/oxidized/model/nos.rb
@@ -22,7 +22,7 @@ class NOS < Oxidized::Model
   end
 
   cmd 'show chassis' do |cfg|
-    comment cfg.each_line.reject { |line| line.match /Time/ }.join
+    comment cfg.each_line.reject { |line| line.match /Time/ or line.match /Update/ }.join
   end
 
   cfg 'show system' do |cfg|


### PR DESCRIPTION
… current day.

This removes that 'up' date value from the show chassis command.

This fixes #Issue-432
