### PR TITLE
Fix #1001: Use git show instead of git diff for reporting changes

### DIFF
--- a/extra/oxidized-report-git-commits
+++ b/extra/oxidized-report-git-commits
@@ -58,4 +58,4 @@ echo "Git repo: ${OX_REPO_NAME}"
 echo "Git commit ID: ${OX_REPO_COMMITREF}"
 echo ""
 
-git --bare --git-dir="${OX_REPO_NAME}" diff --no-color "${OX_REPO_COMMITREF}~1..${OX_REPO_COMMITREF}"
+git --bare --git-dir="${OX_REPO_NAME}" show --pretty='' --no-color "${OX_REPO_COMMITREF}"


### PR DESCRIPTION
When running aginst a new repo, OX_REPO_COMMITREF points to the initial
commit and OX_REPO_COMMITREF~1 is invalid. Git diff fails with error:
unknown revision or path not in the working tree