### PR TITLE
[Firewareos] Update prompt to include that of the status user

### DIFF
--- a/lib/oxidized/model/firewareos.rb
+++ b/lib/oxidized/model/firewareos.rb
@@ -1,6 +1,6 @@
 class FirewareOS < Oxidized::Model
 
-  prompt /^\[?\w*\]?\w*<?\w*>?#\s*$/
+  prompt /^\[?\w*\]?\w*<?\w*>?(#|>)\s*$/
   comment  '-- '
 
   cmd :all do |cfg|


### PR DESCRIPTION
By design there are two users on the firewareos devices. These are `admin`, and `status`. 

In my testing I confirmed that both users can retrieve the same configuration file, but the difference is that the  `status` is a readonly account, so it can't change anything.

Now, this PR is modify prompt so that of the status user is matched.

For reference here are the prompts:

admin:
```
WG#
```

status:
```
WG>
```