### PR TITLE
Driver for Westell 8178G and Westell 8266G devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,8 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
    * [EdgeSwitch](lib/oxidized/model/edgeswitch.rb)
  * Watchguard
    * [Fireware OS](lib/oxidized/model/firewareos.rb)
+ * Westell
+   * [Westell 8178G, Westell 8266G](lib/oxidized/model/weos.rb)
  * Zhone
    * [Zhone (OLT and MX)](lib/oxidized/model/zhoneolt.rb)
  * Zyxel

--- a/lib/oxidized/model/weos.rb
+++ b/lib/oxidized/model/weos.rb
@@ -1,0 +1,22 @@
+class WEOS < Oxidized::Model
+
+  #Westell WEOS, works with Westell 8178G, Westell 8266G
+
+  prompt /^(\s[\w.@-]+[#>]\s?)$/
+
+  cmd :all do |cfg|
+    cfg.each_line.to_a[1..-2].join
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg
+  end
+
+  cfg :telnet do
+    username /login:/
+    password /assword:/
+    post_login 'cli more disable'
+    pre_logout 'logout'
+  end
+
+end


### PR DESCRIPTION
We use Westell devices in our network (Westell 8178G and Westell 8266G), so I wrote a driver.
SSH daemon is broken on those devices, so only telnet-based shell works.