### PR TITLE
delete secret password if it is called secret

### DIFF
--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -26,7 +26,9 @@ class IOS < Oxidized::Model
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /username (\S+) privilege (\d+) (\S+).*/, '<secret hidden>'
     cfg.gsub! /^username \S+ password \d \S+/, '<secret hidden>'
+    cfg.gsub! /^username \S+ secret \d \S+/, '<secret hidden>'
     cfg.gsub! /^enable password \d \S+/, '<secret hidden>'
+    cfg.gsub! /^enable secret \d \S+/, '<secret hidden>'
     cfg.gsub! /wpa-psk ascii \d \S+/, '<secret hidden>'
     cfg.gsub! /^tacacs-server key \d \S+/, '<secret hidden>'
     cfg


### PR DESCRIPTION
hello ytti!
First of all: thanks for this project :)
I encountered the problem that some router-configs do not call their password entries "password" at it is expected in your lib/oxidized/model/ios.rb. This leads to the problem that the secrets are still there due to the fact that the regex does not match.
I took the change to add two substitutions that also match this case.
Do you need anything else from me or is this PR fine for you?

Thank you in advance,
Kind Regards,
Matthias