### PR TITLE
Ignore undefined UTF8 in ironware.rb

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -30,7 +30,7 @@ class IronWare < Oxidized::Model
   end
 
   cmd 'show chassis' do |cfg|
-    cfg.encode!("UTF-8", :invalid => :replace) #sometimes ironware returns broken encoding
+    cfg.encode!("UTF-8", :invalid => :replace, :undef => :replace) #sometimes ironware returns broken encoding
     cfg.gsub! /(^((.*)Current temp(.*))$)/, '' #remove unwanted lines current temperature
     cfg.gsub! /Speed = [A-Z-]{2,6} \(\d{2,3}\%\)/, '' #remove unwanted lines Speed Fans
     cfg.gsub! /current speed is [A-Z]{2,6} \(\d{2,3}\%\)/, ''


### PR DESCRIPTION
We have some Brocade MLX devices that are triggering  'raised Encoding::UndefinedConversionError with msg ""\xFF" from ASCII-8BIT to UTF-8"'.  Update the ironware.rb file to ignore undefined UTF8 as well as invalid UTF8