### PR TITLE
Cisco ASA: gather inventory and status for the secondary machine in a redundant pair.

### DIFF
--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -36,6 +36,21 @@ class ASA < Oxidized::Model
     comment cfg
   end
 
+  cmd 'show failover state' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show failover history' do |cfg|
+    comment cfg
+  end
+
+  cmd 'failover exec mate show inventory' do |cfg|
+    comment cfg
+  end
+
+  cmd 'more system:running-config' do |cfg|
+     cfg = cfg.each_line.to_a[3..-1].join
+     cfg.gsub! /^: [^\n]*\n/, ''
   post do
     if @is_multiple_context
       multiple_context

--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -48,9 +48,6 @@ class ASA < Oxidized::Model
     comment cfg
   end
 
-  cmd 'more system:running-config' do |cfg|
-     cfg = cfg.each_line.to_a[3..-1].join
-     cfg.gsub! /^: [^\n]*\n/, ''
   post do
     if @is_multiple_context
       multiple_context


### PR DESCRIPTION
Please consider adding this to get complete inventory from a redundant pair. Useful when
oxidized is controlled by librenms, because in that case you can't add the secondary device to monitoring. 