### PR TITLE
Change SIGTERM (default) to SIGINT when stopping oxidized systemd unit

### DIFF
--- a/extra/oxidized.service
+++ b/extra/oxidized.service
@@ -9,6 +9,7 @@ Description=Oxidized - Network Device Configuration Backup Tool
 [Service]
 ExecStart=/usr/local/bin/oxidized
 User=oxidized
+KillSignal=SIGINT
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Puma docs @ https://github.com/puma/puma/blob/master/docs/signals.md state that SIGTERM (which systemd uses by default) stops single worker while SIGINT stops the whole cluster. Additionally a hang was observed when using the default SIGTERM when shutting down the unit. Switching to SIGINT worked as expected.

This pull request simply changes the systemd unit to use SIGINT signal.