### PR TITLE
Ignore fan speed changes for ironware

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -34,6 +34,7 @@ class IronWare < Oxidized::Model
     cfg.gsub! /(^((.*)Current temp(.*))$)/, '' #remove unwanted lines current temperature
     cfg.gsub! /Speed = [A-Z-]{2,6} \(\d{2,3}\%\)/, '' #remove unwanted lines Speed Fans
     cfg.gsub! /current speed is [A-Z]{2,6} \(\d{2,3}\%\)/, ''
+    cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)<->([\[]*)3([\]]*)/, ''
     cfg.gsub! /\d{2}\.\d deg-C/, 'XX.X deg-C'
     if cfg.include? "TEMPERATURE"
       sc = StringScanner.new cfg


### PR DESCRIPTION
Brocade ICX/FCX log fan speed changes like this:

Fan ok, speed (auto): 1<->[[2]]<->3
Fan ok, speed (auto): [[1]]<->2<->3

Remove the current fan speed from the configuration to prevent lots of useless changes from being logged.