### PR TITLE
Quanta: accept shorter username prompt

### DIFF
--- a/lib/oxidized/model/quantaos.rb
+++ b/lib/oxidized/model/quantaos.rb
@@ -12,7 +12,7 @@ class QuantaOS < Oxidized::Model
   end
 
   cfg :telnet do
-    username /^Username:/
+    username /^User(name)?:/
     password /^Password:/
   end
 


### PR DESCRIPTION
This was default with my Quanta LB4M

Software Version............................... 1.1.0.8
Operating System............................... VxWorks 6.6