### PR TITLE
Add secret removal for bkup-passwords on Aruba

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -22,6 +22,7 @@ class AOSW < Oxidized::Model
     cfg.gsub!(/key (\S+)$/, 'key <secret removed>')
     cfg.gsub!(/secret (\S+)$/, 'secret <secret removed>')
     cfg.gsub!(/wpa-passphrase (\S+)$/, 'wpa-passphrase <secret removed>')
+    cfg.gsub!(/bkup-passwords (\S+)$/, 'bkup-passwords <secret removed>')
     cfg
   end
 


### PR DESCRIPTION
Our Aruba controllers have bkup-passwords in the configuration, which seem to change often.  This treats them like the other secret config items on Aruba and redacts the secret.