### PR TITLE
HTTP input and PanOS API model

### DIFF
--- a/lib/oxidized/input/http.rb
+++ b/lib/oxidized/input/http.rb
@@ -1,0 +1,63 @@
+module Oxidized
+  require 'net/http'
+  require 'net/https'
+  require_relative 'cli'
+
+  class HTTP < Input
+    RescueFail = {
+      :debug => [
+      ],
+      :warn => [
+      ],
+    }
+
+    # Why? This is not a CLI method... but if not, it doesn't get registered
+    # in the manager...
+    include Input::CLI
+    
+    def connect node  
+      @node = node  
+      @mode.model.cfg['http'].each { |cb| instance_exec(&cb) }  
+      @log = File.open(Oxidized::Config::Log + "/#{@node.ip}-http", 'w') if Oxidized.config.input.debug?  
+      # Don't use @node.ip here, because this will make Net::HTTP not send a  
+      # correct HOST header.  
+      @http = Net::HTTP.new(@node.name)  
+      if vars(:ssl)  
+        @http.use_ssl = true  
+        @http.port = vars(:https_port) || 443  
+        @http.verify_mode = OpenSSL::SSL::VERIFY_NONE unless Oxidized.config.input.http.validate_ssl_cert  
+      else  
+        @http.port = vars(:http_port) || 80  
+      end  
+      connected?
+    end
+  
+    def connected?  
+      @http and not @http.finished?  
+    end  
+  
+    def cmd req  
+      Oxidized.logger.debug "HTTP: #{req.method} #{req.path} @ #{@node.name}"  
+      @http.request req  
+    end  
+
+    # I do not understand these two methods, I just copied them from ftp.rb
+    def send my_proc
+      my_proc.call
+    end
+
+    def output
+      ""
+    end
+
+    private
+
+    def disconnect
+      @http.finish
+    #rescue Errno::ECONNRESET, IOError
+    ensure
+      @log.close if Oxidized.config.input.debug?
+    end
+
+  end
+end

--- a/lib/oxidized/model/panosapi.rb
+++ b/lib/oxidized/model/panosapi.rb
@@ -1,0 +1,40 @@
+class PanOSAPI < Oxidized::Model
+  begin
+    require 'nokogiri'
+  rescue LoadError
+    raise OxidizedError, 'nokogiri not found: sudo gem install nokogiri'
+  end
+
+  # Run this command as an instance of Model so we can access node
+  pre do
+    apikey_req = Net::HTTP::Get.new '/api/?' + URI.encode_www_form({
+      :user => node.auth[:username],
+      :password => node.auth[:password],
+      :type => 'keygen'
+    })
+
+    cmd apikey_req do |response|
+      doc = Nokogiri::XML(response.body)
+      status = doc.xpath('//response/@status').first
+      if status.to_s != 'success'
+        msg = doc.xpath('//response/result/msg').text
+        raise OxidizedError, ('Could not generate PanOS API key: ' + msg)
+      end
+      apikey = doc.xpath('//response/result/key').text.to_s
+    end
+  end
+
+  config_export_req = Net::HTTP::Get.new '/api/?' + URI.encode_www_form({
+    :key => apikey,
+    :type => 'export',
+    :category => 'configuration'
+  })
+
+  cmd config_export_req do |response|
+    Nokogiri::XML(response.body).to_xml(:indent => 2)
+  end
+
+  cfg :http do
+  end
+
+end


### PR DESCRIPTION
As suggested by @ytti in #440, this is my attempt at implementing XML configuration retrieval for the PanOS API over HTTP.

First, I have created a ruby script that successfully is able to pull configuration. See this gist: https://gist.github.com/pv2b/e156040ece91ad8dde6c5109ce968646

Some explanation of the flow. First of all, an API key has to be retrieved. I have opted for the slightly longer route of generating an API key on every attempt, rather than trying to persist the API key somewhere. I feel this fits better in with how people expect oxidized to work. This is done by a GET request on the path `/api/?user=username&password=password&type=keygen`

The response is returned inside some XML, we unwrap it.

We can then call GET on the path `/api/?key=apikey&type=export&category=configuration` to get an XML-format output. This is then prettyprinted using nokogiri (because the output by default is just one long line of XML which is impossible to diff...)

In the model, I have tried to preserve similar semantics to the ftp.rb model. I'm not 100% sure of how this works, because my mental model of how the actual model works is lacking at best. I haven't quite been able to mentally get my mind around exactly what order and context things are called in. Rather than using strings for the paths as suggested by @ytti, I have instead attempted to use Net:HTTPGenericRequest objects for the actual command. My hope would be that this would allow model writers to be very general and flexible about what kind of HTTP calls their models need to do, perhaps if special headers need to be set for authentication, POST methods, etc. This has made using the input a little more cumbersome than I had hoped, but it's not too bad.

Where I run into a problem, and I think the main obstacle to getting this code to work, is that the full form of the HTTP request is not known a priori. I.e., the API key needs to be known in order to construct the full HTTP request to actually download the API key, and I have no idea how I might represent that in this kind of execution model.

So, I'm putting the PR in here, to hopefully solicit some feedback about how this might be made to work, or how it may be refactored.