### PR TITLE
Watchguard prompt - fix to #813

### DIFF
--- a/lib/oxidized/model/firewareos.rb
+++ b/lib/oxidized/model/firewareos.rb
@@ -1,6 +1,6 @@
 class FirewareOS < Oxidized::Model
 
-  prompt /^\[?\w*\]?\w*<?\w*>?(#|>)\s*$/
+  prompt /^([\w.@-]+[#>]\s?)$/
   comment  '-- '
 
   cmd :all do |cfg|


### PR DESCRIPTION
Fix to #813.

I decided to play safe - `/^([\w.@-]+[#>]\s?)$/`.

Perhaps worth waiting for @Alexandre-io just a couple of days to see if he has anything to add.