### PR TITLE
changed "diagnose autoupdate version" behaviour, since with every upd…

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -34,7 +34,7 @@ class FortiOS < Oxidized::Model
     end
 
     cfg << cmd('diagnose autoupdate version') do |cfg|
-      comment cfg
+      comment cfg.each_line.reject { |line| line.match /Last Update|Result/ }.join
     end
 
     cfg << cmd('end') if @vdom_enabled


### PR DESCRIPTION
removed Last Updated, Last Update attempt and Result from the return of 'diagnose autoupdate version'
since it changes with every online update check and signature update.

It doen't do anything for the config so it's not really usefull to store.
even Version and Contract Expiry Date are not doing anything vor the config, so maybe the whole cmd schould be removed? Maybe it can be implemented with a hook?