### PR TITLE
Restore compatibility with older versions of IronWare

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -74,16 +74,20 @@ class IronWare < Oxidized::Model
   cfg :telnet, :ssh do
     if vars :enable
       post_login do
-        send "enable\r\n"
+        send "enable\n"
         cmd vars(:enable)
       end
     end
     post_login ''
     post_login 'skip-page-display'
     post_login 'terminal length 0'
-    pre_logout 'logout'
-    pre_logout 'exit'
-    pre_logout 'exit'
+    pre_logout do
+      send "logout\n"
+      sleep 0.01
+      send "exit\n"
+      sleep 0.01
+      send "exit\n"
+    end
   end
 
 end


### PR DESCRIPTION
Remove \r from the "enable" command. Both \r and \n are interpreted the same on older versions, causing a blank line to be sent as the enable password.
Add a delay between the sending of the "logout" command and each "exit" command. Older devices don't seem to be able to keep up with the speed the commands are sent without a delay.
Fixes #208 and #676.