### PR TITLE
Tweak the white space for cleaning.

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -90,7 +90,7 @@ class AOSW < Oxidized::Model
       next if line.match /Output \d Config/i
       next if line.match /(Tachometers|Temperatures|Voltages)/
       next if line.match /((Card|CPU) Temperature|Chassis Fan|VMON1[0-9])/
-      next if line.match /[0-9]+ (RPMS?|m?V|C)/i
+      next if line.match /[0-9]+\s+(RPMS?|m?V|C)/i
       out << line.strip
     end
     out = comment out.join "\n"


### PR DESCRIPTION
This change allows cleaning of fan speed and temperature from the output of an Aruba S2500-24P switches running version 7.4.1.4 by allowing one or more spaces between the measurement and the units. Previously only one space was permitted in the expression. 

This change should not affect other devices and version as the single space will still be correctly parsed. 