### PR TITLE
Fix for foundry/jetcore username prompt on telnet

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -67,7 +67,7 @@ class IronWare < Oxidized::Model
     # match expected prompts on both older and newer
     # versions of IronWare
     username /^(Please Enter Login Name|Username):/
-    password /^(Please Enter )Password:/
+    password /^(Please Enter Password |Password):/
   end
 
   #handle pager with enable


### PR DESCRIPTION
Fix for foundry/ironcore devices. `Password:` in telnet was failing and the device will not login. After this change, oxidized can login to jetcore/ironcore devices.