### PR TITLE
Allow configure mode in prompt regex

### DIFF
--- a/lib/oxidized/model/nos.rb
+++ b/lib/oxidized/model/nos.rb
@@ -2,7 +2,7 @@ class NOS < Oxidized::Model
 
   # Brocade Network Operating System
 
-  prompt /^(?:\e\[..h)?[\w.-]+(\([\w.-]+\))*# $/
+  prompt /^(?:\e\[..h)?[\w.-]+(\([\w.-]+\))?# $/
   comment  '! '
 
   cmd :all do |cfg|

--- a/lib/oxidized/model/nos.rb
+++ b/lib/oxidized/model/nos.rb
@@ -2,7 +2,7 @@ class NOS < Oxidized::Model
 
   # Brocade Network Operating System
 
-  prompt /^(?:\e\[..h)?[\w.-]+# $/
+  prompt /^(?:\e\[..h)?[\w.-]+(\([\w.-]+\))*# $/
   comment  '! '
 
   cmd :all do |cfg|

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -2,7 +2,7 @@ class Procurve < Oxidized::Model
 
   # some models start lines with \r
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  prompt /^\r?([\w.-]+(\([\w+.-\]+))*# )$/
+  prompt /^\r?([\w.-]+(\([\w+.-\]+))?# )$/
 
   comment  '! '
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -2,7 +2,7 @@ class Procurve < Oxidized::Model
 
   # some models start lines with \r
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  prompt /^\r?([\w.-]+# )$/
+  prompt /^\r?([\w.-]+(\([\w+.-\]+))*# )$/
 
   comment  '! '
 


### PR DESCRIPTION
To properly use oxidized-script and switch to configure terminal, the prompt regex needs to accept `<hostname>(config)# ` and all other context layers (vlan-... etc.).

With the given regex, oxidized-script times out once the context is switched to configure terminal because the regex does not match anymore.