### PR TITLE
Fix version output (single git repo without group case)

### DIFF
--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -144,8 +144,10 @@ class Git < Output
   def yield_repo_and_path(node, group)
     repo, path = node.repo, node.name
 
-    if group and @cfg.single_repo?
+    if group && group != "" && @cfg.single_repo?
       path = "#{group}/#{node.name}"
+    else
+      path = "#{node.name}"
     end
 
     [repo, path]


### PR DESCRIPTION
When trying to get backup versions in single repo without groups, I was getting 'Versions not found'.