### PR TITLE
Don't show error is unsupported

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -36,10 +36,12 @@ class AOSW < Oxidized::Model
   end
 
   cmd 'show slots' do |cfg|
+    cfg = "" if cfg.match /Invalid input detected at '\^' marker/ #Don't show for unsupported devices
     rstrip_cfg comment cfg
   end
 
   cmd 'show license' do |cfg|
+    cfg = "" if cfg.match /Invalid input detected at '\^' marker/ #Don't show for unsupported devices
     rstrip_cfg comment cfg
   end
 


### PR DESCRIPTION
This is the proposed fix for issue #669. Let me know if there is anything that I need to fix.
This appears to be working correctly for the switch I have in house (S2400-24P). However the model is not working for the Aruba Instant AP (IAP) (virtual) controller. I hope to submit a fix for those once I have it working. The problems with that device appear to be unrelated to these changes as the prompt is incorrect.