### PR TITLE
Update edgeswitch.rb

### DIFF
--- a/lib/oxidized/model/edgeswitch.rb
+++ b/lib/oxidized/model/edgeswitch.rb
@@ -11,8 +11,8 @@ class EdgeSwitch < Oxidized::Model
   end
 
   cfg :telnet do
-    username /Username:\s/
-    password /^Password:\s/
+    username /User(name)?:\s?/
+    password /^Password:\s?/
   end
 
   cfg :telnet, :ssh do


### PR DESCRIPTION
Fix user prompt on some versions (Only "User:" at the prompt, with no spaces