### PR TITLE
fortiOS updates: secret removal, autoupdate messages

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -15,7 +15,8 @@ class FortiOS < Oxidized::Model
   end
 
   cmd :secret do |cfg|
-    cfg.gsub! /(set (?:passwd|password)).*/, '\\1 <configuration removed>'
+    cfg.gsub! /(set (?:passwd|password|psksecret)).*/, '\\1 <configuration removed>'
+    cfg.gsub! /(set private-key).*-+END ENCRYPTED PRIVATE KEY-*"$/m , '\\1 <configuration removed>'
     cfg
   end
 

--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -31,14 +31,18 @@ class FortiOS < Oxidized::Model
     cfg << cmd('config global') if @vdom_enabled
 
     cfg << cmd('get hardware status') do |cfg|
-      comment cfg
+       comment cfg
     end
 
-    cfg << cmd('diagnose autoupdate version') do |cfg|
-      comment cfg.each_line.reject { |line| line.match /Last Update|Result/ }.join
+    #default behaviour: include autoupdate output (backwards compatibility)
+    #do not include if variable "show_autoupdate" is set to false
+    if  defined?(vars(:fortios_autoupdate)).nil? || vars(:fortios_autoupdate)
+       cfg << cmd('diagnose autoupdate version') do |cfg|
+          comment cfg.each_line.reject { |line| line.match /Last Update|Result/ }.join
+       end
     end
 
-    cfg << cmd('end') if @vdom_enabled
+cfg << cmd('end') if @vdom_enabled
 
     cfg << cmd('show')
     cfg.join "\n"
@@ -54,3 +58,4 @@ class FortiOS < Oxidized::Model
   end
 
 end
+


### PR DESCRIPTION
added psk and private-key statements to secret removal section since they were not included and they keep changing each "show" command, too, so versioning is not possible.

also introduced variable fortiso_autoupdate like the cmdline variable in comware model to exclude autoupdate section. these section keeps changing a lot and is not really configuration relevant, so no versioning possible.

default behaviour is to include the autoupdate section for backwards compatibility

fixed some formatting misalignments, too.
