### PR TITLE
Exclude secondary-secrets and rsso-secret

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -15,7 +15,7 @@ class FortiOS < Oxidized::Model
   end
 
   cmd :secret do |cfg|
-    cfg.gsub! /(set (?:passwd|password|psksecret|secret|key ENC)).*/, '\\1 <configuration removed>'
+    cfg.gsub! /(set (?:passwd|password|secondary-secret|rsso-secret|psksecret|secret|key ENC)).*/, '\\1 <configuration removed>'
     cfg.gsub! /(set private-key).*-+END ENCRYPTED PRIVATE KEY-*"$/m , '\\1 <configuration removed>'
     cfg
   end


### PR DESCRIPTION
I've noticed there are sometimes secondary keys and rsso-secrets, so I propose we also replace them (worked for us)!