### PR TITLE
New FTP option - Passive

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -14,6 +14,8 @@ input:
   debug: true
   ssh:
     secure: false
+  ftp:
+    passive: true
 ```
 
 ### Privileged mode

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -37,6 +37,7 @@ module Oxidized
       asetus.default.input.default    = 'ssh, telnet'
       asetus.default.input.debug      = false # or String for session log file
       asetus.default.input.ssh.secure = false # complain about changed certs
+      asetus.default.input.ftp.passive = true # ftp passive
 
       asetus.default.output.default = 'file'  # file, git
       asetus.default.source.default = 'csv'   # csv, sql

--- a/lib/oxidized/input/ftp.rb
+++ b/lib/oxidized/input/ftp.rb
@@ -13,7 +13,9 @@ module Oxidized
       @node       = node
       @node.model.cfg['ftp'].each { |cb| instance_exec(&cb) }
       @log = File.open(Oxidized::Config::Log + "/#{@node.ip}-ftp", 'w') if Oxidized.config.input.debug?
-      @ftp = Net::FTP.new @node.ip, @node.auth[:username], @node.auth[:password]
+      @ftp = Net::FTP.new(@node.ip)
+      @ftp.passive = false
+      @ftp.login  @node.auth[:username], @node.auth[:password]
       connected?
     end
 

--- a/lib/oxidized/input/ftp.rb
+++ b/lib/oxidized/input/ftp.rb
@@ -14,7 +14,7 @@ module Oxidized
       @node.model.cfg['ftp'].each { |cb| instance_exec(&cb) }
       @log = File.open(Oxidized::Config::Log + "/#{@node.ip}-ftp", 'w') if Oxidized.config.input.debug?
       @ftp = Net::FTP.new(@node.ip)
-      @ftp.passive = false
+      @ftp.passive = Oxidized.config.input.ftp.passive
       @ftp.login  @node.auth[:username], @node.auth[:password]
       connected?
     end

--- a/lib/oxidized/input/ftp.rb
+++ b/lib/oxidized/input/ftp.rb
@@ -1,17 +1,11 @@
 module Oxidized
   require 'net/ftp'
   require 'timeout'
-  require_relative 'cli'
-
+  require 'oxidized/input/cli'
   class FTP < Input
     RescueFail = {
-      :debug => [
-        #Net::SSH::Disconnect,
-      ],
-      :warn => [
-        #RuntimeError,
-        #Net::SSH::AuthenticationFailed,
-      ],
+      :debug => [],
+      :warn => [],
     }
     include Input::CLI
 
@@ -30,15 +24,6 @@ module Oxidized
     def cmd file
       Oxidized.logger.debug "FTP: #{file} @ #{@node.name}"
       @ftp.getbinaryfile file, nil
-    end
-
-    # meh not sure if this is the best way, but perhaps better than not implementing send
-    def send my_proc
-      my_proc.call
-    end
-
-    def output
-      ""
     end
 
     private

--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -19,6 +19,7 @@ class RouterOS < Oxidized::Model
     cmd run_cmd do |cfg|
       cfg.gsub! /\x1B\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]/, '' # strip ANSI colours
       cfg.gsub! /\\\r\n\s+/, ''   # strip new line
+      cfg.gsub! /# inactive time\r\n/, ''   # Remove time based system comment
       cfg = cfg.split("\n").select { |line| not line[/^\#\s\w{3}\/\d{2}\/\d{4}.*$/] }
       cfg.join("\n") + "\n"
     end

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -4,7 +4,7 @@ class ZyNOS < Oxidized::Model
 
   comment  '! '
 
-  cmd 'config-0'
+  cmd 'config'
 
   cfg :ftp do
   end

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -4,7 +4,7 @@ class ZyNOS < Oxidized::Model
 
   comment  '! '
 
-  cmd 'config'
+  cmd 'config-0'
 
   cfg :ftp do
   end


### PR DESCRIPTION
Working with Xyzel XGS4600 series, they require passive to be set to false.

To make this possible, the ftp session is established after setting the passive setting.

The default is true, keeping the behaviour unchanged for anyone else using FTP to retrieve files.