### PR TITLE
Refresh Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,38 @@
-FROM phusion/baseimage:0.9.18
-MAINTAINER Samer Abdel-Hafez <sam@arahant.net>
+# -- stage 1: backport libssh2 1.7.0 from zesty for xenial, as githubrepo hook requires it
+FROM ubuntu:xenial as libssh2-backport
 
-RUN add-apt-repository ppa:brightbox/ruby-ng && \
-	apt-get update && \
-  apt-get install -y ruby2.3 ruby2.3-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++ libffi-dev
+# set up dependencies for the build process
+RUN apt-get -yq update && \
+    apt-get -yq install build-essential chrpath debhelper dh-autoreconf libgcrypt20-dev zlib1g-dev
 
-RUN mkdir -p /tmp/oxidized
+# build libssh2 1.7.0
+WORKDIR /tmp/libssh2-build
+ADD https://launchpad.net/ubuntu/+archive/primary/+files/libssh2_1.7.0-1ubuntu1.debian.tar.xz .
+ADD https://launchpad.net/ubuntu/+archive/primary/+files/libssh2_1.7.0.orig.tar.gz .
+RUN tar xvf libssh2_1.7.0.orig.tar.gz
+WORKDIR /tmp/libssh2-build/libssh2-1.7.0
+RUN tar xvf ../libssh2_1.7.0-1ubuntu1.debian.tar.xz
+
+WORKDIR /tmp/libssh2-build/libssh2-1.7.0
+ENV DEB_BUILD_OPTIONS nocheck
+RUN dpkg-buildpackage -b
+
+# -- stage 2: build the actual oxidized container
+FROM phusion/baseimage:0.10.0
+LABEL maintainer="Samer Abdel-Hafez <sam@arahant.net>"
+
+# set up dependencies for the build process
+RUN apt-get -yq update && \
+    apt-get -yq install ruby2.3 ruby2.3-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++ libffi-dev
+
+# upgrade libssh2 to self-built backport from stage 1
+COPY --from=libssh2-backport \
+    /tmp/libssh2-build/libssh2-1_1.7.0-1ubuntu1_amd64.deb \
+    /tmp/libssh2-build/libssh2-1-dev_1.7.0-1ubuntu1_amd64.deb \
+    /tmp/
+RUN dpkg -i /tmp/*.deb
+
+# build and install oxidized
 COPY . /tmp/oxidized/
 WORKDIR /tmp/oxidized
 
@@ -16,16 +43,15 @@ RUN gem install oxidized-*.gem
 RUN gem install oxidized-web --no-ri --no-rdoc
 
 # dependencies for hooks
-RUN gem install aws-sdk
-RUN gem install slack-api
-RUN gem install xmpp4r
+RUN gem install aws-sdk slack-api xmpp4r
 
+# clean up
+WORKDIR /
 RUN rm -rf /tmp/oxidized
+RUN rm /tmp/*.deb
+RUN apt-get -yq --purge autoremove ruby-dev pkg-config make cmake
 
-RUN apt-get remove -y ruby-dev pkg-config make cmake
-
-RUN apt-get -y autoremove
-
+# add runit services
 ADD extra/oxidized.runit /etc/service/oxidized/run
 ADD extra/auto-reload-config.runit /etc/service/auto-reload-config/run
 ADD extra/update-ca-certificates.runit /etc/service/update-ca-certificates/run


### PR DESCRIPTION
Refresh Dockerfile to resolve multiple issues:
* Bump base image from 0.9.18 to 0.10.0 (now xenial based).
* Remove dependency on ppa:brightbox and use xenial ruby2.3
* Split build into 2 stages to backport libssh2 1.7.0 which is
  needed for githubrepo hook but is not available in xenial
* Misc cleanup and comments

This is meant to supersede #1039 by taking a more elegant approach, and closes #1204