### PR TITLE
FortiOS Issue identifying prompt with truncated hostname

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -2,7 +2,7 @@ class FortiOS < Oxidized::Model
 
   comment  '# '
 
-  prompt /^([-\w\.]+(\s[\(\w\-\.\)]+)?\~?\s?[#>$]\s?)$/
+  prompt /^([-\w\.\~]+(\s[\(\w\-\.\)]+)?\~?\s?[#>$]\s?)$/
 
   expect /^--More--\s$/ do |data, re|
     send ' '


### PR DESCRIPTION
The FortiOS device will truncate the hostname if it exceeds 24 characters. It will place a tilde (~) in the hostname, either at the end or before a hyphen. This causes a failure with prompt recognition and causes the backup to fail. This change adds a tilde as an identifying character in the prompt.