### PR TITLE
Mask out configuration date for fiberdriver

### DIFF
--- a/lib/oxidized/model/fiberdriver.rb
+++ b/lib/oxidized/model/fiberdriver.rb
@@ -14,6 +14,7 @@ class FiberDriver < Oxidized::Model
     cfg.gsub! /^Building configuration.*$/, ''
     cfg.gsub! /^Current configuration:.*$$/, ''
     cfg.gsub! /^! Configuration saved on .*$/, ''
+    cfg
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/fiberdriver.rb
+++ b/lib/oxidized/model/fiberdriver.rb
@@ -11,6 +11,9 @@ class FiberDriver < Oxidized::Model
 
   cmd "show running-config" do |cfg|
     cfg.each_line.to_a[3..-1].join
+    cfg.gsub! /^Building configuration.*$/, ''
+    cfg.gsub! /^Current configuration:.*$$/, ''
+    cfg.gsub! /^! Configuration saved on .*$/, ''
   end
 
   cfg :ssh do


### PR DESCRIPTION
Our fiberdriver devices report a timestamp during 'show running-config', which results in a config diff on every run.  This patch removes the '+! Configuration saved on 2017/01/10 14:21:20' line from the config, as well as a couple other useless status messages