### PR TITLE
Fix Encoding::UndefinedConversionError from FTOS

### DIFF
--- a/lib/oxidized/model/ftos.rb
+++ b/lib/oxidized/model/ftos.rb
@@ -15,6 +15,8 @@ class FTOS  < Oxidized::Model
   end
 
   cmd 'show inventory' do |cfg|
+    # Old versions of FTOS can occasionally return data that triggers encoding errors.
+    cfg.encode!("UTF-8", :invalid => :replace, :undef => :replace, :replace => "")
     comment cfg
   end
 


### PR DESCRIPTION
On older firmware revisions FTOS can trigger encoding errors when listing hardware inventory.

This patch replaces the invalid data (which is normally \uFFFD) with the empty string.