### PR TITLE
Workaround: Allow Oxidized service to be stopped.

### DIFF
--- a/extra/oxidized.service
+++ b/extra/oxidized.service
@@ -10,7 +10,7 @@ Wants=network-online.target
 [Service]
 ExecStart=/usr/local/bin/oxidized
 User=oxidized
-KillSignal=SIGINT
+KillSignal=SIGKILL
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
There is an issue with oxidized and correctly terminating when a user stops the service.

Unfortunately the root cause of this issue has yet to be identified, and it may
have to do with specific versions of Ruby gems.

As such, the workaround is to use a SIGKILL to kill the oxidized/puma service
instead of a SIGINIT.

Note: This does not solve the issue with manually starting the oxidized
daemon and using Ctrl + c to stop it. The solution here is to then
press Ctrl + Z, then manually "kill -9 <PID>".
 
Fixes: #864
