### PR TITLE
Update saos.rb

### DIFF
--- a/lib/oxidized/model/saos.rb
+++ b/lib/oxidized/model/saos.rb
@@ -10,6 +10,7 @@ class SAOS < Oxidized::Model
   end
 
   cmd 'configuration show' do |cfg|
+    cfg.gsub! /^! Created: [^\n]*\n/, ''
     cfg
   end
 


### PR DESCRIPTION
This proposed change is to make shure lines starting with "! Created: " are ignored. This preventes a diff in the config every time oxidized runs over Ciena SAOS devices.
This is probably not the most elegant way but it's a start.