### PR TITLE
RouterOS: Use `/export hide-sensitive` when `remove_secret` is set in Oxidized

### DIFF
--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -14,11 +14,14 @@ class RouterOS < Oxidized::Model
     comment cfg
   end
 
-  cmd '/export' do |cfg|
-    cfg.gsub! /\x1B\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]/, '' # strip ANSI colours
-    cfg.gsub! /\\\r\n\s+/, ''   # strip new line
-    cfg = cfg.split("\n").select { |line| not line[/^\#\s\w{3}\/\d{2}\/\d{4}.*$/] }
-    cfg.join("\n") + "\n"
+  post do
+    run_cmd = vars(:remove_secret) ? '/export hide-sensitive' : '/export'
+    cmd run_cmd do |cfg|
+      cfg.gsub! /\x1B\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]/, '' # strip ANSI colours
+      cfg.gsub! /\\\r\n\s+/, ''   # strip new line
+      cfg = cfg.split("\n").select { |line| not line[/^\#\s\w{3}\/\d{2}\/\d{4}.*$/] }
+      cfg.join("\n") + "\n"
+    end
   end
 
   cfg :telnet do


### PR DESCRIPTION
This runs export with the hide-sensitive using the Mikrotik command to remove secrets from the config pulled from the device. 
Closes #900 