### PR TITLE
[AWOS] Make the space between # mandatory rather than optional in the promt

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -11,7 +11,7 @@ class AOSW < Oxidized::Model
   # All IAPs connected to a Instant Controller will have the same config output. Only the controller needs to be monitored. 
 
   comment  '# '
-  prompt /^\(?.+\)?\s?[#>]/
+  prompt /^\(?.+\)?\s[#>]/
 
   cmd :all do |cfg|
     cfg.each_line.to_a[1..-2].join


### PR DESCRIPTION
Per discussion in https://github.com/ytti/oxidized/issues/1000#issuecomment-363444488. Fixes: #1000 