### PR TITLE
Support lowercase U and P on telnet login prompt.

### DIFF
--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -53,8 +53,8 @@ class IOS < Oxidized::Model
   end
 
   cfg :telnet do
-    username /^[U,u]sername:/
-    password /^[P,p]assword:/
+    username /^[Uu]sername:/
+    password /^[Pp]assword:/
   end
 
   cfg :telnet, :ssh do

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -53,8 +53,8 @@ class IOS < Oxidized::Model
   end
 
   cfg :telnet do
-    username /^Username:/
-    password /^Password:/
+    username /^[U,u]sername:/
+    password /^[P,p]assword:/
   end
 
   cfg :telnet, :ssh do


### PR DESCRIPTION
Cases where "username:" and "password:" are all lowercase, seen in older IOS versions when connecting via telnet.