### PR TITLE
Added option to disable ssl verification checks for http source

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ source:
       X-Auth-Token: 'somerandomstring'
 ```
 
-You can also pass `no_check_certificate = true` if you want to disable ssl certificate verification:
+You can also pass `secure: false` if you want to disable ssl certificate verification:
 
 ```
 source:
@@ -514,7 +514,7 @@ source:
   http:
     url: https://url/api
     scheme: https
-    no_check_certificate: true
+    secure: false
 ```
 
 ### Output: File

--- a/README.md
+++ b/README.md
@@ -506,6 +506,17 @@ source:
       X-Auth-Token: 'somerandomstring'
 ```
 
+You can also pass `no_check_certificate = true` if you want to disable ssl certificate verification:
+
+```
+source:
+  default: http
+  http:
+    url: https://url/api
+    scheme: https
+    no_check_certificate: true
+```
+
 ### Output: File
 
 Parent directory needs to be created manually, one file per device, with most recent running config.

--- a/lib/oxidized/source/http.rb
+++ b/lib/oxidized/source/http.rb
@@ -20,6 +20,7 @@ class HTTP < Source
     uri = URI.parse(@cfg.url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.scheme == 'https'
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE if uri.no_check_certificate == true
 
     # map headers
     headers = {}

--- a/lib/oxidized/source/http.rb
+++ b/lib/oxidized/source/http.rb
@@ -20,7 +20,7 @@ class HTTP < Source
     uri = URI.parse(@cfg.url)
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true if uri.scheme == 'https'
-    http.verify_mode = OpenSSL::SSL::VERIFY_NONE if uri.no_check_certificate == true
+    http.verify_mode = OpenSSL::SSL::VERIFY_NONE unless @cfg.secure
 
     # map headers
     headers = {}


### PR DESCRIPTION
As always, prefaced by I'm not a ruby guy :)

Tested by someone on gitter channel (well the basics of just adding `http.verify_mode = OpenSSL::SSL::VERIFY_NONE` directly to the http.rb was but I've turned it into a config option and update docs.