### PR TITLE
Add support for Supermicro SSE-G48-TG4

### DIFF
--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -128,7 +128,8 @@
  * Siklu
    * [EtherHaul](lib/oxidized/model/siklu.rb)
  * Supermicro
-   * [Supermicro](lib/oxidized/model/supermicro.rb)
+   * [Supermicro](lib/oxidized/model/supermicro.rb): Known to work with the Supermicro SSE-G2252.
+   * [Supermicro2](lib/oxidized/model/supermicro2.rb): Known to work with the Supermicro SSE-G48-TG4.
  * Symantec
    * [Blue Coat ProxySG / Security Gateway OS (SGOS)](lib/oxidized/model/sgos.rb)
  * Trango Systems


### PR DESCRIPTION
This model (and possibly others) runs an OS with a different set of commands than the Supermicro model that already exists.

I didn't find anything resembling a name of the OS, so I just used the model name for the class. If you think this name is fine I can update the PR to add it to the README. If not, please suggest a better name (maybe just Supermicro2?).