### PR TITLE
Update ironware.rb

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -34,7 +34,7 @@ class IronWare < Oxidized::Model
     cfg.gsub! /(^((.*)Current temp(.*))$)/, '' #remove unwanted lines current temperature
     cfg.gsub! /Speed = [A-Z-]{2,6} \(\d{2,3}\%\)/, '' #remove unwanted lines Speed Fans
     cfg.gsub! /current speed is [A-Z]{2,6} \(\d{2,3}\%\)/, ''
-    cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)<->([\[]*)3([\]]*)/, ''
+    cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)(<->([\[]*)3([\]]*))*/, ''
     cfg.gsub! /\d{2}\.\d deg-C/, 'XX.X deg-C'
     if cfg.include? "TEMPERATURE"
       sc = StringScanner.new cfg


### PR DESCRIPTION
Some Brocade devices only have two possible fan speeds.  Previously, this only handled three levels of fan speeds.  Updated regex will handle both of these cases:

    Fan 1 ok, speed (auto): 1<->[[2]]
    Fan 1 ok, speed (auto): 1<->[[2]]<->3