### PR TITLE
Introduce support for OXIDIZED_SSH_PASSPHRASE for githubrepo hook

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -67,6 +67,8 @@ This hook configures the repository `remote` and _push_ the code when the specif
   * `publickey`: publickey for repository auth.
   * `privatekey`: privatekey for repository auth.
 
+It is also possible to set the environment variable `OXIDIZED_SSH_PASSPHRASE` to a passphrase if your keypair requires it.
+
 When using groups repositories, each group must have its own `remote` in the `remote_repo` config.
 
 ``` yaml

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -51,7 +51,7 @@ class GithubRepo < Oxidized::Hook
     else
       if cfg.has_key?('publickey') && cfg.has_key?('privatekey')
         log "Using ssh auth with key", :debug
-        Rugged::Credentials::SshKey.new(username: 'git', publickey: File.expand_path(cfg.publickey), privatekey: File.expand_path(cfg.privatekey))
+        Rugged::Credentials::SshKey.new(username: 'git', publickey: File.expand_path(cfg.publickey), privatekey: File.expand_path(cfg.privatekey), passphrase: ENV["OXIDIZED_SSH_PASSPHRASE"])
       else
         log "Using ssh auth with agentforwarding", :debug
         Rugged::Credentials::SshKeyFromAgent.new(username: 'git')


### PR DESCRIPTION
This breaks out the change introduced by @yeled in #1039 to introduce OXIDIZED_SSH_PASSPHRASE support apart from the Dockerfile update contained in the same PR. 

A revised Dockerfile that is meant to supersede the changes introduced in #1039  has been submitted as #1207 - this feature depends on it being merged.

Convenience submission. Completely untested and assumes the original change set was valid.