### PR TITLE
Planet: remove temperature from output

### DIFF
--- a/lib/oxidized/model/planet.rb
+++ b/lib/oxidized/model/planet.rb
@@ -39,9 +39,10 @@ class Planet < Oxidized::Model
 
     cfg = cfg.each_line.to_a[0...-2]
 
-   # Strip system time and system uptime from planet gs switches
+   # Strip system (up)time and temperature
     cfg = cfg.reject { |line| line.match /System Time\s*:.*/ }
     cfg = cfg.reject { |line| line.match /System Uptime\s*:.*/ }
+    cfg = cfg.reject { |line| line.match /Temperature\s*:.*/ }
 
     comment cfg.join
   end


### PR DESCRIPTION
Some Planet Switches (at least from their industrial line)
show the system temperature on the 'show version'
command, so strip it from the output, too.