### PR TITLE
Netgear model: Permit . as valid character in prompt

### DIFF
--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -1,7 +1,7 @@
 class Netgear < Oxidized::Model
 
   comment '!'
-  prompt /^(\([\w-]+\)\s[#>])$/
+  prompt /^(\([\w\-.]+\)\s[#>])$/
 
   cmd :secret do |cfg|
     cfg.gsub!(/password (\S+)/, 'password <hidden>')


### PR DESCRIPTION
I have Netgear switch with hostname like "switch.example.net" which results in prompt like:

    (SWGE001-STO-DC1.ita.local) #

This is not considered valid by current prompt regex, so I added . as a valid character in the character class.
