### PR TITLE
Procurve: Handle switch selection for stack commanders

### DIFF
--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -21,6 +21,11 @@ class Procurve < Oxidized::Model
     ""
   end
 
+  expect /Enter switch number/ do
+    send "\n"
+    ""
+  end
+
   cmd :all do |cfg|
     cfg = cfg.each_line.to_a[1..-2].join
     cfg = cfg.gsub /^\r/, ''


### PR DESCRIPTION
When trying to connect to a HP Procurve Switch with stacking enabled,
you are asked to choose which switch to connect to to manage.

This patch makes it so that if this question is encountered, just press
"Enter" to choose the stack commander.

This won't make backing up stack members work (they still need to be
configured seperately and given IP addresses, making stacking useless)
but at least it makes it possible to back up a commander in a stack
seperately.

Fixed #1070

Credit to @stiltzkin10 for this fix.