### PR TITLE
removed current bw stats from screenos 'get system'

### DIFF
--- a/lib/oxidized/model/screenos.rb
+++ b/lib/oxidized/model/screenos.rb
@@ -20,6 +20,7 @@ class ScreenOS  < Oxidized::Model
   cmd 'get system' do |cfg|
     cfg.gsub! /^Date\ .*\n/, ''
     cfg.gsub! /^Up\ .*\n/, ''
+	cfg.gsub! /(current bw ).*/, '\\1 <removed>'
     comment cfg
   end
 

--- a/lib/oxidized/model/screenos.rb
+++ b/lib/oxidized/model/screenos.rb
@@ -20,7 +20,7 @@ class ScreenOS  < Oxidized::Model
   cmd 'get system' do |cfg|
     cfg.gsub! /^Date\ .*\n/, ''
     cfg.gsub! /^Up\ .*\n/, ''
-	cfg.gsub! /(current bw ).*/, '\\1 <removed>'
+    cfg.gsub! /(current bw ).*/, '\\1 <removed>'
     comment cfg
   end
 


### PR DESCRIPTION
removed current bandwith from get system, because it can create different config versions when there is traffic on the interfaces.
current bw is just stats.