### PR TITLE
support passphrases on ssh key in githubrepo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,25 @@
-FROM phusion/baseimage:0.9.18
+FROM phusion/baseimage:0.9.22
 MAINTAINER Samer Abdel-Hafez <sam@arahant.net>
 
 RUN add-apt-repository ppa:brightbox/ruby-ng && \
 	apt-get update && \
   apt-get install -y ruby2.3 ruby2.3-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++
+RUN apt-get install -y libgcrypt11-dev dh-autoreconf libgcrypt20-dev chrpath build-essential wget
 
 RUN mkdir -p /tmp/oxidized
 COPY . /tmp/oxidized/
 WORKDIR /tmp/oxidized
+RUN wget https://launchpad.net/ubuntu/+archive/primary/+files/libssh2_1.7.0-1ubuntu1.debian.tar.xz
+RUN wget https://launchpad.net/ubuntu/+archive/primary/+files/libssh2_1.7.0.orig.tar.gz
+RUN tar xvf libssh2_1.7.0-1ubuntu1.debian.tar.xz
+RUN tar xfv libssh2_1.7.0.orig.tar.gz
+RUN mv debian/ libssh2-1.7.0/
+WORKDIR /tmp/oxidized/libssh2-1.7.0/
+ENV DEB_BUILD_OPTIONS nocheck
+RUN dpkg-buildpackage -b
+RUN dpkg -i ../libssh*deb
 
+WORKDIR /tmp/oxidized
 RUN gem build oxidized.gemspec
 RUN gem install oxidized-*.gem
 

--- a/README.md
+++ b/README.md
@@ -963,6 +963,8 @@ This hook configures the repository `remote` and _push_ the code when the specif
   * `publickey`: publickey for repository auth.
   * `privatekey`: privatekey for repository auth.
 
+Use an environment variable `OXIDIZED_SSH_PASSPHRASE` if your key has a passphrase
+
 When using groups repositories, each group must have its own `remote` in the `remote_repo` config.
 
 ``` yaml

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -51,7 +51,6 @@ class GithubRepo < Oxidized::Hook
     else
       if cfg.has_key?('publickey') && cfg.has_key?('privatekey')
         log "Using ssh auth with key", :debug
-        log "passphrase = #{ENV['OXIDIZED_SSH_PASSPHRASE']}", :debug
         Rugged::Credentials::SshKey.new(username: 'git', publickey: File.expand_path(cfg.publickey), privatekey: File.expand_path(cfg.privatekey), passphrase: ENV["OXIDIZED_SSH_PASSPHRASE"])
       else
         log "Using ssh auth with agentforwarding", :debug

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -51,7 +51,8 @@ class GithubRepo < Oxidized::Hook
     else
       if cfg.has_key?('publickey') && cfg.has_key?('privatekey')
         log "Using ssh auth with key", :debug
-        Rugged::Credentials::SshKey.new(username: 'git', publickey: File.expand_path(cfg.publickey), privatekey: File.expand_path(cfg.privatekey))
+        log "passphrase = #{ENV['OXIDIZED_SSH_PASSPHRASE']}", :debug
+        Rugged::Credentials::SshKey.new(username: 'git', publickey: File.expand_path(cfg.publickey), privatekey: File.expand_path(cfg.privatekey), passphrase: ENV["OXIDIZED_SSH_PASSPHRASE"])
       else
         log "Using ssh auth with agentforwarding", :debug
         Rugged::Credentials::SshKeyFromAgent.new(username: 'git')


### PR DESCRIPTION
Due to https://github.com/libgit2/rugged/issues/530 we need a newer libssh2 to support a passphrase on an SSH key.

This necessarily needs Dockerfile hacking.