### PR TITLE
Update README to indicate that Alcatel Lucent routers running SR OS (TiMOS) are supported.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
    * [AOS](lib/oxidized/model/aos.rb)
    * [AOS7](lib/oxidized/model/aos7.rb)
    * [ISAM](lib/oxidized/model/isam.rb)
+   * [SR OS (Formerly TiMOS)](lib/oxidized/model/timos.rb)
    * Wireless
  * Alvarion
    * [BreezeACCESS](lib/oxidized/model/alvarion.rb)


### PR DESCRIPTION
In PR #995, I was a bit confused on the support for Alcatel-Lucent (Nokia) devices, as the README only mentioned support for the omniswitch platform.