### PR TITLE
Added individual repository per device option for git output

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,7 +607,7 @@ output:
     repo: "/var/lib/oxidized/devices.git"
 ```
 
-And for groups repositories:
+For a single repositories per group:
 
 ``` yaml
 output:
@@ -643,6 +643,42 @@ output:
     single_repo: true
     repo: "/var/lib/oxidized/devices.git"
 
+```
+
+For a single repositories per device:
+
+```yaml
+output:
+  default: git
+  git:
+    user: Oxidized
+    email: o@example.com
+    individual_repo: true
+    repo: "/var/lib/oxidized/git-repos/default.git"
+```
+
+Oxidized will create a folder for each group in the same directory as the `default.git`. When no group is provided, the folder default will be created. It will create one repository per device. For example:
+
+```csv
+host1:ios:first
+host2:nxos:second
+host3:fortios:nill
+```
+
+This will generate the following folders/repositories:
+
+```bash
+$ ls /var/lib/oxidized/git-repos
+default first second
+
+$ ls /var/lib/oxidized/git-repos/default
+host3.git
+
+$ ls /var/lib/oxidized/git-repos/first
+host1.git
+
+$ ls /var/lib/oxidized/git-repos/second
+host2.git
 ```
 
 ### Output: Git-Crypt

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -170,7 +170,11 @@ module Oxidized
         remote_repo = Oxidized.config.output.git.repo
 
         if remote_repo.is_a?(::String)
-          if Oxidized.config.output.git.single_repo? || @group.nil?
+          if Oxidized.config.output.git.individual_repo? && !@group.nil?
+            File.join(File.dirname(remote_repo), @group + '/' + @name + '.git')
+          elsif Oxidized.config.output.git.individual_repo? && @group.nil?
+            File.join(File.dirname(remote_repo), '/default/' + @name + '.git')
+          elsif Oxidized.config.output.git.single_repo? || @group.nil?
             remote_repo
           else
             File.join(File.dirname(remote_repo), @group + '.git')

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -148,6 +148,9 @@ class Git < Output
       path = "#{group}/#{node.name}"
     end
 
+    if group and @cfg.individual_repo?
+      path = "#{node.name}"
+    end
     [repo, path]
   end
 
@@ -159,11 +162,17 @@ class Git < Output
         file = File.join @opt[:group], file
       else
         repo = if repo.is_a?(::String)
-                 File.join File.dirname(repo), @opt[:group] + '.git'
+                 if(@cfg.individual_repo?)
+                   File.join File.dirname(repo), @opt[:group], @opt[:name] + '.git'
+                 else
+                   File.join File.dirname(repo), @opt[:group] + '.git'
+                 end
                else
                  repo[@opt[:group]]
                end
       end
+    elsif(@cfg.individual_repo?)
+      repo = File.join File.dirname(repo), '/default/', @opt[:name] + '.git'
     end
 
     begin

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -46,7 +46,7 @@ module Oxidized
         msg += " with message '#{node.msg}'" if node.msg
         output = node.output.new
         if output.store node.name, job.config,
-                              :msg => msg, :user => node.user, :group => node.group
+                              :msg => msg, :user => node.user, :group => node.group, :name => node.name
           Oxidized.logger.info "Configuration updated for #{node.group}/#{node.name}"
           Oxidized.Hooks.handle :post_store, :node => node,
                                              :job => job,


### PR DESCRIPTION
Additional to the existing options of a single repository for all
devices or one repository per group, this option allows to have one
repository for every individual device.

This comes in handy as i addressed this issue:
https://github.com/ytti/oxidized-web/issues/115

Large repositories slow down the process of finding the last configuration change, because the walker has to iterate through a lot of updates from other devices.