### PR TITLE
Fix prompt pattern for firewareos clusters

### DIFF
--- a/lib/oxidized/model/firewareos.rb
+++ b/lib/oxidized/model/firewareos.rb
@@ -1,6 +1,6 @@
 class FirewareOS < Oxidized::Model
 
-  prompt /^([\w.@-]+[#>]\s?)$/
+  prompt /^\[?\w*\]?\w*?(<\w*>)?(#|>)\s*$/
   comment  '-- '
 
   cmd :all do |cfg|


### PR DESCRIPTION
Default prompt in firewareos cluster mode look like this :

```
WG<master># 
```

I had to rollback to the first pattern to avoid breaking the xml with `>`