### PR TITLE
Added support for model specific credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,12 +843,17 @@ For model specific credentials
 
 ```
 models:
-  mikrotik:
+  junos:
     username: admin
-    password: blank
-  ubiquiti:
-    username: ubnt
-    password: ubnt
+    password: password
+  ironware:
+    username: admin
+    password: password
+    vars: 
+      enable: enablepassword
+  apc_aos:
+    username: apc
+    password: password
 ```
 
 ### Triggered backups

--- a/README.md
+++ b/README.md
@@ -839,6 +839,17 @@ map:
   name: 1
   group: 2
 ```
+For model specific credentials
+
+```
+models:
+  mikrotik:
+    username: admin
+    password: blank
+  ubiquiti:
+    username: ubnt
+    password: ubnt
+```
 
 ### Triggered backups
 

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -31,6 +31,7 @@ module Oxidized
       asetus.default.next_adds_job = false            # if true, /next adds job, so device is fetched immmeiately
       asetus.default.vars          = {}               # could be 'enable'=>'enablePW'
       asetus.default.groups        = {}               # group level configuration
+      asetus.default.models        = {}               # model level configuration
       asetus.default.pid           = File.join(Oxidized::Config::Root, 'pid')
 
       asetus.default.input.default    = 'ssh, telnet'

--- a/lib/oxidized/config/vars.rb
+++ b/lib/oxidized/config/vars.rb
@@ -8,8 +8,12 @@ module Oxidized::Config::Vars
         r ||= Oxidized.config.groups[@node.group].vars[name.to_s]
       end
     end
+    if Oxidized.config.models.has_key?(@node.model.class.name.to_s.downcase)
+      if Oxidized.config.models[@node.model.class.name.to_s.downcase].vars.has_key?(name.to_s)
+        r ||= Oxidized.config.models[@node.model.class.name.to_s.downcase].vars[name.to_s]
+      end
+    end
     r ||= Oxidized.config.vars[name.to_s] if Oxidized.config.vars.has_key?(name.to_s)
     r
   end
 end
-

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -216,6 +216,14 @@ module Oxidized
         end
       end
 
+      #model
+      if Oxidized.config.models.has_key?(@model.class.name.to_s.downcase)
+        if Oxidized.config.models[@model.class.name.to_s.downcase].has_key?(key_str)
+          value = Oxidized.config.models[@model.class.name.to_s.downcase][key_str]
+          Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '#{value}' from model"
+        end
+      end
+
       #node
       value = opt[key_sym] || value
       Oxidized.logger.debug "node.rb: returning node key '#{key}' with value '#{value}'"


### PR DESCRIPTION
Hi.

I needed specific credentials for models, and I wanted to keep my groups not dependent from the model.

It's works quite well, but I only tested it with ironware, junos and apc_aos equipments as I only have these equipements.

It works well with the model_map list, so the model in the input can match one on these entries in the model_map list.

Thanks.