### PR TITLE
saos: support ssh and different disable-pager command

### DIFF
--- a/lib/oxidized/model/saos.rb
+++ b/lib/oxidized/model/saos.rb
@@ -17,7 +17,9 @@ class SAOS < Oxidized::Model
     username /login:/
     password /assword:/
   end
-  cfg :telnet do
+
+  cfg :telnet, :ssh do
+    post_login 'system shell set more off'
     post_login 'system shell session set more off'
     pre_logout 'exit'
   end


### PR DESCRIPTION
I can retrieve configurations from a Ciena 3911 running saos-06-05-01-0051 with this when I set `saos_shell_set_more_off`.

Looking around, it seems like the command to disable the pager differs based on version and/or model, so I am not sure whether there is a better solution than to use the variable.