### PR TITLE
more Cumulus files backed up

### DIFF
--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -60,15 +60,21 @@ class Cumulus < Oxidized::Model
     cfg += add_comment 'PASSWD'
     cfg += cmd 'cat /etc/passwd'
     
-    cfg += add_comment ' SWITCHD'
+    cfg += add_comment 'SWITCHD'
     cfg += cmd 'cat /etc/cumulus/switchd.conf'
     
+    cfg += add_comment 'PORTS'
+    cfg += cmd 'cat /etc/cumulus/ports.conf'
+    
+    cfg += add_comment 'TRAFFIC'
+    cfg += cmd 'cat /etc/cumulus/datapath/traffic.conf'
+   	
     cfg += add_comment 'ACL'
     cfg += cmd 'iptables -L -n'
     
     cfg += add_comment 'VERSION'
     cfg += cmd 'cat /etc/cumulus/etc.replace/os-release'
-
+    
     cfg += add_comment 'License'
     cfg += cmd 'cl-license'
     


### PR DESCRIPTION
For Cumulus devices, added traffic.conf and ports.conf to files backed up by Oxidized.

(also touched up a weeeeeee white space typo in the SWITCHD comment insertion and some tabs v. spaces)

Tested against devices running Cumulus versions 3.1 and 3.2