### PR TITLE
Add support for Brocade 6910 (br6910)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
    * Ironware
    * NOS (Network Operating System)
    * Vyatta
+   * 6910
  * Ciena
    * SOAS
  * Cisco

--- a/lib/oxidized/model/br6910.rb
+++ b/lib/oxidized/model/br6910.rb
@@ -1,7 +1,7 @@
 
 class BR6910 < Oxidized::Model
 
-  prompt /^Vty-1\#$/
+  prompt /^Vty-[0-9]\#$/
   comment  '! '
 
   # not possible to disable paging prior to show running-config

--- a/lib/oxidized/model/br6910.rb
+++ b/lib/oxidized/model/br6910.rb
@@ -1,0 +1,45 @@
+
+class BR6910 < Oxidized::Model
+
+  prompt /^Vty-1\#$/
+  comment  '! '
+
+  # not possible to disable paging prior to show running-config
+  expect /^((.*)Others to exit ---(.*))$/ do |data, re|
+    send 'a'
+    data.sub re, ''
+  end
+
+  cmd :all do |cfg|
+    # sometimes br6910s inserts arbitrary whitespace after commands are
+    # issued on the CLI, from run to run.  this normalises the output.
+    cfg.each_line.to_a[1..-2].drop_while { |e| e.match /^\s+$/ }.join
+  end
+
+  cmd 'show version' do |cfg|
+    comment cfg
+  end
+
+  # show flash is not possible on a brocade 6910, do dir instead 
+  # to see flash contents (includes config file names)
+  cmd 'dir' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show running-config' do |cfg|
+    arr = cfg.each_line.to_a
+    arr[2..-1].join unless arr.length < 2
+  end
+
+  cfg :telnet do
+    username /^Username:/
+    password /^Password:/
+  end
+
+  # post login and post logout 
+  cfg :telnet, :ssh do
+    post_login ''
+    pre_logout 'exit'
+  end
+
+end


### PR DESCRIPTION
The Brocade 6910 switch has a significantly different CLI to Ironware/Fastiron and requires different treatment to pull config.

Major differences are:
1. Not possible to disable paging prior to show running-config. Using expect and looking for "--- [Space] Next page, [Enter] Next line, [A] All, Others to exit ---" then sending "a".
2. No show flash command. Closest is "dir" which shows OS bin files plus config filenames.
3. No separate elevated command prompt.