### PR TITLE
Strip passwords from RouterOS

### DIFF
--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -21,6 +21,14 @@ class RouterOS < Oxidized::Model
     cfg.join("\n") + "\n"
   end
 
+  cmd :secret do |cfg|
+    cfg.gsub! /(password=)(\S+)/, '\\1<password hidden>'
+    cfg.gsub! /((?:wpa|wpa2)-pre-shared-key=)(\S+)/, '\\1<password hidden>'
+    cfg.gsub! /(authentication-key=)(\S+)/, '\\1<password hidden>'
+    cfg.gsub! /(tcp-md5-key=)(\S+)/, '\\1<password hidden>'
+    cfg
+  end
+
   cfg :telnet do
     username /^Login:/
     password /^Password:/


### PR DESCRIPTION
This should add ability to have secrets/passwords stripped from RouterOS config backup (should include BGP/OSPF keys, PPTP/OVPN passwords and WPA/WPA2 keys, but I've probably missed something).

Downside is that if you have a system script that has a password variable of any sort (e.g. DDNS scripts sometimes do this) then that won't be stripped since that'd be pretty hard to do on user-defined variables.