### PR TITLE
move ssh_no_exec exec test into exec definition

### DIFF
--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -112,7 +112,7 @@ module Oxidized
     end
 
     def exec state=nil
-      state == nil ? @exec : (@exec=state)
+      state == nil ? @exec : (@exec=state) unless vars :ssh_no_exec
     end
 
     def cmd_shell(cmd, expect_re)

--- a/lib/oxidized/model/airos.rb
+++ b/lib/oxidized/model/airos.rb
@@ -15,6 +15,6 @@ class Airos < Oxidized::Model
   end
 
   cfg :ssh do
-    exec true unless vars :ssh_no_exec
+    exec true
   end
 end

--- a/lib/oxidized/model/fabricos.rb
+++ b/lib/oxidized/model/fabricos.rb
@@ -15,7 +15,7 @@ class FabricOS < Oxidized::Model
   end
 
   cfg :ssh do
-    exec true unless vars :ssh_no_exec  # don't run shell, run each command in exec channel
+    exec true  # don't run shell, run each command in exec channel
   end
 
 end

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -43,7 +43,7 @@ class JunOS < Oxidized::Model
   end
 
   cfg :ssh do
-    exec true unless vars :ssh_no_exec  # don't run shell, run each command in exec channel
+    exec true  # don't run shell, run each command in exec channel
   end
 
   cfg :telnet, :ssh do

--- a/lib/oxidized/model/opengear.rb
+++ b/lib/oxidized/model/opengear.rb
@@ -13,7 +13,7 @@ class OpenGear < Oxidized::Model
   cmd 'config -g config'
 
   cfg :ssh do
-    exec true unless vars :ssh_no_exec  # don't run shell, run each command in exec channel
+    exec true  # don't run shell, run each command in exec channel
   end
 
 end

--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -18,6 +18,6 @@ class RouterOS < Oxidized::Model
   end
 
   cfg :ssh do
-    exec true unless vars :ssh_no_exec
+    exec true
   end
 end

--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -46,7 +46,7 @@ class TMOS < Oxidized::Model
   cmd('cat /config/partitions/*/bigip.conf') { |cfg| comment cfg }
 
   cfg :ssh do
-    exec true unless vars :ssh_no_exec  # don't run shell, run each command in exec channel
+    exec true  # don't run shell, run each command in exec channel
   end
 
 end


### PR DESCRIPTION
this cleans up the ssh_no_exec test logic, reverting the individual models back to their original config.