### PR TITLE
fix repository path resolution

### DIFF
--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -176,8 +176,12 @@ module Oxidized
     def resolve_repo
       remote_repo = Oxidized.config.output.git.repo
 
-      if Oxidized.config.output.git.single_repo? || @group.nil? || remote_repo.is_a?(String)
-        remote_repo
+      if remote_repo.is_a?(::String)
+        if Oxidized.config.output.git.single_repo? || @group.nil?
+          remote_repo
+        else
+          File.join(File.dirname(remote_repo), @group + '.git')
+        end
       else
         remote_repo[@group]
       end

--- a/spec/input/ssh_spec.rb
+++ b/spec/input/ssh_spec.rb
@@ -5,6 +5,7 @@ describe Oxidized::SSH do
   before(:each) do
     Oxidized.asetus = Asetus.new
     Oxidized.setup_logger
+    Oxidized::Node.any_instance.stubs(:resolve_repo)
     Oxidized::Node.any_instance.stubs(:resolve_input)
     Oxidized::Node.any_instance.stubs(:resolve_output)
     @node = Oxidized::Node.new(name: 'example.com',

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -5,6 +5,7 @@ describe Oxidized::Node do
     Oxidized.asetus = Asetus.new
     Oxidized.setup_logger
 
+    Oxidized::Node.any_instance.stubs(:resolve_repo)
     Oxidized::Node.any_instance.stubs(:resolve_output)
     @node = Oxidized::Node.new(name: 'example.com',
                                input: 'ssh',
@@ -44,6 +45,10 @@ describe Oxidized::Node do
   end
 
   describe '#repo' do
+    before do
+      Oxidized::Node.any_instance.unstub(:resolve_repo)
+    end
+
     let(:group) { nil }
     let(:node) do
       Oxidized::Node.new({

--- a/spec/nodes_spec.rb
+++ b/spec/nodes_spec.rb
@@ -15,6 +15,7 @@ describe Oxidized::Nodes do
       prompt: 'test_prompt'
     }
 
+    Oxidized::Node.any_instance.stubs(:resolve_repo)
     Oxidized::Node.any_instance.stubs(:resolve_output)
     @nodes_org = %w(ltt-pe1.hel kes2-rr1.tku tor-peer1.oul
                     hal-p2.tre sav-gr1-sw1.kuo psl-sec-pe1.hel).map { |e| Oxidized::Node.new(opts.merge(name: e)) }


### PR DESCRIPTION
There was missing the option for when using groups and defining the repository as a `String` (like, for `default` group).

This should (hopefully) fix some issues, like #473, #497, #334 :smile: 