### PR TITLE
make mellanox config versioning much less noisy

### DIFF
--- a/lib/oxidized/model/mlnxos.rb
+++ b/lib/oxidized/model/mlnxos.rb
@@ -13,6 +13,10 @@ class MLNXOS < Oxidized::Model
     cfg.gsub! /\[\?1h=\r/, '' # Pager Handling
     cfg.gsub! /\r\[K/,'' # Pager Handling
     cfg.gsub! /\s/, '' # Linebreak Handling
+    cfg.gsub! /^CPU\ load\ averages\:\s.+/, '' # Omit constantly changing CPU info
+    cfg.gsub! /^System\ memory\:\s.+/, '' # Omit constantly changing memory info
+    cfg.gsub! /^Uptime\:\s.+/, '' # Omit constantly changing uptime info
+    cfg.gsub! /.+Generated\ at\s\d+.+/, '' # Omit constantly changing generation time info
     cfg = cfg.lines.to_a[2..-3].join
   end
 


### PR DESCRIPTION
When pulling Mellanox configs, the values for CPU info, System memory info, Uptime, and "Generated at" constantly change, resulting in a new configuration diff, file save, or git commit every time the configs themselves are fetched by Oxidized. This results in having to sift through tons of commits to find real network configuration changes.

Using the gsub method, these fields are removed when the configs are fetched. Versioning only occurs when a significant change is detected (OS versions, interface changes, inventory serial numbers, etc...)