### PR TITLE
Fix prompt regexp

### DIFF
--- a/lib/oxidized/model/edgeswitch.rb
+++ b/lib/oxidized/model/edgeswitch.rb
@@ -4,7 +4,7 @@ class EdgeSwitch < Oxidized::Model
 
   comment '!'
 
-  prompt /\(.*\)\s[#>]/
+  prompt /(.)*tr\s[#>]/
 
   cmd 'show running-config' do |cfg|
     cfg.each_line.to_a[2..-2].reject { |line| line.match /System Up Time.*/ or line.match /Current SNTP Synchronized Time.*/ }.join


### PR DESCRIPTION
The prompt regexp shouldn't check for literal parenthesis, they're used to mark a regexp group.