### PR TITLE
added a pre-logout command to quit cleanly from routeros

### DIFF
--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -22,6 +22,10 @@ class RouterOS < Oxidized::Model
     password /^Password:/
   end
 
+  cfg :telnet, :ssh do
+    pre_logout 'quit'
+  end
+
   cfg :ssh do
     exec true
   end


### PR DESCRIPTION
Noticed stale "active users" in some versions of RouterOS, added the CLI "quit" command to cleanly exit.
Tested it for 2 days on 5 devices without any issues.
