### PR TITLE
Dockerfile support any branch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,22 @@ MAINTAINER Samer Abdel-Hafez <sam@arahant.net>
 
 RUN add-apt-repository ppa:brightbox/ruby-ng && \
 	apt-get update && \
-  apt-get install -y ruby2.3 ruby2.3-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev
+  apt-get install -y ruby2.3 ruby2.3-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git
 
-RUN gem install oxidized oxidized-web --no-ri --no-rdoc
+RUN mkdir -p /tmp/oxidized
+COPY . /tmp/oxidized/
+WORKDIR /tmp/oxidized
+
+RUN gem build oxidized.gemspec
+RUN gem install oxidized-*.gem
+
+# web interface
+RUN gem install oxidized-web --no-ri --no-rdoc
+
+# dependencies for hooks
+RUN gem install aws-sdk
+
+RUN rm -rf /tmp/oxidized
 
 RUN apt-get remove -y ruby-dev pkg-config make cmake
 


### PR DESCRIPTION
The existing Dockerfile installs oxidized from a published gem. This does not support building containers for development from any branch.

Proposed changes build the docker image from the git clone you currently have checked out locally.

🐳 