### PR TITLE
FTP Passive/Active modes & Xyzel XGS4600 series Docs

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -74,6 +74,15 @@ vars_map:
 ...
 ```
 
+### FTP Passive Mode
+
+Oxidized uses ftp passive mode by default. Some devices require passive mode to be disabled. To do so, we can set `input.ftp.passive` to false
+```
+input:
+  ftp:
+    passive: false
+```
+
 ### Advanced Configuration
 
 Below is an advanced example configuration. You will be able to (optionally) override options per device. The router.db format used is `hostname:model:username:password:enable_password`. Hostname and model will be the only required options, all others override the global configuration sections.

--- a/docs/Model-Notes/README.md
+++ b/docs/Model-Notes/README.md
@@ -13,6 +13,7 @@ Vendor          | Model           |Updated
 ----------------|-----------------|----------------
 Huawei|[VRP](VRP-Huawei.md)|17 Nov 2017
 Juniper|[MX/QFX/EX/SRX/J Series](JunOS.md)|18 Jan 2018
+Xyzel|[XGS4600 Series](XGS4600-Zyxel.md)|23 Jan 2018
 
 
 If you discover additional caveats or problems please make sure to consult the [GitHub issues for oxidized](https://github.com/ytti/oxidized/issues) known issues.

--- a/docs/Model-Notes/XGS4600-Zyxel.md
+++ b/docs/Model-Notes/XGS4600-Zyxel.md
@@ -1,0 +1,24 @@
+ZynOS Configuration
+========================
+
+## FTP
+FTP access is only possible as admin, other users can login but cannot pull the files.
+For the XGS4600 series the config file is _config_ and not _config-0_
+
+The following line in _oxidized/lib/oxidized/model/zynos.rb_ with need changing
+```
+  cmd 'config-0'
+
+```
+
+The inclusion of an extra ftp option is also require. Within _input_ add the following
+```
+input:
+  ftp:
+    passive: false
+```
+
+Oxidized can now retrieve your configuration!
+
+
+Back to [Model-Notes](README.md)

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -37,6 +37,7 @@ module Oxidized
       asetus.default.input.default    = 'ssh, telnet'
       asetus.default.input.debug      = false # or String for session log file
       asetus.default.input.ssh.secure = false # complain about changed certs
+      asetus.default.input.ftp.passive= true  # ftp passive mode
 
       asetus.default.output.default = 'file'  # file, git
       asetus.default.source.default = 'csv'   # csv, sql

--- a/lib/oxidized/input/ftp.rb
+++ b/lib/oxidized/input/ftp.rb
@@ -19,7 +19,9 @@ module Oxidized
       @node       = node
       @node.model.cfg['ftp'].each { |cb| instance_exec(&cb) }
       @log = File.open(Oxidized::Config::Log + "/#{@node.ip}-ftp", 'w') if Oxidized.config.input.debug?
-      @ftp = Net::FTP.new @node.ip, @node.auth[:username], @node.auth[:password]
+      @ftp = Net::FTP.new(@node.ip)
+      @ftp.passive = Oxidized.config.input.ftp.passive
+      @ftp.login  @node.auth[:username], @node.auth[:password]
       connected?
     end
 


### PR DESCRIPTION
Having refactored the code/docs.

The Xyzel XGS4600 series require an active FTP session to enable the config file to be pulled.

Unfortunately only admin can pull the config and thus a CLI version is in the works.

Hopefully the passive/active option will be helpful for other users