### PR TITLE
Added documentation for setting up JunOS with Oxidized

### DIFF
--- a/docs/Model-Notes/JunOS.md
+++ b/docs/Model-Notes/JunOS.md
@@ -1,0 +1,38 @@
+JunOS Configuration
+========================
+
+Create login class cfg-view
+
+```
+set system login class cfg-view permissions view-configuration
+set system login class cfg-view allow-commands "(show)|(set cli screen-length)|(set cli screen-width)"
+set system login class cfg-view deny-commands "(clear)|(file)|(file show)|(help)|(load)|(monitor)|(op)|(request)|(save)|(set)|(start)|(test)"
+set system login class cfg-view deny-configuration all
+```
+
+Create a user with cfg-view class
+
+```
+set system login user oxidized class cfg-view
+set system login user oxidized authentication plain-text-password "verysecret"
+```
+
+The commands Oxidized executes are:
+
+1. set cli screen-length 0
+2. set cli screen-width 0
+3. show configuration
+4. show version
+5. show chassis hardware
+6. show system license
+7. show system license keys
+ex22|ex33|ex4|ex8|qfx only
+8. show virtual-chassis
+MX960 only
+9. show chassis fabric reachability
+
+
+Oxidized can now retrieve your configuration!
+
+
+Back to [Model-Notes](README.md)

--- a/docs/Model-Notes/README.md
+++ b/docs/Model-Notes/README.md
@@ -12,6 +12,7 @@ Use the table below for more information on the Vendor/Model caveats.
 Vendor          | Model           |Updated
 ----------------|-----------------|----------------
 Huawei|[VRP](VRP-Huawei.md)|17 Nov 2017
+Juniper|[MX/QFX/EX/SRX/J Series](JunOS.md)|18 Jan 2018
 
 
 If you discover additional caveats or problems please make sure to consult the [GitHub issues for oxidized](https://github.com/ytti/oxidized/issues) known issues.


### PR DESCRIPTION
I've been testing this with an SRX220H2 and should be applying this to several EX and QFX switches and our MX series routers.

So far only the J2300 has shown any errors and that was due to _omit_ within the _show configuration | display omit_ command. Its running such an old version of JunOS the command doesn't exist.

It isn't extensively tested, to ensure its locked down 100%, but at least Oxidized won't be accessing with root privileges.
It was assembled using Junipers own documentation on their [knowledge base](## https://kb.juniper.net/InfoCenter/index?page=content&id=KB23038&actp=METADATA)