### PR TITLE
Fix issue where "email" JSON field is not being passed through from REST API

### DIFF
--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -6,7 +6,7 @@ module Oxidized
   class ModelNotFound  < OxidizedError; end
   class Node
     attr_reader :name, :ip, :model, :input, :output, :group, :auth, :prompt, :vars, :last, :repo
-    attr_accessor :running, :user, :msg, :from, :stats, :retry
+    attr_accessor :running, :user, :email, :msg, :from, :stats, :retry
     alias :running? :running
 
     def initialize opt
@@ -121,7 +121,7 @@ module Oxidized
     end
 
     def reset
-      @user = @msg = @from = nil
+      @user = @email = @msg = @from = nil
       @retry = 0
     end
 

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -68,6 +68,7 @@ module Oxidized
         with_lock do
           n = del node
           n.user = opt['user']
+          n.email = opt['email']
           n.msg  = opt['msg']
           n.from = opt['from']
           # set last job to nil so that the node is picked for immediate update

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -52,7 +52,7 @@ module Oxidized
         msg += " with message '#{node.msg}'" if node.msg
         output = node.output.new
         if output.store node.name, job.config,
-                              :msg => msg, :user => node.user, :group => node.group
+                              :msg => msg, :email => node.email, :user => node.user, :group => node.group
           Oxidized.logger.info "Configuration updated for #{node.group}/#{node.name}"
           Oxidized.Hooks.handle :post_store, :node => node,
                                              :job => job,


### PR DESCRIPTION
Currently, the email field is not being passed from the REST API to the worker. This prevents, in my case, Gitlab from properly displaying the commit author in the commit history/blame.

I corrected this by adding an "email" field to the node class, and modifying the worker to pass through the "email" option to the node.