### PR TITLE
exclude time from show run output

### DIFF
--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -22,7 +22,7 @@ class EOS < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show running-config | no-more' do |cfg|
+  cmd 'show running-config | no-more | exclude Time:' do |cfg|
     cfg
   end
 

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -22,7 +22,7 @@ class EOS < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show running-config | no-more | exclude Time:' do |cfg|
+  cmd 'show running-config | no-more | exclude ! Time:' do |cfg|
     cfg
   end
 


### PR DESCRIPTION
Older versions of EOS output the current time when running the command 'show running-config | no-more' 