### PR TITLE
IOSXR Admin Configuration Backup

### DIFF
--- a/lib/oxidized/model/iosxr.rb
+++ b/lib/oxidized/model/iosxr.rb
@@ -23,8 +23,11 @@ class IOSXR < Oxidized::Model
     comment cfg
   end
 
+  cmd 'admin show running-config' do |cfg|
+    cfg
+  end
+
   cmd 'show running-config' do |cfg|
-    cfg = cfg.each_line.to_a[3..-1].join
     cfg
   end
 

--- a/lib/oxidized/model/iosxr.rb
+++ b/lib/oxidized/model/iosxr.rb
@@ -24,10 +24,12 @@ class IOSXR < Oxidized::Model
   end
 
   cmd 'admin show running-config' do |cfg|
+    cfg = cfg.each_line.to_a[1..-1].join
     cfg
   end
 
   cmd 'show running-config' do |cfg|
+    cfg = cfg.each_line.to_a[1..-1].join
     cfg
   end
 

--- a/lib/oxidized/model/iosxr.rb
+++ b/lib/oxidized/model/iosxr.rb
@@ -29,7 +29,7 @@ class IOSXR < Oxidized::Model
   end
 
   cmd 'show running-config' do |cfg|
-    cfg = cfg.each_line.to_a[1..-1].join
+    cfg = cfg.each_line.to_a[3..-1].join
     cfg
   end
 


### PR DESCRIPTION
In order for an XR device to be successfully restored, the admin config must also be backed up.  This PR adds that.

I wanted to also leave in the line "!! IOS XR Admin Configuration 5.3.4." and "!! IOS XR Configuration 5.3.4" so you could distinguish the admin config from the running-config, but I suck at ruby.  Using the delete_at method on the array returns the value of the deleted element, not the array.  Can't figure out how to just yank that line using array methods.  Maybe you guys can help me with that.  I was also thinking to using gsub to remove it, but figured the cleaner way would be to remove it in the cmd block as you were already removing the first four lines of the config in this manner.

**My first PR, be gentle. **
