### PR TITLE
[procurve] add show commands

### DIFF
--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -47,6 +47,10 @@ class Procurve < Oxidized::Model
     comment cfg
   end
 
+  cmd 'show system power-supply' do |cfg|
+    comment cfg
+  end
+
   cmd 'show interfaces transceiver' do |cfg|
     comment cfg
   end


### PR DESCRIPTION
Sanitized output:

```
 Power Supply Status: 
 
  PS#    Model       State        AC/DC  + V      Wattage
  ---- --------- ------------- ----------------- ---------
    1   Unknwn    Powered         AC 220V          1500
    2   Unknwn    Powered         AC 220V          1500 
 
    2 /  2 supply bays delivering power.
    Total power: 3000 W
```

Of course you see `unknwn` but that is addressed in latest firmware release.

Thanks!