### PR TITLE
panos (Palo Alto): Make it possible to configure configuration format

### DIFF
--- a/lib/oxidized/model/panos.rb
+++ b/lib/oxidized/model/panos.rb
@@ -4,7 +4,7 @@ class PanOS < Oxidized::Model
 
   comment  '! '
 
-  prompt /^[\w.\@:\(\)-]+>\s?$/
+  prompt /^[\w.\@:\(\)-]+[>#]\s?$/
 
   cmd :all do |cfg|
     cfg.each_line.to_a[2..-3].join
@@ -22,12 +22,18 @@ class PanOS < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show config running' do |cfg|
+  cmd 'configure'
+
+  cmd 'show' do |cfg|
     cfg
   end
 
   cfg :ssh do
     post_login 'set cli pager off'
+    if vars :panos_config_format
+      post_login 'set cli config-output-format ' + vars(:panos_config_format)
+    end
+    pre_logout 'quit'
     pre_logout 'quit'
   end
 end


### PR DESCRIPTION
Hi.

Currently, the panos model retrieves and stores the configuraiton in the default configuration format that looks something like this:

```
config {
  mgt-config {
    users {
      admin {
        phash <redacted>
        permissions {
          role-based {
            superuser yes;
          }
        }
      }
```

This format lends itself really poorly to diffing, because it's unclear without a lot of context information where you actually are in a configuration. Instead I prefer to retrieve the configuration in "set" format which looks like this:

```
set mgt-config users admin phash <redacted>
set mgt-config users admin permissions role-based superuser yes
```

In order to accomplish this, the command ```set cli config-output-format set``` has to be issued. Instead of "set" also valid is: default, json, set and xml. If someone prefers, he can set these instead.

The current code uses the command ```show config running``` to dump the command output. Unfortunately, this command does not respect the ```set cli config-output-format``` setting. Instead it always outputs in the bogus format above. As an alternative, instead you have to enter ```configure``` mode, and then issue the command ```show```. For this reason, I also had to widen the legal prompt regex.

The code I have submitted looks to work on my end, but I'm not sure if I've done this in the "correct" way.

Finally, I have some doubts as to whether it's actually possible to restore configuration files that have been dumped out on CLI in their entirety, or whether either of these formats is useful for auditing purposes only. It may be that you have to use XML format (ugh) no matter what. But this is not really a topic for this PR at the moment.