### PR TITLE
fortios.rb fortios_autoupdate remove FDS Address

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -38,6 +38,7 @@ class FortiOS < Oxidized::Model
     #do not include if variable "show_autoupdate" is set to false
     if  defined?(vars(:fortios_autoupdate)).nil? || vars(:fortios_autoupdate)
        cfg << cmd('diagnose autoupdate version') do |cfg|
+          cfg.gsub! /(FDS Address\n---------\n).*/, '\\1IP Address removed'
           comment cfg.each_line.reject { |line| line.match /Last Update|Result/ }.join
        end
     end


### PR DESCRIPTION
The output of "diagnose autoupdate version" contains the FortiGuard
Distribution Server (FDS) address. This IP Address changes several times
per week and therefore versioning is hardly possible. Added a line to
remove the IP Address when fortios_autoupdate is set true.

See #727 for the initial idea of fortiso_autoupdate variable 