### PR TITLE
fix for auto-reload. 'read' doesn't block when stdin not attached

### DIFF
--- a/extra/auto-reload-config.runit
+++ b/extra/auto-reload-config.runit
@@ -2,7 +2,7 @@
 
 if [ -z "$CONFIG_RELOAD_INTERVAL" ]; then
     # Just stop and do nothing
-    read
+    sleep infinity
 fi
 
 while true; do


### PR DESCRIPTION
When running with docker in the background, and no CONFIG_RELOAD_INTERVAL variable set, stdin isn't attached to anything.  The blocking 'read' then fails and config reload is performed repeatedly without a delay

```
I, [2017-03-22T12:01:47.122379 #8997]  INFO -- : lib/oxidized/nodes.rb: Loading nodes
I, [2017-03-22T12:01:47.124551 #8997]  INFO -- : lib/oxidized/nodes.rb: Loaded 2 nodes
sleep: missing operand
Try 'sleep --help' for more information.
Reloading config...
I, [2017-03-22T12:01:47.154603 #8997]  INFO -- : lib/oxidized/nodes.rb: Loading nodes
I, [2017-03-22T12:01:47.156913 #8997]  INFO -- : lib/oxidized/nodes.rb: Loaded 2 nodes
sleep: missing operand
Try 'sleep --help' for more information.
Reloading config...
```

