### PR TITLE
Allow whitespaces in hostname

### DIFF
--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -2,7 +2,7 @@ class Procurve < Oxidized::Model
 
   # some models start lines with \r
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  prompt /^\r?([\w.-]+# )$/
+  prompt /^\r?([\w\s.-]+# )$/
 
   comment  '! '
 


### PR DESCRIPTION
Without this change a prompt that look like this will fail: "MY SWITCH#"