### PR TITLE
Cisco ASA - Added support for multiple contexts

### DIFF
--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -16,6 +16,13 @@ class ASA < Oxidized::Model
     cfg
   end
 
+  # check for multiple contexts
+  cmd 'show mode' do |cfg|
+    if (@context.nil?)
+      @context = true if cfg.include? 'multiple'
+    end
+  end
+
   cmd 'show version' do |cfg|
     # avoid commits due to uptime / ixo-router01 up 2 mins 28 secs / ixo-router01 up 1 days 2 hours
     cfg = cfg.each_line.select { |line| not line.match /(\s+up\s+\d+\s+)|(.*days.*)/ }
@@ -27,26 +34,52 @@ class ASA < Oxidized::Model
     comment cfg
   end
 
-  cmd 'more system:running-config' do |cfg|
-    cfg = cfg.each_line.to_a[3..-1].join
-    cfg.gsub! /^: [^\n]*\n/, ''
-    # backup any xml referenced in the configuration.
-    anyconnect_profiles = cfg.scan(Regexp.new('(\sdisk0:/.+\.xml)')).flatten
-    anyconnect_profiles.each do |profile|
-  	  cfg << (comment profile + "\n" )
-   	  cmd ("more" + profile) do |xml|
-	      cfg << (comment xml)
-	    end
-    end
-    # if DAP is enabled, also backup dap.xml
-    if cfg.rindex(/dynamic-access-policy-record\s(?!DfltAccessPolicy)/)
-   	  cfg << (comment "disk0:/dap.xml\n")
-      cmd "more disk0:/dap.xml" do |xml|
-        cfg << (comment xml)
+  post do
+    if (@context == true)
+      # Multiple context mode
+      cmd 'changeto system' do |cfg|
+        cmd 'show running-config' do |systemcfg|
+          allcfg = "\n\n" + systemcfg + "\n\n"
+          contexts = systemcfg.scan(/^context (\S+)$/)
+          files = systemcfg.scan(/config-url (\S+)$/)
+          i = 0
+          contexts.each do |cont|
+            allcfg = allcfg + "\n\n---=== [ CONTEXT " + cont.join(" ") + " FILE " + files[i].join(" ") + " ] ===---\n\n"
+            cmd "more " + files[i].join(" ") do |cfgcontext|
+              allcfg = allcfg + "\n\n" + cfgcontext
+            end
+            i += 1
+          end
+          cfg = allcfg
+        end
+        cfg
+      end
+    else
+      # Single context mode
+      cmd 'more system:running-config' do |cfg|
+        cfg = cfg.each_line.to_a[3..-1].join
+        cfg.gsub! /^: [^\n]*\n/, ''
+        # backup any xml referenced in the configuration.
+        anyconnect_profiles = cfg.scan(Regexp.new('(\sdisk0:/.+\.xml)')).flatten
+        anyconnect_profiles.each do |profile|
+            cfg << (comment profile + "\n" )
+            cmd ("more" + profile) do |xml|
+              cfg << (comment xml)
+            end
+        end
+        # if DAP is enabled, also backup dap.xml
+        if cfg.rindex(/dynamic-access-policy-record\s(?!DfltAccessPolicy)/)
+            cfg << (comment "disk0:/dap.xml\n")
+            cmd "more disk0:/dap.xml" do |xml|
+              cfg << (comment xml)
+              puts xml
+            end
+        end
+        cfg
       end
     end
-    cfg
   end
+
 
   cfg :ssh do
     if vars :enable


### PR DESCRIPTION
#338

In order to solve the Cisco ASA issue with multiple contexts I've added some changes to automatically detect if the ASA is running in single or multiple context mode. Based on that if it's running in multiple context mode it will also save the config for each context. Everything will be saved in the same file and contexts configs are preceded by a description line.

I've tested this against 4 Cisco ASA firewalls without problems. 
