### PR TITLE
create a `logs` dir for all the debug logs

### DIFF
--- a/lib/oxidized.rb
+++ b/lib/oxidized.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 module Oxidized
   class OxidizedError < StandardError; end
 
@@ -34,6 +36,7 @@ module Oxidized
   end
 
   def self.setup_logger
+    FileUtils.mkdir_p(Config::Log) unless File.directory?(Config::Log)
     self.logger = if config.has_key?('use_syslog') && config.use_syslog
                     require 'syslog/logger'
                     Syslog::Logger.new('oxidized')

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -5,7 +5,7 @@ module Oxidized
   class Config
     Root      = ENV['OXIDIZED_HOME'] || File.join(ENV['HOME'], '.config', 'oxidized')
     Crash     = File.join Root, 'crash'
-    Log       = File.join Root, 'log'
+    Log       = File.join Root, 'logs'
     InputDir  = File.join Directory, %w(lib oxidized input)
     OutputDir = File.join Directory, %w(lib oxidized output)
     ModelDir  = File.join Directory, %w(lib oxidized model)

--- a/lib/oxidized/input/ftp.rb
+++ b/lib/oxidized/input/ftp.rb
@@ -18,7 +18,7 @@ module Oxidized
     def connect node
       @node       = node
       @node.model.cfg['ftp'].each { |cb| instance_exec(&cb) }
-      @log = File.open(Oxidized::Config::Log + "-#{@node.ip}-ftp", 'w') if Oxidized.config.input.debug?
+      @log = File.open(Oxidized::Config::Log + "/#{@node.ip}-ftp", 'w') if Oxidized.config.input.debug?
       @ftp = Net::FTP.new @node.ip, @node.auth[:username], @node.auth[:password]
       connected?
     end

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -21,7 +21,7 @@ module Oxidized
       @output     = ''
       @node.model.cfg['ssh'].each { |cb| instance_exec(&cb) }
       secure = Oxidized.config.input.ssh.secure
-      @log = File.open(Oxidized::Config::Log + "-#{@node.ip}-ssh", 'w') if Oxidized.config.input.debug?
+      @log = File.open(Oxidized::Config::Log + "/#{@node.ip}-ssh", 'w') if Oxidized.config.input.debug?
       port = vars(:ssh_port) || 22
       if proxy_host = vars(:ssh_proxy)
         proxy =  Net::SSH::Proxy::Command.new("ssh #{proxy_host} -W %h:%p")

--- a/lib/oxidized/input/telnet.rb
+++ b/lib/oxidized/input/telnet.rb
@@ -16,7 +16,7 @@ module Oxidized
               'Port'    => port.to_i,
               'Timeout' => @timeout,
               'Model'   => @node.model }
-      opt['Output_log'] = Oxidized::Config::Log + "-#{@node.ip}-telnet" if Oxidized.config.input.debug?
+      opt['Output_log'] = Oxidized::Config::Log + "/#{@node.ip}-telnet" if Oxidized.config.input.debug?
 
       @telnet  = Net::Telnet.new opt
       if @node.auth[:username] and @node.auth[:username].length > 0


### PR DESCRIPTION
since we have several hundreds of devices, the `oxidized` directory is bloated with log files.
now the logs are kept in a `oxidized/logs` direcotry :smiley: 