### PR TITLE
Remove single line 'Up Time' lines from show system

### DIFF
--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -67,6 +67,7 @@ class PowerConnect < Oxidized::Model
       end
       out << line.strip
     end
+    out = out.select { |line| not line[/Up\sTime/] }
     out = comment out.join "\n"
     out << "\n"
   end


### PR DESCRIPTION
PR #96 seems to have broken the stripping out the Up Time line in show system on some (older?) versions of PowerConnect firmware. I am seeing the following over and over in my history:

```
-! System Up Time (days,hour:min:sec):       12,02:20:24
+! System Up Time (days,hour:min:sec):       12,03:23:26
```

Switches which put the uptime into a multi-line table work fine, but ones that put it on a single line, such as below, do not:

```
# show system
System Description:                       PowerConnect 5448
System Up Time (days,hour:min:sec):       76,01:00:08
System Contact:                           <snip>
System Name:                              <snip>
System Location:                          <snip>
System MAC Address:                       <snip>
System Object ID:                         1.3.6.1.4.1.674.10895.3021
Type:                                     Ethernet Switch
Asset tag:
Service tag:                              <snip>

Main Power Supply Status:                 OK
Fan 1 Status:                             OK
Fan 2 Status:                             OK
Fan 3 Status:                             OK


          Unit            Temperature (Celsius)            Status
------------------------ ------------------------ ------------------------
           1                        32                       OK
```

In this example the Temperature table at the bottom is stripped out just fine, but the System Up Time line is not.

To fix this I just copied the line to strip out the System Up Time from the section for cleaning up show version and added it in the clean function.