### PR TITLE
Update dnos.rb

### DIFF
--- a/lib/oxidized/model/dnos.rb
+++ b/lib/oxidized/model/dnos.rb
@@ -33,15 +33,16 @@ class DNOS  < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
-    post_login 'terminal length 0'
-    post_login 'terminal width 0'
     if vars :enable
       post_login do
         send "enable\n"
         send vars(:enable) + "\n"
       end
     end
+    post_login 'terminal length 0'
+    post_login 'terminal width 0'
     pre_logout 'exit'
+    pre_logout 'exit'    
   end
 
 end


### PR DESCRIPTION
Handles old DNOS switches that do not allow term length 0 prior to enable, and double exits in case of enable..