### PR TITLE
Update regexp to match pfSense 2.3.3 config files

### DIFF
--- a/lib/oxidized/model/pfsense.rb
+++ b/lib/oxidized/model/pfsense.rb
@@ -7,7 +7,8 @@ class PfSense < Oxidized::Model
   end
   
   cmd 'cat /cf/conf/config.xml' do |cfg|
-    cfg.gsub! /\s<revision>\s*.*\s*<time>\d*<\/time>\s*.*\s*<\/revision>/, ''
+    cfg.gsub! /\s<revision>\s*<time>\d*<\/time>\s*.*\s*.*\s*<\/revision>/, ''
+    cfg.gsub! /\s<last_rule_upd_time>\d*<\/last_rule_upd_time>/, ''
     cfg
   end
   


### PR DESCRIPTION
Fix regexp for pfSense (2.3.3-RELEASE) to remove revision time in config pull.

Also remove snort last_rule_upd_time in config pull.