### PR TITLE
Added secret removal to vrp model

### DIFF
--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -4,6 +4,12 @@ class VRP < Oxidized::Model
   prompt /^(<[\w.-]+>)$/
   comment '# '
 
+  cmd :secret do |cfg|
+    cfg.gsub! /(pin verify (?:auto|)).*/, '\\1 <PIN hidden>'
+    cfg.gsub! /(%\^%#.*%\^%#)/, '<secret hidden>'
+    cfg
+  end
+
   cmd :all do |cfg|
     cfg.each_line.to_a[1..-2].join
   end


### PR DESCRIPTION
Added possibilty to remove lines of configration containing secrets.
The displayed encrypted PIN changes with every call of "display current-configuration all" and makes versioning impossible.
Other secrets are also stored in an encrypted format (%^%#...%^%#)