### PR TITLE
New Slack hook - posts colourized diffs to a channel

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ MAINTAINER Samer Abdel-Hafez <sam@arahant.net>
 
 RUN add-apt-repository ppa:brightbox/ruby-ng && \
 	apt-get update && \
-  apt-get install -y ruby2.3 ruby2.3-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git
+  apt-get install -y ruby2.3 ruby2.3-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++
 
 RUN mkdir -p /tmp/oxidized
 COPY . /tmp/oxidized/
@@ -17,6 +17,7 @@ RUN gem install oxidized-web --no-ri --no-rdoc
 
 # dependencies for hooks
 RUN gem install aws-sdk
+RUN gem install slack-api
 
 RUN rm -rf /tmp/oxidized
 

--- a/README.md
+++ b/README.md
@@ -874,6 +874,29 @@ AWS SNS hook requires the following configuration keys:
 
 Your AWS credentials should be stored in `~/.aws/credentials`.
 
+## Hook type: slackdiff
+
+The `slackdiff` hook posts colorized config diffs to a [Slack](http://www.slack.com) channel of your choice. It only triggers for `post_store` events.
+
+You will need to manually install the `slack-api` gem on your system:
+
+```
+gem install slack-api
+```
+
+Configuration example:
+
+``` yaml
+hooks:
+  slack:
+    type: slackdiff
+    events: [post_store]
+    token: SLACK_BOT_TOKEN
+    channel: "#network-changes"
+```
+
+Note the channel name must be in quotes.
+
 # Ruby API
 
 The following objects exist in Oxidized.

--- a/lib/oxidized/hook/slackdiff.rb
+++ b/lib/oxidized/hook/slackdiff.rb
@@ -1,0 +1,30 @@
+require 'slack'
+
+class SlackDiff < Oxidized::Hook
+  def validate_cfg!
+    raise KeyError, 'hook.token is required' unless cfg.has_key?('token')
+    raise KeyError, 'hook.channel is required' unless cfg.has_key?('channel')
+  end
+
+  def run_hook(ctx)
+    if ctx.node
+      if ctx.event.to_s == "post_store"
+        log "Connecting to slack"
+        client = Slack::Client.new token: cfg.token
+        client.auth_test
+        log "Connected"
+        gitoutput = ctx.node.output.new
+        diff = gitoutput.get_diff ctx.node, ctx.node.group, ctx.commitref, nil
+        title = "#{ctx.node.name.to_s} #{ctx.node.group.to_s} #{ctx.node.model.class.name.to_s.downcase}"
+        log "Posting diff as snippet to #{cfg.channel}"
+        client.files_upload(channels: cfg.channel, as_user: true,
+                             content: diff[:patch].lines.to_a[4..-1].join,
+                             filetype: "diff",
+                             title: title,
+                             filename: "change"
+                            )
+        log "Finished"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This contribution includes a native [Slack](http://slack.com) hook which can be used to post colourized diffs to a Slack channel of your choice.

![screen shot 2017-02-16 at 16 35 16](https://cloud.githubusercontent.com/assets/1790618/23030488/d6cd069a-f465-11e6-9aea-46a19940547a.png)

When expanded:

![screen shot 2017-02-16 at 16 35 27](https://cloud.githubusercontent.com/assets/1790618/23030492/de01a07e-f465-11e6-8684-f20712605935.png)

Configurable as follows:

```yaml
hooks:
  slack:
    type: slackdiff
    events: [post_store]
    token: #########################
    channel: "#oxidized-prod"
```
