### PR TITLE
Update br6910.rb

### DIFF
--- a/lib/oxidized/model/br6910.rb
+++ b/lib/oxidized/model/br6910.rb
@@ -1,7 +1,7 @@
 
 class BR6910 < Oxidized::Model
 
-  prompt /^Vty-[0-9]\#$/
+  prompt /^([\w.@()-]+[#>]\s?)$/
   comment  '! '
 
   # not possible to disable paging prior to show running-config


### PR DESCRIPTION
The BR6910 switch can be configured to display anything on the prompt, by default it's vty-, I have modified the prompt statement to allow for whatever the user has configured the prompt to be.