### PR TITLE
Disconnect input when expected prompt wasn't found

### DIFF
--- a/lib/oxidized/input/cli.rb
+++ b/lib/oxidized/input/cli.rb
@@ -14,6 +14,9 @@ module Oxidized
         d = node.model.get
         disconnect
         d
+      rescue PromptUndetect
+        disconnect
+        raise
       end
 
       def connect_cli


### PR DESCRIPTION
Without this oxidized never closes the connection and potentially blocks additional sessions on some (crap) devices.