### PR TITLE
Hide db last update

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -17,6 +17,7 @@ class FortiOS < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub! /(set (?:passwd|password|secondary-secret|rsso-secret|psksecret|secret|key ENC)).*/, '\\1 <configuration removed>'
     cfg.gsub! /(set private-key).*-+END ENCRYPTED PRIVATE KEY-*"$/m , '\\1 <configuration removed>'
+    cfg.gsub! /(IPS Malicious URL Database).*/, '\\1 <configuration removed>'
     cfg
   end
 


### PR DESCRIPTION
Everyday the IPS URL db is updated and so the configuration is "changed". I believe this information spams the diff config and my team and I just decided to replace it by a unique string. Maybe instead of putting this in the :secret, we could create an other var or something that can be specified in the conf. Don't know what you think of this ;-)