### PR TITLE
Handle Dell N2000 switches (dnos6)

### DIFF
--- a/lib/oxidized/model/dnos.rb
+++ b/lib/oxidized/model/dnos.rb
@@ -5,6 +5,7 @@ class DNOS  < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
+    cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
     cfg.each_line.to_a[2..-2].join
   end
 
@@ -19,6 +20,14 @@ class DNOS  < Oxidized::Model
   end
 
   cmd 'show inventory media' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show version' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show system' do |cfg|
     comment cfg
   end
 


### PR DESCRIPTION
Manage Dell Network OS 6  extending the `dnos` model. May correct #804.

