### PR TITLE
model/ios: handle RBAC-enabled IOS shells

### DIFF
--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -115,7 +115,23 @@ class IOS < Oxidized::Model
     comment cfg
   end
 
+  cmd 'show running-config view full' do |cfg|
+    @running_full_config_rbac = process_running_config(cfg)
+  end
+
   cmd 'show running-config' do |cfg|
+    # if running-config view full returned actual output and
+    # not the 3-line "Invalid input detected....", accept it.
+    if @running_full_config_rbac.lines.count > 5
+      ""
+    else
+      cfg
+    end
+  end
+
+  # add an intermediate method to process running config
+  # in order to control running-config variations
+  def process_running_config cfg
     cfg = cfg.each_line.to_a[3..-1]
     cfg = cfg.reject { |line| line.match /^ntp clock-period / }.join
     cfg.gsub! /^Current configuration : [^\n]*\n/, ''


### PR DESCRIPTION
RBAC-enabled shells and users in IOS, need show running-config view full in order to return meaningful results.

As not all IOS versions support this command, run view full version first, and if this returns less than 5 lines, (ie \n% Invalid input detected\n\n), fallback to get output from 'show running-config'.

Code was proposed in ytti/oxidized#213, I'm just testing and creating the request.

Testing:
- Works as it should (view full output wins) with my RBAC-enabled cisco shell and oxidize user being a non-privileged user.
- As I currently don't have any non-RBAC cisco shells to test the fallback, did the following to test it:
  - changed the command to `show running-config view fall` instead of `full`
  - this behaves as `show run view full` would in non-RBAC equipment (ie. "% Invalid input" etc.).
  Code fallbacks successfully  to `show run` command output in that case.

Thanks!

Fixes: #213