### PR TITLE
added firmware version to airos

### DIFF
--- a/lib/oxidized/model/airos.rb
+++ b/lib/oxidized/model/airos.rb
@@ -1,14 +1,19 @@
 class Airos < Oxidized::Model
   # Ubiquiti AirOS circa 5.x
-  
+
   prompt /^[^#]+# /
-  
+  comment '# '
+
   cmd 'cat /etc/board.info' do |cfg|
     cfg.split("\n").map { |line| "# #{line}" }.join("\n") + "\n"
   end
-  
+
+  cmd 'cat /etc/version' do |cfg|
+    comment "airos version: #{cfg}"
+  end
+
   cmd 'sort /tmp/system.cfg'
-  
+
   cmd :secret do |cfg|
     cfg.gsub! /^(users\.\d+\.password|snmp\.community)=.+/, "# \\1=<hidden>"
     cfg


### PR DESCRIPTION
adds the firmware version number to the comments part of the config.  I also cleaned up whitespace in the file.