### PR TITLE
all nodes done hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -894,6 +894,7 @@ Following configuration keys need to be defined for all hooks:
   * `node_success`: triggered when configuration is succesfully pulled from a node and right before storing the configuration.
   * `node_fail`: triggered after `retries` amount of failed node pulls.
   * `post_store`: triggered after node configuration is stored (this is executed only when the configuration has changed).
+  * `nodes_done`: triggered after finished fetching all nodes.
 
 ## Hook type: exec
 The `exec` hook type allows users to run an arbitrary shell command or a binary when triggered.

--- a/lib/oxidized/hook.rb
+++ b/lib/oxidized/hook.rb
@@ -23,6 +23,7 @@ class HookManager
     :node_success,
     :node_fail,
     :post_store,
+    :nodes_done
   ]
   attr_reader :registered_hooks
 

--- a/lib/oxidized/hook/exec.rb
+++ b/lib/oxidized/hook/exec.rb
@@ -71,7 +71,6 @@ class Exec < Oxidized::Hook
         "OX_NODE_FROM" => ctx.node.from.to_s,
         "OX_NODE_MSG" => ctx.node.msg.to_s,
         "OX_NODE_GROUP" => ctx.node.group.to_s,
-        "OX_EVENT" => ctx.event.to_s,
         "OX_REPO_COMMITREF" => ctx.commitref.to_s,
         "OX_REPO_NAME" => ctx.node.repo.to_s,
       )

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -8,6 +8,7 @@ module Oxidized
     attr_reader :name, :ip, :model, :input, :output, :group, :auth, :prompt, :vars, :last, :repo
     attr_accessor :running, :user, :msg, :from, :stats, :retry
     alias :running? :running
+
     def initialize opt
       Oxidized.logger.debug 'resolving DNS for %s...' % opt[:name]
       # remove the prefix if an IP Address is provided with one as IPAddr converts it to a network address.
@@ -217,6 +218,7 @@ module Oxidized
       end
 
       #model
+      # FIXME: warning: instance variable @model not initialized
       if Oxidized.config.models.has_key?(@model.class.name.to_s.downcase)
         if Oxidized.config.models[@model.class.name.to_s.downcase].has_key?(key_str)
           value = Oxidized.config.models[@model.class.name.to_s.downcase][key_str]

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -3,6 +3,7 @@ module Oxidized
   require 'oxidized/jobs'
   class Worker
     def initialize nodes
+      @jobs_done  = 0
       @nodes      = nodes
       @jobs       = Jobs.new(Oxidized.config.threads, Oxidized.config.interval, @nodes)
       @nodes.jobs = @jobs
@@ -14,8 +15,9 @@ module Oxidized
       @jobs.delete_if { |job| ended << job if not job.alive? }
       ended.each      { |job| process job }
       @jobs.work
+
       while @jobs.size < @jobs.want
-        Oxidized.logger.debug "lib/oxidized/worker.rb: Jobs #{@jobs.size}, Want: #{@jobs.want}"
+        Oxidized.logger.debug "lib/oxidized/worker.rb: Jobs running: #{@jobs.size} of #{@jobs.want} - ended: #{@jobs_done} of #{@nodes.size}"
         # ask for next node in queue non destructive way
         nextnode = @nodes.first
         unless nextnode.last.nil?
@@ -29,6 +31,8 @@ module Oxidized
         @jobs.push Job.new node
         Oxidized.logger.debug "lib/oxidized/worker.rb: Added #{node.name} to the job queue"
       end
+
+      run_done_hook if is_cycle_finished?
       Oxidized.logger.debug("lib/oxidized/worker.rb: #{@jobs.size} jobs running in parallel") unless @jobs.empty?
     end
 
@@ -38,6 +42,8 @@ module Oxidized
       node.stats.add job
       @jobs.duration job.time
       node.running = false
+      @jobs_done += 1 # needed for worker_done event
+
       if job.status == :success
         Oxidized.Hooks.handle :node_success, :node => node,
                                              :job => job
@@ -71,5 +77,20 @@ module Oxidized
       Oxidized.logger.warn "#{node.name} not found, removed while collecting?"
     end
 
+    private
+
+    def is_cycle_finished?
+      @jobs_done > 0 && @jobs_done % @nodes.count == 0
+    end
+
+    def run_done_hook
+      Oxidized.logger.debug "lib/oxidized/worker.rb: Running :nodes_done hook"
+      Oxidized.Hooks.handle :nodes_done
+    rescue => e
+      # swallow the hook erros and continue as normal
+      Oxidized.logger.error "lib/oxidized/worker.rb: #{e.message}"
+    ensure
+      @jobs_done = 0
+    end
   end
 end


### PR DESCRIPTION
This PR includes a new event `nodes_done` for a complete cycle.

Example of a run:

```
D, (...) loads of logs lines (...)
D,  lib/oxidized/node.rb: Oxidized::SSH ran for 10.X.X.206 successfully
D,  lib/oxidized/job.rb: Config fetched for 10.X.X.206 at 2017-08-15 14:50:54 UTC
D,  lib/oxidized/worker.rb: Jobs running: 0 of 1 - ended: 3 of 3
D,  lib/oxidized/worker.rb: Running :nodes_done hook
D,  Exec: Execute: "env >> /tmp/nodes_done.log"
D,  lib/oxidized/worker.rb: Jobs running: 0 of 1 - ended: 0 of 3
D,  lib/oxidized/worker.rb: Jobs running: 0 of 1 - ended: 0 of 3
```

closes #178 