### PR TITLE
add Planet SGS

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
    * [Opengear](lib/oxidized/model/opengear.rb)
  * Palo Alto
    * [PANOS](lib/oxidized/model/panos.rb)
+ * PLANET
+   * [SGS](lib/oxidized/model/planetsgs.rb)
  * [pfSense](lib/oxidized/model/pfsense.rb)
  * Quanta
    * [Quanta / VxWorks 6.6 (1.1.0.8)](lib/oxidized/model/quantaos.rb)


### PR DESCRIPTION
This adds support for Planet's Layer 3 [Managed Ethernet Switches](http://www.planet.com.tw/en/product/product_list.php?id2=504).

Their syntax is pretty similar to the one from Cisco, but there are some hacks needed (like `\r` sometimes being echoed before the prompt, and a non-existing `show inventory`, which is why I decided to use a separate model for them.