### PR TITLE
Next with new thread functionality (v2)

### DIFF
--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -28,8 +28,9 @@ module Oxidized
       asetus.default.retries       = 3
       asetus.default.prompt        = /^([\w.@-]+[#>]\s?)$/
       asetus.default.rest          = '127.0.0.1:8888' # or false to disable
-      asetus.default.vars          = {}             # could be 'enable'=>'enablePW'
-      asetus.default.groups        = {}             # group level configuration
+      asetus.default.next_adds_job = false            # if true, /next adds job, so device is fetched immmeiately
+      asetus.default.vars          = {}               # could be 'enable'=>'enablePW'
+      asetus.default.groups        = {}               # group level configuration
       asetus.default.pid           = File.join(Oxidized::Config::Root, 'pid')
 
       asetus.default.input.default    = 'ssh, telnet'

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -73,7 +73,7 @@ module Oxidized
           # set last job to nil so that the node is picked for immediate update
           n.last = nil
           put n
-          jobs.want += 1
+          jobs.want += 1 if Config.next_adds_job
         end
       end
     end

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -4,7 +4,7 @@ module Oxidized
   class Oxidized::NotSupported < OxidizedError; end
   class Oxidized::NodeNotFound < OxidizedError; end
   class Nodes < Array
-    attr_accessor :source
+    attr_accessor :source, :jobs
     alias :put :unshift
     def load node_want=nil
       with_lock do
@@ -73,6 +73,7 @@ module Oxidized
           # set last job to nil so that the node is picked for immediate update
           n.last = nil
           put n
+          jobs.want += 1
         end
       end
     end

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -73,7 +73,7 @@ module Oxidized
           # set last job to nil so that the node is picked for immediate update
           n.last = nil
           put n
-          jobs.want += 1 if Config.next_adds_job
+          jobs.want += 1 if Oxidized.config.next_adds_job?
         end
       end
     end

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -3,8 +3,9 @@ module Oxidized
   require 'oxidized/jobs'
   class Worker
     def initialize nodes
-      @nodes   = nodes
-      @jobs    = Jobs.new(Oxidized.config.threads, Oxidized.config.interval, @nodes)
+      @nodes      = nodes
+      @jobs       = Jobs.new(Oxidized.config.threads, Oxidized.config.interval, @nodes)
+      @nodes.jobs = @jobs
       Thread.abort_on_exception = true
     end
 


### PR DESCRIPTION
Updated PR to include only functionality to increase the job pool by 1 when /next is called.

This feature is gated by the `next_adds_job: true` config option.

Cherry picked commits from this branch https://github.com/ytti/oxidized/tree/next-with-new-thread