### PR TITLE
Fixes for Netgear

### DIFF
--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -8,21 +8,29 @@ class Netgear < Oxidized::Model
     cfg
   end
 
+  cfg :telnet do
+    username /^User:/
+  end
+
   cfg :telnet, :ssh do
     if vars :enable
       post_login do
-        cmd 'enable'
+        send "enable\n"
         # Interpret enable: true as meaning we won't be prompted for a password
         unless vars(:enable).is_a? TrueClass
           expect /[pP]assword:\s?$/
-          cmd vars(:enable) + "\n"
+          send vars(:enable) + "\n"
         end
         expect /^.+[#]$/
       end
     end
     post_login 'terminal length 0'
-    pre_logout 'exit'
-    pre_logout 'quit'
+    # quit / logout will sometimes prompt the user:
+    #
+    #     The system has unsaved changes.
+    #     Would you like to save them now? (y/n)
+    #
+    # So it is safer simply to disconnect and not issue a pre_logout command
   end
 
   cmd 'show running-config' do |cfg|


### PR DESCRIPTION
- match the User: prompt on telnet
- fix the sending of enable password
- don't issue exit/quit commands on logout, because an
  additional prompt may or may not be encountered

Closes #920