### PR TITLE
Adding support for internal CA certs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,7 @@ RUN apt-get -y autoremove
 
 ADD extra/oxidized.runit /etc/service/oxidized/run
 ADD extra/auto-reload-config.runit /etc/service/auto-reload-config/run
+ADD extra/update-ca-certificates.runit /etc/service/update-ca-certificates/run
 
 VOLUME ["/root/.config/oxidized"]
 EXPOSE 8888/tcp

--- a/README.md
+++ b/README.md
@@ -364,6 +364,12 @@ If you want to have the config automatically reloaded (e.g. when using a http so
 docker run -v /etc/oxidized:/root/.config/oxidized -p 8888:8888/tcp -e CONFIG_RELOAD_INTERVAL=3600 -t oxidized/oxidized:latest
 ```
 
+If you need to use an internal CA (e.g. to connect to an private github instance)
+
+```
+docker run -v /etc/oxidized:/root/.config/oxidized -v /path/to/MY-CA.crt:/usr/local/share/ca-certificates/MY-CA.crt -p 8888:8888/tcp -e UPDATE_CA_CERTIFICATES=true -t oxidized/oxidized:latest
+```
+
 ## Cookbook
 ### Debugging
 In case a model plugin doesn't work correctly (ios, procurve, etc.), you can enable live debugging of SSH/Telnet sessions. Just add a ```debug``` option containing the value true to the ```input``` section. The log files will be created depending on the parent directory of the logfile option.

--- a/extra/update-ca-certificates.runit
+++ b/extra/update-ca-certificates.runit
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+if [ "$UPDATE_CA_CERTIFICATES" == "true" ]; then
+    update-ca-certificates
+fi
+
+sleep infinity


### PR DESCRIPTION
I have this specific use case for oxidized docker image.

We got a private github instance that uses a cert signed by our internal CA.

Of course the githubrepo hook fails, since the internal CA isn't trusted.

The simplest solution I could think of is this:
1) Utilise `update-ca-certs` that scans scans `/usr/local/share/ca-certificates/`
2) New environment variable `UPDATE_CA_CERTIFICATE` (similar to `CONFIG_RELOAD_INTERVAL`) to control whether update-ca-certificate should be executed.

Of course this means that the internal CA certs need to end up in the container somehow, but something among the lines of should work.

```
docker run -v /etc/oxidized:/root/.config/oxidized -v /path/to/MY-CA.crt:/usr/local/share/ca-certificates/MY-CA.crt -p 8888:8888/tcp -e UPDATE_CA_CERTIFICATES=true -t oxidized/oxidized:latest
```


I've also updated the README.md to reflect this

Let me know what you think.

 