### PR TITLE
docs: Added model note for 3com comware

### DIFF
--- a/docs/Model-Notes/Comware.md
+++ b/docs/Model-Notes/Comware.md
@@ -1,0 +1,10 @@
+Comware Configuration
+=====================
+
+If you find 3Com comware devices aren't being backed up this may be due to prompt detection not matching 
+because a previous login message is disabled after the first prompt. You can disable this on the devices 
+themselves by running this command:
+
+`info-center source default channel 1 log state off debug state off`
+
+[Reference](https://github.com/ytti/oxidized/issues/1171)

--- a/docs/Model-Notes/README.md
+++ b/docs/Model-Notes/README.md
@@ -11,6 +11,7 @@ Use the table below for more information on the Vendor/Model caveats.
 
 Vendor          | Model           |Updated
 ----------------|-----------------|----------------
+3COM|[Comware](Comware.md)|15 Feb 2018
 Huawei|[VRP](VRP-Huawei.md)|17 Nov 2017
 Juniper|[MX/QFX/EX/SRX/J Series](JunOS.md)|18 Jan 2018
 Xyzel|[XGS4600 Series](XGS4600-Zyxel.md)|23 Jan 2018


### PR DESCRIPTION
Fixes: #1171 

Unless someone adds support for pre_login call then this can be used by people to configure devices correctly to not trip up over prompt detection.