### PR TITLE
Basic HTTP auth requires user and pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,8 @@ source:
     url: https://url/api
     scheme: https
     delimiter: !ruby/regexp /:/
+    user: username
+    pass: password
     map:
       name: hostname
       model: os


### PR DESCRIPTION
The example for basic http auth doesn't match https://github.com/ytti/oxidized/blob/master/lib/oxidized/source/http.rb#L31, which requires cfg.user and cfg.pass.