### PR TITLE
Create siklu.rb to add support for Siklu EtherHaul radios

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
  * [pfSense](lib/oxidized/model/pfsense.rb)
  * Quanta
    * [Quanta / VxWorks 6.6 (1.1.0.8)](lib/oxidized/model/quantaos.rb)
+ * Siklu
+   * [EtherHaul](lib/oxidized/model/siklu.rb)
  * Supermicro
    * [Supermicro](lib/oxidized/model/supermicro.rb)
  * Trango Systems

--- a/lib/oxidized/model/siklu.rb
+++ b/lib/oxidized/model/siklu.rb
@@ -6,10 +6,12 @@ class Siklu < Oxidized::Model
 
   prompt /^[\w-]+>$/
 
-  cmd 'copy running-configuration display'
+  cmd 'copy startup-configuration display' do |cfg|
+    cfg.each_line.to_a[2..2].join
+  end
 
-  cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+  cmd 'copy running-configuration display' do |cfg|
+    cfg.each_line.to_a[3..-2].join
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/siklu.rb
+++ b/lib/oxidized/model/siklu.rb
@@ -2,8 +2,6 @@ class Siklu < Oxidized::Model
 
   # Siklu EtherHaul #
 
-  comment '# '
-
   prompt /^[\w-]+>$/
 
   cmd 'copy startup-configuration display' do |cfg|

--- a/lib/oxidized/model/siklu.rb
+++ b/lib/oxidized/model/siklu.rb
@@ -1,0 +1,19 @@
+class Siklu < Oxidized::Model
+
+  # Siklu EtherHaul #
+
+  comment '# '
+
+  prompt /^[\w-]+>$/
+
+  cmd 'copy running-configuration display'
+
+  cmd :all do |cfg|
+    cfg.each_line.to_a[1..-2].join
+  end
+
+  cfg :ssh do
+    pre_logout 'exit'
+  end
+
+end


### PR DESCRIPTION
I've tested this file on a Siklu EH-1200FX radio, however that's the only model I have, and it pulls the configuration without error.

I'm looking for feedback with grabbing the running-configuration versus the startup-configuration, though. The only difference in the output is that with the startup-configuration command you get a line at the beginning that tells you what version created the configuration file. I feel like this might be important to have, however I'd also like to know if changes were made to the running config that weren't saved.

Example of the line in startup-configuration output:
`
####====####  Generated by ver. 7.0.0.16739, convert ver. 12`