### PR TITLE
Fixes for Brocade ADX loadbalancers

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -35,6 +35,7 @@ class IronWare < Oxidized::Model
     cfg.gsub! /Speed = [A-Z-]{2,6} \(\d{2,3}\%\)/, '' #remove unwanted lines Speed Fans
     cfg.gsub! /current speed is [A-Z]{2,6} \(\d{2,3}\%\)/, ''
     cfg.gsub! /Fan [1-6] - STATUS: OK [A-Z()[0-9] :-]{0,30}/, '' # Fix for ADX Fan speed reporting
+    cfg.gsub! /[0-9][0-9] deg C/, '' # Fix for ADX temperature reporting
     cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)(<->([\[]*)3([\]]*))*/, ''
     cfg.gsub! /\d{2}\.\d deg-C/, 'XX.X deg-C'
     if cfg.include? "TEMPERATURE"

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -52,6 +52,7 @@ class IronWare < Oxidized::Model
   end
 
   cmd 'show flash' do |cfg|
+    cfg.gsub! /(\d+) bytes/, '' # Fix for ADX flash size
     comment cfg
   end
 

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -35,7 +35,7 @@ class IronWare < Oxidized::Model
     cfg.gsub! /Speed = [A-Z-]{2,6} \(\d{2,3}\%\)/, '' #remove unwanted lines Speed Fans
     cfg.gsub! /current speed is [A-Z]{2,6} \(\d{2,3}\%\)/, ''
     cfg.gsub! /Fan [1-6] - STATUS: OK [A-Z()[0-9] :-]{0,30}/, '' # Fix for ADX Fan speed reporting
-    cfg.gsub! /[0-9][0-9] deg C/, '' # Fix for ADX temperature reporting
+    cfg.gsub! /\d* deg C/, '' # Fix for ADX temperature reporting
     cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)(<->([\[]*)3([\]]*))*/, ''
     cfg.gsub! /\d{2}\.\d deg-C/, 'XX.X deg-C'
     if cfg.include? "TEMPERATURE"

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -34,6 +34,7 @@ class IronWare < Oxidized::Model
     cfg.gsub! /(^((.*)Current temp(.*))$)/, '' #remove unwanted lines current temperature
     cfg.gsub! /Speed = [A-Z-]{2,6} \(\d{2,3}\%\)/, '' #remove unwanted lines Speed Fans
     cfg.gsub! /current speed is [A-Z]{2,6} \(\d{2,3}\%\)/, ''
+    cfg.gsub! /Fan [1-6] - STATUS: OK [A-Z()[0-9] :-]{0,30}/, '' # Fix for ADX Fan speed reporting
     cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)(<->([\[]*)3([\]]*))*/, ''
     cfg.gsub! /\d{2}\.\d deg-C/, 'XX.X deg-C'
     if cfg.include? "TEMPERATURE"

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -34,7 +34,7 @@ class IronWare < Oxidized::Model
     cfg.gsub! /(^((.*)Current temp(.*))$)/, '' #remove unwanted lines current temperature
     cfg.gsub! /Speed = [A-Z-]{2,6} \(\d{2,3}\%\)/, '' #remove unwanted lines Speed Fans
     cfg.gsub! /current speed is [A-Z]{2,6} \(\d{2,3}\%\)/, ''
-    cfg.gsub! /Fan [1-6] - STATUS: OK [A-Z()[0-9] :-]{0,30}/, '' # Fix for ADX Fan speed reporting
+    cfg.gsub! /Fan \d* - STATUS: OK \D*\d*./, '' # Fix for ADX Fan speed reporting
     cfg.gsub! /\d* deg C/, '' # Fix for ADX temperature reporting
     cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)(<->([\[]*)3([\]]*))*/, ''
     cfg.gsub! /\d{2}\.\d deg-C/, 'XX.X deg-C'


### PR DESCRIPTION
When setting up oxidized I kept getting updates for my Brocade ADX loadbalancers due to config byte size changes and Fan speed and temperature changes. I've modified ironware.rb to remove these.

There's just one side effect, the byte size removal also removes the bytes from image sizes in "show flash" on other Brocade devices. For me thats not a problem but for others it might be. Feel free to improve my regexp where possible :).