### PR TITLE
Add support for VyOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
    * [AirOS](lib/oxidized/model/airos.rb)
    * [Edgeos](lib/oxidized/model/edgeos.rb)
    * [EdgeSwitch](lib/oxidized/model/edgeswitch.rb)
+ * [VyOS](lib/oxidized/model/vyos.rb)
  * Watchguard
    * [Fireware OS](lib/oxidized/model/firewareos.rb)
  * Zhone

--- a/lib/oxidized/model/vyatta.rb
+++ b/lib/oxidized/model/vyatta.rb
@@ -1,6 +1,6 @@
 class Vyatta < Oxidized::Model
 
-  # Brocade Vyatta / VyOS model #
+  # Brocade Vyatta #
   
   prompt /\@.*?\:~\$\s/
 

--- a/lib/oxidized/model/vyos.rb
+++ b/lib/oxidized/model/vyos.rb
@@ -1,0 +1,26 @@
+class VyOS < Oxidized::Model
+  # VyOS Model #
+
+  prompt /\@.*?\:~\$\s/
+
+  cmd :all do |cfg|
+    cfg = cfg.lines.to_a[1..-2].join
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /community (\S+) {/, 'community <hidden> {'
+    cfg
+  end
+
+  cmd 'show configuration | no-more'
+
+  cfg :telnet do
+    username  /login:\s/
+    password  /^Password:\s/
+  end
+
+  cfg :telnet, :ssh do
+    pre_logout 'exit'
+  end
+
+end


### PR DESCRIPTION
VyOS is a fork of Vyatta however some applications treat the two devices differently. When Oxidized integrates with LibreNMS via the LibreNMS API, LibreNMS passes back the OS for VyOS devices as "vyos". This makes Oxidized not work properly with VyOS devices since oxidized is currently looking for the OS type "Vyatta".

This is tested on VyOS 1.17