### PR TITLE
Updating fabricos.rb to ignore dynamic fields

### DIFF
--- a/lib/oxidized/model/fabricos.rb
+++ b/lib/oxidized/model/fabricos.rb
@@ -7,10 +7,11 @@ class FabricOS < Oxidized::Model
   comment  '# '
 
   cmd 'chassisShow' do |cfg|
-    comment cfg
+    comment cfg.each_line.reject { |line| line.match /Time Awake:/ or line.match /Power Usage \(Watts\):/ or line.match /Time Alive:/ or line.match /Update:/ }.join
   end
 
   cmd 'configShow -all' do |cfg|
+    cfg = cfg.each_line.reject { |line| line.match /date = /}.join
     cfg
   end
 


### PR DESCRIPTION
Ignore dynamic fields (Uptime/Power/Date) in chassisShow and configShow on FabricOS.

Tested against FabricOS 6.2, 7.1, and 7.4