### PR TITLE
changed panos logout from exit to quit

### DIFF
--- a/lib/oxidized/model/panos.rb
+++ b/lib/oxidized/model/panos.rb
@@ -28,6 +28,6 @@ class PanOS < Oxidized::Model
 
   cfg :ssh do
     post_login 'set cli pager off'
-    pre_logout 'exit'
+    pre_logout 'quit'
   end
 end


### PR DESCRIPTION
If you exit PanOS CLI with exit, the SSH session will be exited, but the user session inside PanOS keeps open until the session timeout occours. If you're using quit to end the SSH session, the user session will be closed too and no idle sessions keep lingering around.