### PR TITLE
Cisco ASA Secret filter for TACACS+ key

### DIFF
--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -15,6 +15,7 @@ class ASA < Oxidized::Model
     cfg.gsub! /username (\S+) password (\S+) (.*)/, 'username \1 password <secret hidden> \3'
     cfg.gsub! /ikev2 pre-shared-key (\S+)/, 'ikev2 pre-shared-key <secret hidden>'
     cfg.gsub! /ikev2 (remote|local)-authentication pre-shared-key (\S+)/, 'ikev2 \1-authentication pre-shared-key <secret hidden>'
+    cfg.gsub! /^(aaa-server TACACS\+ \(\S+\) host.*\n\skey) \S+$/m, '\1 <secret hidden>'
     cfg
   end
 


### PR DESCRIPTION
Tested on
----

```
! Cisco Adaptive Security Appliance Software Version 9.6(1)5
! Device Manager Version 7.6(1)
!
! Compiled on Fri 03-Jun-16 00:07 PDT by builders
! System image file is "(hd0,1)/asa961-5-smp-k8.bin"
! Config file at boot was "startup-config"
!
!
! Hardware:   ASAv, 2048 MB RAM, CPU Xeon 5600 series 2397 MHz,
! Model Id:   ASAv10
```

Mock text
----

Before:
```
aaa-server TACACS+ protocol tacacs+
 reactivation-mode depletion deadtime 1
aaa-server TACACS+ (my_fancy_network) host my_tacacs_host1
 timeout 7
 key mysecret_key123123
user-identity default-domain LOCAL
aaa authentication http console TACACS+ LOCAL
```

After:
```
aaa-server TACACS+ protocol tacacs+
 reactivation-mode depletion deadtime 1
aaa-server TACACS+ (my_fancy_network) host my_tacacs_host1
 timeout 7
 key <secret hidden>
user-identity default-domain LOCAL
aaa authentication http console TACACS+ LOCAL
```