### PR TITLE
Extreme XOS policies backup

### DIFF
--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -29,6 +29,10 @@ class XOS < Oxidized::Model
 
   cmd 'show configuration'
 
+  cmd 'show policy detail' do |cfg|
+    comment cfg
+  end
+
   cfg :telnet do
     username /^login:/
     password /^\r*password:/


### PR DESCRIPTION
Hello,
Backup of XOS switches is incomplete without policies: they are the separate .xsf files on the filesystems. They are used for ACLs, routing policies etc. 

Fortunately, there is a 'show policy detail' command displaying policy files content. It shows only policies actually used in a config so it fits perfect into backup routine