### PR TITLE
strip trailing lines in junos model if ssh_no_exec enabled

### DIFF
--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -7,8 +7,7 @@ class JunOS < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    # we don't need screen-scraping in ssh due to exec
-    cfg = cfg.lines.to_a[1..-2].join if telnet || !vars(:ssh_no_exec)
+    cfg = cfg.lines.to_a[1..-2].join if screenscrape
     cfg.lines.map { |line| line.rstrip }.join("\n") + "\n"
   end
 

--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -154,6 +154,10 @@ module Oxidized
       data
     end
 
+    def screenscrape
+      @input.class.to_s.match(/Telnet/) || vars(:ssh_no_exec)
+    end
+
     private
 
     def process_cmd_output output, name


### PR DESCRIPTION
logic was the wrong way around, oops