### PR TITLE
Create enterasys.rb (C3/B3 series switches)

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,9 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
  * Ericsson/Redback
    * [IPOS (former SEOS)](lib/oxidized/model/ipos.rb)
  * Extreme Networks
-   * [XOS](lib/oxidized/model/xos.rb)
+   * [Enterasys](/lib/oxidized/model/enterasys.rb)
    * [WM](lib/oxidized/model/mtrlrfs.rb)
+   * [XOS](lib/oxidized/model/xos.rb)
  * F5
    * [TMOS](lib/oxidized/model/tmos.rb)
  * Force10

--- a/lib/oxidized/model/enterasys.rb
+++ b/lib/oxidized/model/enterasys.rb
@@ -1,20 +1,25 @@
 class Enterasys < Oxidized::Model
 
-  # Enterasys B3 model #
+  # Enterasys B3/C3 models #
 
   prompt /^.+\w\(su\)->\s?$/
 
   comment  '!'
 
   cmd :all do |cfg|
-     cfg.each_line.to_a[1..-2].join
+     cfg.each_line.to_a[2..-3].map{|line|line.delete("\r").rstrip}.join("\n") + "\n"
   end
 
   cmd 'show system hardware' do |cfg|
-    cfg
+    comment cfg
   end
 
   cmd 'show config' do |cfg|
+    cfg.gsub! /^This command shows non-default configurations only./, ''
+    cfg.gsub! /^Use 'show config all' to show both default and non-default configurations./, ''
+    cfg.gsub! /^!|#.*/, ''
+    cfg.gsub! /^$\n/, ''
+
     cfg
   end
 

--- a/lib/oxidized/model/enterasys.rb
+++ b/lib/oxidized/model/enterasys.rb
@@ -1,0 +1,25 @@
+class Enterasys < Oxidized::Model
+
+  # Enterasys B3 model #
+
+  prompt /^.+\w\(su\)->\s?$/
+
+  comment  '!'
+
+  cmd :all do |cfg|
+     cfg.each_line.to_a[1..-2].join
+  end
+
+  cmd 'show system hardware' do |cfg|
+    cfg
+  end
+
+  cmd 'show config' do |cfg|
+    cfg
+  end
+
+  cfg :ssh do
+    pre_logout 'exit'
+  end
+
+end


### PR DESCRIPTION
Used for the lanparty Frag-o-Matic

Tested with the following switches:
- Enterasys Securestack C3G124-48
- Enterasys Securestack B3G124-48

This adds basic support. We will try and maintain this file if we find valuable additions in the future.