### PR TITLE
Some older IOS uses lowercase in the telnet prompt

### DIFF
--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -126,8 +126,8 @@ class IOS < Oxidized::Model
   end
 
   cfg :telnet do
-    username /^Username:/
-    password /^Password:/
+    username /^Username:/i
+    password /^Password:/i
   end
 
   cfg :telnet, :ssh do


### PR DESCRIPTION
Some older IOS builds have lower case telnet prompts.

username: instead of Username:
password: instead of Password:

So I've changed the match to be case insensitive.