### PR TITLE
model - mlnxos : patch exit command

### DIFF
--- a/lib/oxidized/model/mlnxos.rb
+++ b/lib/oxidized/model/mlnxos.rb
@@ -42,6 +42,6 @@ class MLNXOS < Oxidized::Model
 
   cfg :ssh do
     password /^Password:\s*/
-    pre_logout 'exit'
+    pre_logout "\nexit"
   end
 end


### PR DESCRIPTION
Very little change to fix the Mellanox driver.

I observed that the SSH command never exits correctly at the end of the dumping of the configuration. By adding an extra '\n' to the pre_logout command, it works really better.