### PR TITLE
enable/disable ssl certificate validation for githubrepo remote server

### DIFF
--- a/README.md
+++ b/README.md
@@ -962,6 +962,7 @@ This hook configures the repository `remote` and _push_ the code when the specif
   * `password`: password for repository auth.
   * `publickey`: publickey for repository auth.
   * `privatekey`: privatekey for repository auth.
+  * `secure`: whether the ssl certificate of the remote repository should be verified. Default: true
 
 When using groups repositories, each group must have its own `remote` in the `remote_repo` config.
 

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -11,11 +11,11 @@ class GithubRepo < Oxidized::Hook
 
     fetch_and_merge_remote(repo)
 
-    remote.push([repo.head.name], credentials: credentials)
+    remote.push([repo.head.name], credentials: credentials, certificate_check: certificate_validation)
   end
 
   def fetch_and_merge_remote(repo)
-    result = repo.fetch('origin', [repo.head.name], credentials: credentials)
+    result = repo.fetch('origin', [repo.head.name], credentials: credentials, certificate_check: certificate_validation)
     log result.inspect, :debug
 
     unless result[:total_deltas] > 0
@@ -43,6 +43,10 @@ class GithubRepo < Oxidized::Hook
   end
 
   private
+
+  def certificate_validation
+    lambda { |valid, host| cfg.has_key? 'secure' and cfg.secure == false ? true : valid }
+  end
 
   def credentials
     @credentials ||= if cfg.has_key?('username') && cfg.has_key?('password')


### PR DESCRIPTION
The githubrepo hook currently lacks of a "secure: false" option to disable SSL verification for fetch and push operations on the remote server.