### PR TITLE
Fix Cisco SMB prompt suggested by ytti

### DIFF
--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -34,7 +34,7 @@ class CiscoSMB < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
-    username /^Username:/
+    username /^User ?[nN]ame:/
     password /^\r?Password:$/
     post_login 'terminal datadump' # Disable pager
     post_login 'terminal width 0'


### PR DESCRIPTION
Related to #610

Hope it is ok with you @ytti that I took your suggestion and added it here. The current master branch implementation of the user name prompt is broken for all my 300 series Cisco SMB switches and would prefer to get this wrapped up.