### PR TITLE
add support for PLANET SG switches

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,7 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
    * [Opengear](lib/oxidized/model/opengear.rb)
  * Palo Alto
    * [PANOS](lib/oxidized/model/panos.rb)
- * PLANET
-   * [SGS](lib/oxidized/model/planetsgs.rb)
+ * [PLANET SG/SGS Switches](lib/oxidized/model/planet.rb)
  * [pfSense](lib/oxidized/model/pfsense.rb)
  * Quanta
    * [Quanta / VxWorks 6.6 (1.1.0.8)](lib/oxidized/model/quantaos.rb)


### PR DESCRIPTION
So far, only SGS switches were supported.

Now, we check the model type during the `show version` command, and only
execute the `show transceiver details` command in case an SGS switch was
detected (as its not supported on SG models).
We will also strip lines containing the current System Time and Uptime.
These only appear on SG models, but it's a good idea to strip them anyways.