### PR TITLE
Suppress timestamp response to ios commands

### DIFF
--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -140,7 +140,6 @@ class IOS < Oxidized::Model
     end
     post_login 'terminal length 0'
     post_login 'terminal width 0'
-    post_login 'terminal exec prompt no-timestamp'
     pre_logout 'exit'
   end
 

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -140,6 +140,7 @@ class IOS < Oxidized::Model
     end
     post_login 'terminal length 0'
     post_login 'terminal width 0'
+    post_login 'terminal exec prompt no-timestamp'
     pre_logout 'exit'
   end
 

--- a/lib/oxidized/model/iosxr.rb
+++ b/lib/oxidized/model/iosxr.rb
@@ -36,6 +36,7 @@ class IOSXR < Oxidized::Model
   cfg :telnet, :ssh do
     post_login 'terminal length 0'
     post_login 'terminal width 0'
+    post_login 'terminal exec prompt no-timestamp'
     if vars :enable
       post_login do
         send "enable\n"


### PR DESCRIPTION
At least some versions of ios output a timestamp after each input command. This will cause Oxidized to have a different version of the config for every poll of the device. I added the per-session command to suppress timestamps.

fixes #1022