### PR TITLE
Lint markdown docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,286 +1,324 @@
-# 0.21.0
-- FEATURE: routeros include system history (@InsaneSplash)
-- FEATURE: vrp added support for removing secrets (@bheum)
-- FEATURE: hirschmann model (@OCangrand)
-- FEATURE: asa added multiple context support (@marnovdm)
-- FEATURE: procurve added additional output (@davama)
-- FEATURE: Updated git commits to bare repo + drop need for temp dir during clone (@asenci)
-- FEATURE: asyncos model (@cd67-usrt)
-- FEATURE: ciscosma model (@cd67-usrt)
-- FEATURE: procurve added transceiver info (@davama)
-- FEATURE: routeros added remove_secret option (@spinza)
-- FEATURE: Updated net-ssh version (@Fauli83)
-- FEATURE: audiocodes model (@Fauli83)
-- FEATURE: Added docs for Huawei VRP devices (@tuxis-ie)
-- FEATURE: ciscosmb added radius key detection (@davama)
-- FEATURE: radware model (@sfini)
-- FEATURE: enterasys model (@koenvdheuvel)
-- FEATURE: weos model (@ignaqui)
-- FEATURE: hpemsa model (@aschaber1)
-- FEATURE: Added nodes_done hook (@danilopopeye)
-- FEATURE: ucs model (@WiXZlo)
-- FEATURE: acsw model (@sfini)
-- FEATURE: aen model (@ZacharyPuls)
-- FEATURE: coriantgroove model (@nickhilliard)
-- FEATURE: sgos model (@seekerOK)
-- FEATURE: powerconnect support password removal (@tobbez)
-- FEATURE: Added haproxy example for Ubuntu (@denvera)
-- BUGFIX: fiberdriver remove configuration generated on from diff (@emjemj)
-- BUGFIX: Fix email pass through (@ZacharyPuls) 
-- BUGFIX: iosxr suppress timestamp (@ja-frog)
-- BUGFIX: ios allow lowercase user/pass prompt (@deepseth)
-- BUGFIX: Use git show instead of git diff (@asenci)
-- BUGFIX: netgear fixed sending enable password and exit/quit (@candlerb)
-- BUGFIX: ironware removed space requirement from password prompt (@crami)
-- BUGFIX: dlink removed uptime from diff (@rfdrake)
-- BUGFIX: planet removed temp from diff (@flokli)
-- BUGFIX: ironware removed fan, temp and flash from diff (@Punicaa)
-- BUGFIX: panos changed exit to quit (@goebelmeier)
-- BUGFIX: fortios remove FDS address from diffs (@bheum)
-- BUGFIX: fortios remove additional secrets from diffs (@brunobritocarvalho)
-- BUGFIX: fortios remove IPS URL DB (@brunobritocarvalho)
-- BUGFIX: voss remove temperature, power and uptime from diff (@ospfbgp)
+# Changelog
 
-# 0.20.0
-- FEATURE: gpg support for CSV source (@elmobp)
-- FEATURE: slackdiff (@natm)
-- FEATURE: gitcrypt output model (@clement-parisot)
-- FEATURE: model specific credentials (@davromaniak)
-- FEATURE: hierarchical json in http source model
-- FEATURE: next-adds-job config toggle (to add new job when ever /next is called)
-- FEATURE: netgear model (@aschaber1)
-- FEATURE: zhone model (@rfdrake)
-- FEATURE: tplink model (@mediumo)
-- FEATURE: oneos model (@crami)
-- FEATURE: cisco NGA model (@udhos)
-- FEATURE: voltaire model (@clement-parisot)
-- FEATURE: siklu model (@bdg-robert)
-- FEATURE: voss model (@ospfbgp)
-- BUGFIX: ios, cumulus, ironware, nxos, fiberdiver, aosw, fortios, comware, procurve, opengear, timos, routeros, junos, asa, aireos, mlnxos, pfsense, saos, powerconnect, firewareos, quantaos
+## 0.21.0
 
-# 0.19.0
-- FEATURE: allow setting ssh_keys (not relying on openssh config) (@denvera)
-- FEATURE: fujitsupy model (@stokbaek)
-- FEATURE: fiberdriver model (@emjemj)
-- FEATURE: hpbladesystems model (@flokli)
-- FEATURE: planetsgs model (@flokli)
-- FEATURE: trango model (@rfdrake)
-- FEATURE: casa model (@rfdrake)
-- FEATURE: dlink model (@rfdrake)
-- FEATURE: hatteras model (@rfdrake)
-- FEATURE: ability to ignore SSL certs in http (@laf)
-- FEATURE: awsns hooks, publish messages to AWS SNS topics (@natm)
-- BUGFIX: pfsense, dnos, powerconnect, ciscosmb, eos, aosw
+* FEATURE: routeros include system history (@InsaneSplash)
+* FEATURE: vrp added support for removing secrets (@bheum)
+* FEATURE: hirschmann model (@OCangrand)
+* FEATURE: asa added multiple context support (@marnovdm)
+* FEATURE: procurve added additional output (@davama)
+* FEATURE: Updated git commits to bare repo + drop need for temp dir during clone (@asenci)
+* FEATURE: asyncos model (@cd67-usrt)
+* FEATURE: ciscosma model (@cd67-usrt)
+* FEATURE: procurve added transceiver info (@davama)
+* FEATURE: routeros added remove_secret option (@spinza)
+* FEATURE: Updated net-ssh version (@Fauli83)
+* FEATURE: audiocodes model (@Fauli83)
+* FEATURE: Added docs for Huawei VRP devices (@tuxis-ie)
+* FEATURE: ciscosmb added radius key detection (@davama)
+* FEATURE: radware model (@sfini)
+* FEATURE: enterasys model (@koenvdheuvel)
+* FEATURE: weos model (@ignaqui)
+* FEATURE: hpemsa model (@aschaber1)
+* FEATURE: Added nodes_done hook (@danilopopeye)
+* FEATURE: ucs model (@WiXZlo)
+* FEATURE: acsw model (@sfini)
+* FEATURE: aen model (@ZacharyPuls)
+* FEATURE: coriantgroove model (@nickhilliard)
+* FEATURE: sgos model (@seekerOK)
+* FEATURE: powerconnect support password removal (@tobbez)
+* FEATURE: Added haproxy example for Ubuntu (@denvera)
+* BUGFIX: fiberdriver remove configuration generated on from diff (@emjemj)
+* BUGFIX: Fix email pass through (@ZacharyPuls)
+* BUGFIX: iosxr suppress timestamp (@ja-frog)
+* BUGFIX: ios allow lowercase user/pass prompt (@deepseth)
+* BUGFIX: Use git show instead of git diff (@asenci)
+* BUGFIX: netgear fixed sending enable password and exit/quit (@candlerb)
+* BUGFIX: ironware removed space requirement from password prompt (@crami)
+* BUGFIX: dlink removed uptime from diff (@rfdrake)
+* BUGFIX: planet removed temp from diff (@flokli)
+* BUGFIX: ironware removed fan, temp and flash from diff (@Punicaa)
+* BUGFIX: panos changed exit to quit (@goebelmeier)
+* BUGFIX: fortios remove FDS address from diffs (@bheum)
+* BUGFIX: fortios remove additional secrets from diffs (@brunobritocarvalho)
+* BUGFIX: fortios remove IPS URL DB (@brunobritocarvalho)
+* BUGFIX: voss remove temperature, power and uptime from diff (@ospfbgp)
 
-# 0.18.0
-- FEATURE: APC model (by @davromaniak )
-- BUGFIX: ironware, aosw
-- BUGFIX: interpolate nil, false, true for node vars too
+## 0.20.0
 
-# 0 17.0
-- FEATURE: "nil", "false" and "true" in source (e.g. router.db) are interpeted as nil, false, true. Empty is now always considered empty string, instead of in some cases nil and some cases empty string.
-- FEATURE: support tftp as input model (@MajesticFalcon)
-- FEATURE: add alvarion model (@MajesticFalcon)
-- FEATURE: detect if ssh wants password terminal/CLI prompt or not
-- FEATURE: node (group, model, username, password) resolution refactoring, supports wider range of use-cases
-- BUGFIX: fetch for file output (@danilopopeye)
-- BUGFIX: net-ssh version specification
-- BUGFIX: routeros, catos, pfsense
+* FEATURE: gpg support for CSV source (@elmobp)
+* FEATURE: slackdiff (@natm)
+* FEATURE: gitcrypt output model (@clement-parisot)
+* FEATURE: model specific credentials (@davromaniak)
+* FEATURE: hierarchical json in http source model
+* FEATURE: next-adds-job config toggle (to add new job when ever /next is called)
+* FEATURE: netgear model (@aschaber1)
+* FEATURE: zhone model (@rfdrake)
+* FEATURE: tplink model (@mediumo)
+* FEATURE: oneos model (@crami)
+* FEATURE: cisco NGA model (@udhos)
+* FEATURE: voltaire model (@clement-parisot)
+* FEATURE: siklu model (@bdg-robert)
+* FEATURE: voss model (@ospfbgp)
+* BUGFIX: ios, cumulus, ironware, nxos, fiberdiver, aosw, fortios, comware, procurve, opengear, timos, routeros, junos, asa, aireos, mlnxos, pfsense, saos, powerconnect, firewareos, quantaos
 
-# 0.16.3
-- FEATURE: pfsense support (by @stokbaek)
-- BUGFIX: cumulus prompt not working with default switch configs (by @nertwork)
-- BUGFIX: disconnect ssh when prompt wasn't found (by @andir)
-- BUGFIX: saos, asa, acos, timos updates, cumulus
+## 0.19.0
 
-# 0.16.2
-- BUGFIX: when not using git (by @danilopopeye)
-- BUGFIX: screenos update
+* FEATURE: allow setting ssh_keys (not relying on openssh config) (@denvera)
+* FEATURE: fujitsupy model (@stokbaek)
+* FEATURE: fiberdriver model (@emjemj)
+* FEATURE: hpbladesystems model (@flokli)
+* FEATURE: planetsgs model (@flokli)
+* FEATURE: trango model (@rfdrake)
+* FEATURE: casa model (@rfdrake)
+* FEATURE: dlink model (@rfdrake)
+* FEATURE: hatteras model (@rfdrake)
+* FEATURE: ability to ignore SSL certs in http (@laf)
+* FEATURE: awsns hooks, publish messages to AWS SNS topics (@natm)
+* BUGFIX: pfsense, dnos, powerconnect, ciscosmb, eos, aosw
 
-# 0.16.1
-- BUGFIX: unnecessary puts statement removed from git.rb
+## 0.18.0
 
-# 0.16.0
-- FEATURE: support Gaia OS devices (by @totosh)
-- BUGFIX: #fetch, #version fixes in nodes.rb (by @danilopopeye)
-- BUGFIX: procurve
+* FEATURE: APC model (by @davromaniak )
+* BUGFIX: ironware, aosw
+* BUGFIX: interpolate nil, false, true for node vars too
 
-# 0.15.0
-- FEATURE: disable periodic collection, only on demand (by Adam Winberg)
-- FEATURE: allow disabling ssh exec mode always (mainly for oxidized-script) (by @nickhilliard)
-- FEATURE: support mellanox devices (by @ham5ter)
-- FEATURE: support firewireos devices (by @alexandre-io)
-- FEATURE: support quanta devices (by @f0o)
-- FEATURE: support tellabs coriant8800, coriant8600 (by @udhos)
-- FEATURE: support brocade6910 (by @cardboardpig)
-- BUGFIX: debugging, tests (by @ElvinEfendi)
-- BUGFIX: nos, panos, acos, procurve, eos, edgeswitch, aosw, fortios updates
+## 0 17.0
 
-# 0.14.3
-- BUGFIX: fix git when using multiple groups without single_repo
+* FEATURE: "nil", "false" and "true" in source (e.g. router.db) are interpeted as nil, false, true. Empty is now always considered empty string, instead of in some cases nil and some cases empty string.
+* FEATURE: support tftp as input model (@MajesticFalcon)
+* FEATURE: add alvarion model (@MajesticFalcon)
+* FEATURE: detect if ssh wants password terminal/CLI prompt or not
+* FEATURE: node (group, model, username, password) resolution refactoring, supports wider range of use-cases
+* BUGFIX: fetch for file output (@danilopopeye)
+* BUGFIX: net-ssh version specification
+* BUGFIX: routeros, catos, pfsense
 
-# 0.14.2
-- BUGFIX: git expand path for all groups
-- BUGFIX: git get_version, teletubbies do it again
-- BUGFIX: comware, acos, procurve models
+## 0.16.3
 
-# 0.14.1
-- BUGFIX: git get_version when groups and single_repo are used
+* FEATURE: pfsense support (by @stokbaek)
+* BUGFIX: cumulus prompt not working with default switch configs (by @nertwork)
+* BUGFIX: disconnect ssh when prompt wasn't found (by @andir)
+* BUGFIX: saos, asa, acos, timos updates, cumulus
 
-# 0.14.0
-- FEATURE: support supermicro swithes (by @funzoneq)
-- FEATURE: support catos switches
-- BUGFIX: git+groups+singlerepo (by @PANZERBARON)
-- BUGFIX: asa, tmos, ironware, ios-xr
-- BUGFIX: mandate net-ssh 3.0.x, don't accept 3.1 (numerous issues)
+## 0.16.2
 
-# 0.13.1
-- BUGFIX: file permissions (Sigh...)
+* BUGFIX: when not using git (by @danilopopeye)
+* BUGFIX: screenos update
 
-# 0.13.0
-- FEATURE: http post for configs (by @jgroom33)
-- FEATURE: support ericsson redbacks (by @roedie)
-- FEATURE: support motorola wireless controllers (by @roadie)
-- FEATURE: support citrix netscaler (by @roadie)
-- FEATURE: support datacom devices (by @danilopopeye)
-- FEATURE: support netonix devices
-- FEATURE: support specifying ssh cipher and kex (by @roadie)
-- FEATURE: rename proxy to ssh_proxy (by @roadie)
-- FEATURE: support ssh keys on ssh_proxy (by @awix)
-- BUGFIX: various (by @danilopopeye)
-- BUGFIX: Node#repo with groups (by @danilopopeye)
-- BUGFIX: githubrepohoook (by @danilopopeye)
-- BUGFIX: fortios, airos, junos, xos, edgeswitch, nos, tmos, procurve, ipos models
+## 0.16.1
 
-# 0.12.2
-- BUGFIX: more MRV model fixes (by @natm)
+* BUGFIX: unnecessary puts statement removed from git.rb
 
-# 0.12.1
-- BUGFIX: set term to vty100
-- BUGFIX: MRV model fixes (by @natm)
+## 0.16.0
 
-# 0.12.0
-- FEATURE: enhance AOSW (by @mikebryant)
-- FEATURE: F5 TMOS support (by @mikebryant)
-- FEATURE: Opengear support (by @mikebryant)
-- FEATURE: EdgeSwitch support (by @doogieconsulting)
-- BUGFIX: rename input debug log files
-- BUGFIX: powerconnect model fixes (by @Madpilot0)
-- BUGFIX: fortigate model fixes (by @ElvinEfendi)
-- BUGFIX: various (by @mikebryant)
-- BUGFIX: write SSH debug to file without buffering
-- BUGFIX: fix IOS XR prompt handling
+* FEATURE: support Gaia OS devices (by @totosh)
+* BUGFIX: #fetch, #version fixes in nodes.rb (by @danilopopeye)
+* BUGFIX: procurve
 
-# 0.11.0
-- FEATURE: ssh proxycommand (by @ElvinEfendi)
-- FEATURE: basic auth in HTTP source (by @laf)
-- BUGFIX: do not inject string to output before model gets it
-- BUGFIX: store pidfile in oxidized root
+## 0.15.0
 
-# 0.10.0
-- FEATURE: Various refactoring (by @ElvinEfendi)
-- FEATURE: Ciena SOAS support (by @jgroom33)
-- FEATURE: support group variables (by @supertylerc)
-- BUGFIX: various ((orly))  (by @marnovdm, @danbaugher, @MrRJ45, @asynet, @nickhilliard)
+* FEATURE: disable periodic collection, only on demand (by Adam Winberg)
+* FEATURE: allow disabling ssh exec mode always (mainly for oxidized-script) (by @nickhilliard)
+* FEATURE: support mellanox devices (by @ham5ter)
+* FEATURE: support firewireos devices (by @alexandre-io)
+* FEATURE: support quanta devices (by @f0o)
+* FEATURE: support tellabs coriant8800, coriant8600 (by @udhos)
+* FEATURE: support brocade6910 (by @cardboardpig)
+* BUGFIX: debugging, tests (by @ElvinEfendi)
+* BUGFIX: nos, panos, acos, procurve, eos, edgeswitch, aosw, fortios updates
 
-# 0.9.0
-- FEATURE: input log now uses devices name as file, instead of string from config (by @skoef)
-- FEATURE: Dell Networkign OS (dnos) support (by @erefre)
-- BUGFIX: CiscoSMB, powerconnect, comware, xos, ironware, nos fixes
+## 0.14.3
 
-# 0.8.1
-- BUGFIX: restore ruby 1.9.3 compatibility
+* BUGFIX: fix git when using multiple groups without single_repo
 
-# 0.8.0
-- FEATURE: hooks (by @aakso)
-- FEATURE: MRV MasterOS support (by @kwibbly)
-- FEATURE: EdgeOS support (by @laf)
-- FEATURE: FTP input and Zyxel ZynOS support (by @ytti)
-- FEATURE: version and diffs API For oxidized-web (by @FlorianDoublet)
-- BUGFIX: aosw, ironware, routeros, xos models
-- BUGFIX: crash with 0 nodes
-- BUGFIX: ssh auth fail without keyboard-interactive
-- Full changelog https://github.com/ytti/oxidized/compare/0.7.1...HEAD
+## 0.14.2
 
-# 0.7.0
-- FEATURE: support http source (by @laf)
-- FEATURE: support Palo Alto PANOS (by @rixxxx)
-- BUGFIX:  screenos fixes (by @rixxxx)
-- BUGFIX:  allow 'none' auth in ssh (spotted by @SaldoorMike, needed by ciscosmb+aireos)
+* BUGFIX: git expand path for all groups
+* BUGFIX: git get_version, teletubbies do it again
+* BUGFIX: comware, acos, procurve models
 
-# 0.6.0
-- FEATURE: support cumulus linux (by @FlorianDoublet)
-- FEATURE: support HP Comware SMB siwtches (by @sid3windr)
-- FEATURE: remove secret additions (by @rodecker)
-- FEATURE: option to put all groups in single repo (by @ytti)
-- FEATURE: expand path in source: csv: (so that ~/foo/bar works) (by @ytti)
-- BUGFIX: screenos fixes (by @rixxxx)
-- BUGFIX: ironware fixes (by @FlorianDoublet)
-- BUGFIX: powerconnect fixes (by @sid3windr)
-- BUGFIX: don't ask interactive password in new net/ssh (by @ytti)
+## 0.14.1
 
-# 0.5.0
-- FEATURE: Mikrotik RouterOS model (by @emjemj)
-- FEATURE: add support for Cisco VSS (by @MrRJ45)
-- BUGFIX: general fixes to powerconnect model (by @MrRJ45)
-- BUGFIX: fix initial commit issues with rugged (by @MrRJ45)
-- BUGFIX: pager error for old dell powerconnect switches (by @emjemj)
-- BUGFIX: logout error for old dell powerconnect switches (by @emjemj)
+* BUGFIX: git get_version when groups and single_repo are used
 
-# 0.4.1
-- BUGFIX: handle missing output file (by @brandt)
-- BUGFIX: fix passwordless enable on Arista EOS model (by @brandt)
+## 0.14.0
 
-# 0.4.0
-- FEATURE: allow setting IP address in addition to name in source (SQL/CSV)
-- FEATURE: approximate how long it takes to get node from larger view than 1
-- FEATURE: unconditionally start new job if too long has passed since previous start
-- FEATURE: add enable to Arista EOS model
-- FEATURE: add rugged dependency in gemspec
-- FEATURE: log prompt detection failures
-- BUGFIX: xos while using telnet (by @fhibler)
-- BUGFIX: ironware logout on some models (by @fhibler)
-- BUGFIX: allow node to be removed while it is being collected
-- BUGFIX: if model returns non string value, return empty string
-- BUGFIX: better prompt for Arista EOS model (by @rodecker)
-- BUGFIX: improved configuration handling for Arista EOS model (by @rodecker)
+* FEATURE: support supermicro swithes (by @funzoneq)
+* FEATURE: support catos switches
+* BUGFIX: git+groups+singlerepo (by @PANZERBARON)
+* BUGFIX: asa, tmos, ironware, ios-xr
+* BUGFIX: mandate net-ssh 3.0.x, don't accept 3.1 (numerous issues)
 
-# 0.3.0
-- FEATURE: *FIXME* bunch of stuff I did for richih, docs needed
-- FEATURE: ComWare model (by erJasp)
-- FEATURE: Add comment support for router.db file
-- FEATURE: Add input debugging and related configuration options
-- BUGFIX: Fix ASA model prompt
-- BUGFIX: Fix Aruba model display
-- BUGFIX: Fix changing output in PowerConnect model
+## 0.13.1
 
-# 0.2.4
-- FEATURE: Cisco SMB (Nikola series VxWorks) model by @thetamind
-- FEATURE: Extreme Networks XOS model (access by sjm)
-- FEATURE: Brocade NOS (Network Operating System) (access by sjm)
-- BUGFIX: Match exactly to node[:name] if node[name] is an ip address.
+* BUGFIX: file permissions (Sigh...)
 
-# 0.2.3
-- BUGFIX: rescue @ssh.close when far end closes disgracefully (ALU ISAM)
-- BUGFIX: bugfixes to models
-- FEATURE: Alcatel-Lucent ISAM 7302/7330 model added by @jalmargyyk
-- FEATURE: Huawei VRP model added by @jalmargyyk
-- FEATURE: Ubiquiti AirOS added by @willglyn
-- FEATURE: Support 'input' debug in config, ssh/telnet use it to write session log
+## 0.13.0
 
-# 0.2.2
-- BUGFIX: mark node as failure if unknown error is raised
+* FEATURE: http post for configs (by @jgroom33)
+* FEATURE: support ericsson redbacks (by @roedie)
+* FEATURE: support motorola wireless controllers (by @roadie)
+* FEATURE: support citrix netscaler (by @roadie)
+* FEATURE: support datacom devices (by @danilopopeye)
+* FEATURE: support netonix devices
+* FEATURE: support specifying ssh cipher and kex (by @roadie)
+* FEATURE: rename proxy to ssh_proxy (by @roadie)
+* FEATURE: support ssh keys on ssh_proxy (by @awix)
+* BUGFIX: various (by @danilopopeye)
+* BUGFIX: Node#repo with groups (by @danilopopeye)
+* BUGFIX: githubrepohoook (by @danilopopeye)
+* BUGFIX: fortios, airos, junos, xos, edgeswitch, nos, tmos, procurve, ipos models
 
-# 0.2.1
-- BUGFIX: vars variable resolving for main level vars
+## 0.12.2
 
-# 0.2.0
-- FEATURE: Force10 model added by @lysiszegerman
-- FEATURE: ScreenOS model added by @lysiszegerman
-- FEATURE: FabricOS model added by @thakala
-- FEATURE: ASA model added by @thakala
-- FEATURE: Vyattamodel added by @thakala
-- BUGFIX: Oxidized::String convenience methods for models fixed
+* BUGFIX: more MRV model fixes (by @natm)
 
-# 0.1.1
-- BUGFIX: vars needs to return value of r, not value of evaluation
+## 0.12.1
+
+* BUGFIX: set term to vty100
+* BUGFIX: MRV model fixes (by @natm)
+
+## 0.12.0
+
+* FEATURE: enhance AOSW (by @mikebryant)
+* FEATURE: F5 TMOS support (by @mikebryant)
+* FEATURE: Opengear support (by @mikebryant)
+* FEATURE: EdgeSwitch support (by @doogieconsulting)
+* BUGFIX: rename input debug log files
+* BUGFIX: powerconnect model fixes (by @Madpilot0)
+* BUGFIX: fortigate model fixes (by @ElvinEfendi)
+* BUGFIX: various (by @mikebryant)
+* BUGFIX: write SSH debug to file without buffering
+* BUGFIX: fix IOS XR prompt handling
+
+## 0.11.0
+
+* FEATURE: ssh proxycommand (by @ElvinEfendi)
+* FEATURE: basic auth in HTTP source (by @laf)
+* BUGFIX: do not inject string to output before model gets it
+* BUGFIX: store pidfile in oxidized root
+
+## 0.10.0
+
+* FEATURE: Various refactoring (by @ElvinEfendi)
+* FEATURE: Ciena SOAS support (by @jgroom33)
+* FEATURE: support group variables (by @supertylerc)
+* BUGFIX: various ((orly))  (by @marnovdm, @danbaugher, @MrRJ45, @asynet, @nickhilliard)
+
+## 0.9.0
+
+* FEATURE: input log now uses devices name as file, instead of string from config (by @skoef)
+* FEATURE: Dell Networkign OS (dnos) support (by @erefre)
+* BUGFIX: CiscoSMB, powerconnect, comware, xos, ironware, nos fixes
+
+## 0.8.1
+
+* BUGFIX: restore ruby 1.9.3 compatibility
+
+## 0.8.0
+
+* FEATURE: hooks (by @aakso)
+* FEATURE: MRV MasterOS support (by @kwibbly)
+* FEATURE: EdgeOS support (by @laf)
+* FEATURE: FTP input and Zyxel ZynOS support (by @ytti)
+* FEATURE: version and diffs API For oxidized-web (by @FlorianDoublet)
+* BUGFIX: aosw, ironware, routeros, xos models
+* BUGFIX: crash with 0 nodes
+* BUGFIX: ssh auth fail without keyboard-interactive
+* Full changelog https://github.com/ytti/oxidized/compare/0.7.1...HEAD
+
+## 0.7.0
+
+* FEATURE: support http source (by @laf)
+* FEATURE: support Palo Alto PANOS (by @rixxxx)
+* BUGFIX:  screenos fixes (by @rixxxx)
+* BUGFIX:  allow 'none' auth in ssh (spotted by @SaldoorMike, needed by ciscosmb+aireos)
+
+## 0.6.0
+
+* FEATURE: support cumulus linux (by @FlorianDoublet)
+* FEATURE: support HP Comware SMB siwtches (by @sid3windr)
+* FEATURE: remove secret additions (by @rodecker)
+* FEATURE: option to put all groups in single repo (by @ytti)
+* FEATURE: expand path in source: csv: (so that ~/foo/bar works) (by @ytti)
+* BUGFIX: screenos fixes (by @rixxxx)
+* BUGFIX: ironware fixes (by @FlorianDoublet)
+* BUGFIX: powerconnect fixes (by @sid3windr)
+* BUGFIX: don't ask interactive password in new net/ssh (by @ytti)
+
+## 0.5.0
+
+* FEATURE: Mikrotik RouterOS model (by @emjemj)
+* FEATURE: add support for Cisco VSS (by @MrRJ45)
+* BUGFIX: general fixes to powerconnect model (by @MrRJ45)
+* BUGFIX: fix initial commit issues with rugged (by @MrRJ45)
+* BUGFIX: pager error for old dell powerconnect switches (by @emjemj)
+* BUGFIX: logout error for old dell powerconnect switches (by @emjemj)
+
+## 0.4.1
+
+* BUGFIX: handle missing output file (by @brandt)
+* BUGFIX: fix passwordless enable on Arista EOS model (by @brandt)
+
+## 0.4.0
+
+* FEATURE: allow setting IP address in addition to name in source (SQL/CSV)
+* FEATURE: approximate how long it takes to get node from larger view than 1
+* FEATURE: unconditionally start new job if too long has passed since previous start
+* FEATURE: add enable to Arista EOS model
+* FEATURE: add rugged dependency in gemspec
+* FEATURE: log prompt detection failures
+* BUGFIX: xos while using telnet (by @fhibler)
+* BUGFIX: ironware logout on some models (by @fhibler)
+* BUGFIX: allow node to be removed while it is being collected
+* BUGFIX: if model returns non string value, return empty string
+* BUGFIX: better prompt for Arista EOS model (by @rodecker)
+* BUGFIX: improved configuration handling for Arista EOS model (by @rodecker)
+
+## 0.3.0
+
+* FEATURE: *FIXME* bunch of stuff I did for richih, docs needed
+* FEATURE: ComWare model (by erJasp)
+* FEATURE: Add comment support for router.db file
+* FEATURE: Add input debugging and related configuration options
+* BUGFIX: Fix ASA model prompt
+* BUGFIX: Fix Aruba model display
+* BUGFIX: Fix changing output in PowerConnect model
+
+## 0.2.4
+
+* FEATURE: Cisco SMB (Nikola series VxWorks) model by @thetamind
+* FEATURE: Extreme Networks XOS model (access by sjm)
+* FEATURE: Brocade NOS (Network Operating System) (access by sjm)
+* BUGFIX: Match exactly to node[:name] if node[name] is an ip address.
+
+## 0.2.3
+
+* BUGFIX: rescue @ssh.close when far end closes disgracefully (ALU ISAM)
+* BUGFIX: bugfixes to models
+* FEATURE: Alcatel-Lucent ISAM 7302/7330 model added by @jalmargyyk
+* FEATURE: Huawei VRP model added by @jalmargyyk
+* FEATURE: Ubiquiti AirOS added by @willglyn
+* FEATURE: Support 'input' debug in config, ssh/telnet use it to write session log
+
+## 0.2.2
+
+* BUGFIX: mark node as failure if unknown error is raised
+
+## 0.2.1
+
+* BUGFIX: vars variable resolving for main level vars
+
+## 0.2.0
+
+* FEATURE: Force10 model added by @lysiszegerman
+* FEATURE: ScreenOS model added by @lysiszegerman
+* FEATURE: FabricOS model added by @thakala
+* FEATURE: ASA model added by @thakala
+* FEATURE: Vyattamodel added by @thakala
+* BUGFIX: Oxidized::String convenience methods for models fixed
+
+## 0.1.1
+
+* BUGFIX: vars needs to return value of r, not value of evaluation

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
 
 [Youtube Video: Oxidized TREX 2014 presentation](http://youtu.be/kBQ_CTUuqeU#t=3h)
 
-#### Index
+## Index
+
 1. [Supported OS Types](docs/Supported-OS-Types.md)
 2. [Installation](#installation)
     * [Debian](#debian)
@@ -54,9 +55,10 @@ Oxidized is a network device configuration backup tool. It's a RANCID replacemen
     * [Source](docs/Ruby-API.md#source)
     * [Model](docs/Ruby-API.md#model)
 
-# Installation
+## Installation
 
-## Debian
+### Debian
+
 Install all required packages and gems.
 
 ```shell
@@ -65,7 +67,8 @@ gem install oxidized
 gem install oxidized-script oxidized-web # if you don't install oxidized-web, make sure you remove "rest" from your config
 ```
 
-## CentOS, Oracle Linux, Red Hat Linux
+### CentOS, Oracle Linux, Red Hat Linux
+
 On CentOS 6 / RHEL 6, install Ruby greater than 1.9.3 (for Ruby 2.1.2 installation instructions see [Installing Ruby 2.1.2 using RVM](#installing-ruby-212-using-rvm)), then install Oxidized dependencies
 
 ```shell
@@ -85,7 +88,8 @@ gem install oxidized
 gem install oxidized-script oxidized-web
 ```
 
-## FreeBSD
+### FreeBSD
+
 [Use RVM to install Ruby v2.1.2](#installing-ruby-2.1.2-using-rvm)
 
 Install all required packages and gems.
@@ -96,7 +100,8 @@ gem install oxidized
 gem install oxidized-script oxidized-web
 ```
 
-## Build from Git
+### Build from Git
+
 ```shell
 git clone https://github.com/ytti/oxidized.git
 cd oxidized/
@@ -104,38 +109,40 @@ gem build *.gemspec
 gem install pkg/*.gem
 ```
 
-# Running with Docker
+## Running with Docker
 
 clone git repo:
 
-```
+```shell
 git clone https://github.com/ytti/oxidized
 ```
 
 build container locally:
 
-```
+```shell
 docker build -q -t oxidized/oxidized:latest oxidized/
 ```
 
 create config directory in main system:
 
-```
+```shell
 mkdir /etc/oxidized
 ```
 
 run container the first time:
 _Note: this step in only needed for creating Oxidized's configuration file and can be skipped if you already have it
 
-```
+```shell
 docker run --rm -v /etc/oxidized:/root/.config/oxidized -p 8888:8888/tcp -t oxidized/oxidized:latest oxidized
 ```
+
 If the RESTful API and Web Interface are enabled, on the docker host running the container
 edit /etc/oxidized/config and modify 'rest: 127.0.0.1:8888' by 'rest: 0.0.0.0:8888'
 this will bind port 8888 to all interfaces then expose port out. [Issue #445](https://github.com/ytti/oxidized/issues/445)
 
 You can also use docker-compose to launch oxidized container:
-```
+
+```yaml
 # docker-compose.yml
 # docker-compose file example for oxidized that will start along with docker daemon
 oxidized:
@@ -151,13 +158,13 @@ oxidized:
 
 create the `/etc/oxidized/router.db` [See CSV Source for further info](docs/Configuration.md#source-csv)
 
-```
+```shell
 vim /etc/oxidized/router.db
 ```
 
 run container again:
 
-```
+```shell
 docker run -v /etc/oxidized:/root/.config/oxidized -p 8888:8888/tcp -t oxidized/oxidized:latest
 oxidized[1]: Oxidized starting, running as pid 1
 oxidized[1]: Loaded 1 nodes
@@ -169,43 +176,47 @@ Puma 2.13.4 starting...
 
 If you want to have the config automatically reloaded (e.g. when using a http source that changes)
 
-```
+```shell
 docker run -v /etc/oxidized:/root/.config/oxidized -p 8888:8888/tcp -e CONFIG_RELOAD_INTERVAL=3600 -t oxidized/oxidized:latest
 ```
 
 If you need to use an internal CA (e.g. to connect to an private github instance)
 
-```
+```shell
 docker run -v /etc/oxidized:/root/.config/oxidized -v /path/to/MY-CA.crt:/usr/local/share/ca-certificates/MY-CA.crt -p 8888:8888/tcp -e UPDATE_CA_CERTIFICATES=true -t oxidized/oxidized:latest
 ```
 
-# Installing Ruby 2.1.2 using RVM
+## Installing Ruby 2.1.2 using RVM
 
 Install Ruby 2.1.2 build dependencies
-```
+
+```shell
 yum install curl gcc-c++ patch readline readline-devel zlib zlib-devel
 yum install libyaml-devel libffi-devel openssl-devel make cmake
 yum install bzip2 autoconf automake libtool bison iconv-devel libssh2-devel
 ```
 
 Install RVM
-```
+
+```shell
 curl -L get.rvm.io | bash -s stable
 ```
 
 Setup RVM environment and compile and install Ruby 2.1.2 and set it as default
-```
+
+```shell
 source /etc/profile.d/rvm.sh
 rvm install 2.1.2
 rvm use --default 2.1.2
 ```
 
-# Configuration
+## Configuration
+
 Oxidized configuration is in YAML format. Configuration files are subsequently sourced from `/etc/oxidized/config` then `~/.config/oxidized/config`. The hashes will be merged, this might be useful for storing source information in a system wide file and  user specific configuration in the home directory (to only include a staff specific username and password). Eg. if many users are using `oxs`, see [Oxidized::Script](https://github.com/ytti/oxidized-script).
 
 It is recommended practice to run Oxidized using its own username.  This username can be added using standard command-line tools:
 
-```
+```shell
 useradd oxidized
 ```
 
@@ -215,7 +226,7 @@ To initialize a default configuration in your home directory `~/.config/oxidized
 
 You can set the env variable `OXIDIZED_HOME` to change its home directory.
 
-```
+```shell
 OXIDIZED_HOME=/etc/oxidized
 
 $ tree -L 1 /etc/oxidized
@@ -239,14 +250,15 @@ Possible outputs are either [File](docs/Configuration.md#output-file), [GIT](doc
 Maps define how to map a model's fields to model [model fields](https://github.com/ytti/oxidized/tree/master/lib/oxidized/model). Most of the settings should be self explanatory, log is ignored if `use_syslog`(requires Ruby >= 2.0) is set to `true`.
 
 First create the directory where the CSV `output` is going to store device configs and start Oxidized once.
-```
+
+```shell
 mkdir -p ~/.config/oxidized/configs
 oxidized
 ```
 
 Now tell Oxidized where it finds a list of network devices to backup configuration from. You can either use CSV or SQLite as source. To create a CSV source add the following snippet:
 
-```
+```yaml
 source:
   default: csv
   csv:
@@ -267,9 +279,9 @@ router02.example.com:ios
 
 Run `oxidized` again to take the first backups.
 
-# Extra
+## Extra
 
-## Ubuntu SystemV init setup
+### Ubuntu SystemV init setup
 
 The init script assumes that you have a used named 'oxidized' and that oxidized is in one of the following paths:
 
@@ -284,26 +296,26 @@ The init script assumes that you have a used named 'oxidized' and that oxidized 
 1. Copy init script from extra/ folder to /etc/init.d/oxidized
 2. Setup /var/run/
 
-```
+```shell
 mkdir /var/run/oxidized
 chown oxidized:oxidized /var/run/oxidized
 ```
 
 3. Make oxidized start on boot
 
-```
+```shell
 update-rc.d oxidized defaults
 ```
 
-# Help
+## Help
 
 If you need help with Oxidized then we have a few methods you can use to get in touch.
 
-  - [Gitter](https://gitter.im/oxidized/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) - You can join the Lobby on gitter to chat to other Oxidized users.
-  - [GitHub](https://github.com/ytti/oxidized/) - For help and requests for code changes / updates.
-  - [Forum](https://community.librenms.org/c/help/oxidized) - A user forum run by [LibreNMS](https://github.com/librenms/librenms) where you can ask for help and support.
+* [Gitter](https://gitter.im/oxidized/Lobby?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge) - You can join the Lobby on gitter to chat to other Oxidized users.
+* [GitHub](https://github.com/ytti/oxidized/) - For help and requests for code changes / updates.
+* [Forum](https://community.librenms.org/c/help/oxidized) - A user forum run by [LibreNMS](https://github.com/librenms/librenms) where you can ask for help and support.
 
-# Help Needed
+## Help Needed
 
 As things stand right now, `oxidized` is maintained by a single person. A great
 many [contributors](https://github.com/ytti/oxidized/graphs/contributors) have
@@ -338,12 +350,11 @@ Brian Anderson (from Rust fame) wrote an [excellent
 post](http://brson.github.io/2017/04/05/minimally-nice-maintainer) on what it
 means to be a maintainer.
 
-# License and Copyright
+## License and Copyright
 
           Copyright
           2013-2015 Saku Ytti <saku@ytti.fi>
           2013-2015 Samer Abdel-Hafez <sam@arahant.net>
-
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/TODO.md
+++ b/TODO.md
@@ -1,23 +1,29 @@
-# refactor core
-  * move state from memory to disk, sqlite probably
-  * allows us to retain stats etc over restart
-  * simplifies code
-  * keep only running nodes in memory
-  * negligible I/O cost, as majority is I/O wait getting config
+# To Do
 
-# separate login to owon package
-  * oxidized-script is not only use-case
-  * it would be good to have minimal package used to login to routers
-  * oxidized just one consumer of that functionality
-  * what to do with models, we need model to know how to login. Should models be separated to another package? oxidized-core, oxidized-models and oxidized-login?
-  * how can we allow interactive login in oxidized-login? With functional VTY etc? REPL loop in input/ssh and input/telnet?
+## refactor core
 
-# thread number
-  * think about algo
-  * if job ended later than now-iteration have rand(node.size) == 0 to add thread
-  * if now is less than job_ended+iteration same chance to remove thread?
-  * should we try to avoid max threads from being hit? (like maybe non-success thread is pulling average?)
+* move state from memory to disk, sqlite probably
+* allows us to retain stats etc over restart
+* simplifies code
+* keep only running nodes in memory
+* negligible I/O cost, as majority is I/O wait getting config
 
-# docs, testing
-  * yard docs
-  * minitest tests
+## separate login to own package
+
+* oxidized-script is not only use-case
+* it would be good to have minimal package used to login to routers
+* oxidized just one consumer of that functionality
+* what to do with models, we need model to know how to login. Should models be separated to another package? oxidized-core, oxidized-models and oxidized-login?
+* how can we allow interactive login in oxidized-login? With functional VTY etc? REPL loop in input/ssh and input/telnet?
+
+## thread number
+
+* think about algo
+* if job ended later than now-iteration have rand(node.size) == 0 to add thread
+* if now is less than job_ended+iteration same chance to remove thread?
+* should we try to avoid max threads from being hit? (like maybe non-success thread is pulling average?)
+
+## docs, testing
+
+* yard docs
+* minitest tests

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,10 +1,12 @@
-## Configuration
-### Debugging
+# Configuration
+
+## Debugging
+
 In case a model plugin doesn't work correctly (ios, procurve, etc.), you can enable live debugging of SSH/Telnet sessions. Just add a `debug` option containing the value true to the `input` section. The log files will be created depending on the parent directory of the logfile option.
 
 The following example will log an active ssh/telnet session `/home/oxidized/.config/oxidized/log/<IP-Adress>-<PROTOCOL>`. The file will be truncated on each consecutive ssh/telnet session, so you need to put a `tailf` or `tail -f` on that file!
 
-```
+```yaml
 log: /home/oxidized/.config/oxidized/log
 
 ...
@@ -16,20 +18,20 @@ input:
     secure: false
 ```
 
-### Privileged mode
+## Privileged mode
 
 To start privileged mode before pulling the configuration, Oxidized needs to send the enable command. You can globally enable this, by adding the following snippet to the global section of the configuration file.
 
-```
+```yaml
 vars:
    enable: S3cre7
 ```
 
-### Removing secrets
+## Removing secrets
 
 To strip out secrets from configurations before storing them, Oxidized needs the the remove_secrets flag. You can globally enable this by adding the following snippet to the global sections of the configuration file.
 
-```
+```yaml
 vars:
   remove_secret: true
 ```
@@ -38,32 +40,33 @@ Device models can contain substitution filters to remove potentially sensitive d
 
 As a partial example from ios.rb:
 
-```
+```yaml
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     (...)
     cfg
   end
 ```
+
 The above strips out snmp community strings from your saved configs.
 
 **NOTE:** Removing secrets reduces the usefulness as a full configuration backup, but it may make sharing configs easier.
 
-### Disabling SSH exec channels
+## Disabling SSH exec channels
 
 Oxidized uses exec channels to make information extraction simpler, but there are some situations where this doesn't work well, e.g. configuring devices.  This feature can be turned off by setting the `ssh_no_exec`
 variable.
 
-```
+```yaml
 vars:
   ssh_no_exec: true
 ```
 
-### SSH Proxy Command
+## SSH Proxy Command
 
 Oxidized can `ssh` through a proxy as well. To do so we just need to set `ssh_proxy` variable.
 
-```
+```yaml
 ...
 map:
   name: 0
@@ -74,20 +77,21 @@ vars_map:
 ...
 ```
 
-### FTP Passive Mode
+## FTP Passive Mode
 
 Oxidized uses ftp passive mode by default. Some devices require passive mode to be disabled. To do so, we can set `input.ftp.passive` to false
-```
+
+```yaml
 input:
   ftp:
     passive: false
 ```
 
-### Advanced Configuration
+## Advanced Configuration
 
 Below is an advanced example configuration. You will be able to (optionally) override options per device. The router.db format used is `hostname:model:username:password:enable_password`. Hostname and model will be the only required options, all others override the global configuration sections.
 
-```
+```yaml
 ---
 username: oxidized
 password: S3cr3tx
@@ -130,14 +134,13 @@ source:
 model_map:
   cisco: ios
   juniper: junos
-
 ```
 
-### Advanced Group Configuration
+## Advanced Group Configuration
 
 For group specific credentials
 
-```
+```yaml
 groups:
   mikrotik:
     username: admin
@@ -146,16 +149,19 @@ groups:
     username: ubnt
     password: ubnt
 ```
+
 and add group mapping
-```
+
+```yaml
 map:
   model: 0
   name: 1
   group: 2
 ```
+
 For model specific credentials
 
-```
+```yaml
 models:
   junos:
     username: admin
@@ -170,26 +176,26 @@ models:
     password: password
 ```
 
-### RESTful API and Web Interface
+## RESTful API and Web Interface
 
 The RESTful API and Web Interface is enabled by configuring the `rest:` parameter in the config file.  This parameter can optionally contain a relative URI.
 
-```
+```yaml
 # Listen on http://127.0.0.1:8888/
 rest: 127.0.0.1:8888
 ```
 
-```
+```yaml
 # Listen on http://10.0.0.1:8000/oxidized/
 rest: 10.0.0.1:8000/oxidized
 ```
 
-### Triggered backups
+## Triggered backups
 
 A node can be moved to head-of-queue via the REST API `GET/POST /node/next/[NODE]`.
 
 In the default configuration this node will be processed when the next job worker becomes available, it could take some time if existing backups are in progress. To execute moved jobs immediately a new job can be added:
 
-```
+```yaml
 next_adds_job: true
 ```

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -1,25 +1,30 @@
 # Hooks
+
 You can define arbitrary number of hooks that subscribe different events. The hook system is modular and different kind of hook types can be enabled.
 
 ## Configuration
+
 Following configuration keys need to be defined for all hooks:
 
-  * `events`: which events to subscribe. Needs to be an array. See below for the list of available events.
-  * `type`: what hook class to use. See below for the list of available hook types.
+* `events`: which events to subscribe. Needs to be an array. See below for the list of available events.
+* `type`: what hook class to use. See below for the list of available hook types.
 
 ### Events
-  * `node_success`: triggered when configuration is succesfully pulled from a node and right before storing the configuration.
-  * `node_fail`: triggered after `retries` amount of failed node pulls.
-  * `post_store`: triggered after node configuration is stored (this is executed only when the configuration has changed).
-  * `nodes_done`: triggered after finished fetching all nodes.
+
+* `node_success`: triggered when configuration is succesfully pulled from a node and right before storing the configuration.
+* `node_fail`: triggered after `retries` amount of failed node pulls.
+* `post_store`: triggered after node configuration is stored (this is executed only when the configuration has changed).
+* `nodes_done`: triggered after finished fetching all nodes.
 
 ## Hook type: exec
+
 The `exec` hook type allows users to run an arbitrary shell command or a binary when triggered.
 
 The command is executed on a separate child process either in synchronous or asynchronous fashion. Non-zero exit values cause errors to be logged. STDOUT and STDERR are currently not collected.
 
 Command is executed with the following environment:
-```
+
+```text
 OX_EVENT
 OX_NODE_NAME
 OX_NODE_IP
@@ -35,13 +40,13 @@ OX_REPO_NAME
 
 Exec hook recognizes following configuration keys:
 
-  * `timeout`: hard timeout for the command execution. SIGTERM will be sent to the child process after the timeout has elapsed. Default: 60
-  * `async`: influences whether main thread will wait for the command execution. Set this true for long running commands so node pull is not blocked. Default: false
-  * `cmd`: command to run.
+* `timeout`: hard timeout for the command execution. SIGTERM will be sent to the child process after the timeout has elapsed. Default: 60
+* `async`: influences whether main thread will wait for the command execution. Set this true for long running commands so node pull is not blocked. Default: false
+* `cmd`: command to run.
 
+## exec hook configuration example
 
-## Hook configuration example
-```
+```yaml
 hooks:
   name_for_example_hook1:
     type: exec
@@ -55,21 +60,21 @@ hooks:
     timeout: 120
 ```
 
-### githubrepo
+### Hook type: githubrepo
 
 This hook configures the repository `remote` and _push_ the code when the specified event is triggerd. If the `username` and `password` are not provided, the `Rugged::Credentials::SshKeyFromAgent` will be used.
 
 `githubrepo` hook recognizes following configuration keys:
 
-  * `remote_repo`: the remote repository to be pushed to.
-  * `username`: username for repository auth.
-  * `password`: password for repository auth.
-  * `publickey`: publickey for repository auth.
-  * `privatekey`: privatekey for repository auth.
+* `remote_repo`: the remote repository to be pushed to.
+* `username`: username for repository auth.
+* `password`: password for repository auth.
+* `publickey`: publickey for repository auth.
+* `privatekey`: privatekey for repository auth.
 
 When using groups repositories, each group must have its own `remote` in the `remote_repo` config.
 
-``` yaml
+```yaml
 hooks:
   push_to_remote:
     remote_repo:
@@ -78,10 +83,9 @@ hooks:
       firewalls: git@git.intranet:oxidized/firewalls.git
 ```
 
+## githubrepo hook configuration example
 
-## Hook configuration example
-
-``` yaml
+```yaml
 hooks:
   push_to_remote:
     type: githubrepo
@@ -97,14 +101,14 @@ The `awssns` hook publishes messages to AWS SNS topics. This allows you to notif
 
 Fields sent in the message:
 
-  * `event`: Event type (e.g. `node_success`)
-  * `group`: Group name
-  * `model`: Model name (e.g. `eos`)
-  * `node`: Device hostname
+* `event`: Event type (e.g. `node_success`)
+* `group`: Group name
+* `model`: Model name (e.g. `eos`)
+* `node`: Device hostname
 
-Configuration example:
+## awssns hook configuration example
 
-``` yaml
+```yaml
 hooks:
   hook_script:
     type: awssns
@@ -115,8 +119,8 @@ hooks:
 
 AWS SNS hook requires the following configuration keys:
 
-  * `region`: AWS Region name
-  * `topic_arn`: ASN Topic reference
+* `region`: AWS Region name
+* `topic_arn`: ASN Topic reference
 
 Your AWS credentials should be stored in `~/.aws/credentials`.
 
@@ -126,13 +130,13 @@ The `slackdiff` hook posts colorized config diffs to a [Slack](http://www.slack.
 
 You will need to manually install the `slack-api` gem on your system:
 
-```
+```shell
 gem install slack-api
 ```
 
-Configuration example:
+## slackdiff hook configuration example
 
-``` yaml
+```yaml
 hooks:
   slack:
     type: slackdiff
@@ -143,7 +147,7 @@ hooks:
 
 Optionally you can disable snippets and post a formatted message, for instance linking to a commit in a git repo. Named parameters `%{node}`, `%{group}`, `%{model}` and `%{commitref}` are available.
 
-``` yaml
+```yaml
 hooks:
   slack:
     type: slackdiff
@@ -162,13 +166,13 @@ The `xmppdiff` hook posts config diffs to a [XMPP](https://en.wikipedia.org/wiki
 
 You will need to manually install the `xmpp4r` gem on your system:
 
-```
+```shell
 gem install xmpp4r
 ```
 
-Configuration example:
+## xmppdiff hook configuration example
 
-``` yaml
+```yaml
 hooks:
   xmpp:
     type: xmppdiff

--- a/docs/Model-Notes/AireOS.md
+++ b/docs/Model-Notes/AireOS.md
@@ -1,12 +1,12 @@
-Cisco WLC Configuration 
-========================
+Cisco WLC Configuration
+=======================
 
 Create a user with read-write privilege :
 
-```
+```text
 mgmtuser add oxidized **** read-write
 ```
 
-Oxidized needs read-write privilege in order to execute 'config paging disable'. 
+Oxidized needs read-write privilege in order to execute 'config paging disable'.
 
 Back to [Model-Notes](README.md)

--- a/docs/Model-Notes/ArbOS.md
+++ b/docs/Model-Notes/ArbOS.md
@@ -3,7 +3,7 @@ Arbor Networks ArbOS notes
 
 If you are running ArbOS version 7 or lower then you may need to update the model to remove `exec true`:
 
-```
+```ruby
   cfg :ssh do
     pre_logout 'exit'
   end

--- a/docs/Model-Notes/Comware.md
+++ b/docs/Model-Notes/Comware.md
@@ -1,10 +1,12 @@
 Comware Configuration
 =====================
 
-If you find 3Com comware devices aren't being backed up this may be due to prompt detection not matching 
-because a previous login message is disabled after the first prompt. You can disable this on the devices 
-themselves by running this command:
+If you find 3Com comware devices aren't being backed up this may be due to prompt detection not matching because a previous login message is disabled after the first prompt.
 
-`info-center source default channel 1 log state off debug state off`
+You can disable this on the devices themselves by running this command:
+
+```text
+info-center source default channel 1 log state off debug state off
+```
 
 [Reference](https://github.com/ytti/oxidized/issues/1171)

--- a/docs/Model-Notes/JunOS.md
+++ b/docs/Model-Notes/JunOS.md
@@ -1,9 +1,9 @@
 JunOS Configuration
-========================
+===================
 
 Create login class cfg-view
 
-```
+```text
 set system login class cfg-view permissions view-configuration
 set system login class cfg-view allow-commands "(show)|(set cli screen-length)|(set cli screen-width)"
 set system login class cfg-view deny-commands "(clear)|(file)|(file show)|(help)|(load)|(monitor)|(op)|(request)|(save)|(set)|(start)|(test)"
@@ -12,7 +12,7 @@ set system login class cfg-view deny-configuration all
 
 Create a user with cfg-view class
 
-```
+```text
 set system login user oxidized class cfg-view
 set system login user oxidized authentication plain-text-password "verysecret"
 ```
@@ -25,14 +25,10 @@ The commands Oxidized executes are:
 4. show version
 5. show chassis hardware
 6. show system license
-7. show system license keys
-ex22|ex33|ex4|ex8|qfx only
-8. show virtual-chassis
-MX960 only
+7. show system license keys (ex22|ex33|ex4|ex8|qfx only)
+8. show virtual-chassis (MX960 only)
 9. show chassis fabric reachability
 
-
 Oxidized can now retrieve your configuration!
-
 
 Back to [Model-Notes](README.md)

--- a/docs/Model-Notes/README.md
+++ b/docs/Model-Notes/README.md
@@ -1,21 +1,17 @@
-
-
 Model Notes
-========================
-
+===========
 
 This directory contains implemention notes and caveats to assist you in your oxidized deployment.
 
 Use the table below for more information on the Vendor/Model caveats.
 
-
 Vendor          | Model           |Updated
 ----------------|-----------------|----------------
 3COM|[Comware](Comware.md)|15 Feb 2018
+AireOS|[AireOS](AireOS.md)|29 Nov 2017
 Arbor Networks|[ArbOS](ArbOS.md)|27 Feb 2018
 Huawei|[VRP](VRP-Huawei.md)|17 Nov 2017
 Juniper|[MX/QFX/EX/SRX/J Series](JunOS.md)|18 Jan 2018
 Xyzel|[XGS4600 Series](XGS4600-Zyxel.md)|23 Jan 2018
-
 
 If you discover additional caveats or problems please make sure to consult the [GitHub issues for oxidized](https://github.com/ytti/oxidized/issues) known issues.

--- a/docs/Model-Notes/VRP-Huawei.md
+++ b/docs/Model-Notes/VRP-Huawei.md
@@ -3,7 +3,7 @@ Huawei VRP Configuration
 
 Create a user with no privileges
 
-```
+```text
     <HUAWEI> system-view
     [~HUAWEI] aaa
     [~HUAWEI-aaa] local-user oxidized password irreversible-cipher verysecret
@@ -21,7 +21,7 @@ The commands Oxidized executes are:
 
 Command 2 and 3 can be executed without issues, but 1 and 4 are only available for higher level users. Instead of making Oxidized a read/write user on your device, lower the priviledge-level for commands 1 and 4:
 
-```
+```text
     <HUAWEI> system-view
     [~HUAWEI] command-privilege level 1 view global display current-configuration all
     [*HUAWEI] command-privilege level 1 view shell screen-length
@@ -29,6 +29,5 @@ Command 2 and 3 can be executed without issues, but 1 and 4 are only available f
 ```
 
 Oxidized can now retrieve your configuration!
-
 
 Back to [Model-Notes](README.md)

--- a/docs/Model-Notes/XGS4600-Zyxel.md
+++ b/docs/Model-Notes/XGS4600-Zyxel.md
@@ -1,24 +1,25 @@
 ZynOS Configuration
-========================
+===================
 
 ## FTP
+
 FTP access is only possible as admin, other users can login but cannot pull the files.
 For the XGS4600 series the config file is _config_ and not _config-0_
 
-The following line in _oxidized/lib/oxidized/model/zynos.rb_ with need changing
-```
-  cmd 'config-0'
+The following line in _oxidized/lib/oxidized/model/zynos.rb_ will need changing
 
+```text
+  cmd 'config-0'
 ```
 
 The inclusion of an extra ftp option is also require. Within _input_ add the following
-```
+
+```yaml
 input:
   ftp:
     passive: false
 ```
 
 Oxidized can now retrieve your configuration!
-
 
 Back to [Model-Notes](README.md)

--- a/docs/Outputs.md
+++ b/docs/Outputs.md
@@ -1,23 +1,22 @@
+# Outputs
 
-## Output
-
-### Output: File
+## Output: File
 
 Parent directory needs to be created manually, one file per device, with most recent running config.
 
-```
+```yaml
 output:
   file:
     directory: /var/lib/oxidized/configs
 ```
 
-### Output: Git
+## Output: Git
 
 This uses the rugged/libgit2 interface. So you should remember that normal Git hooks will not be executed.
 
 For a single repositories for all devices:
 
-``` yaml
+```yaml
 output:
   default: git
   git:
@@ -28,7 +27,7 @@ output:
 
 And for groups repositories:
 
-``` yaml
+```yaml
 output:
   default: git
   git:
@@ -40,14 +39,14 @@ output:
 Oxidized will create a repository for each group in the same directory as the `default.git`. For
 example:
 
-``` csv
+```csv
 host1:ios:first
 host2:nxos:second
 ```
 
 This will generate the following repositories:
 
-``` bash
+```bash
 $ ls /var/lib/oxidized/git-repos
 
 default.git first.git second.git
@@ -55,7 +54,7 @@ default.git first.git second.git
 
 If you would like to use groups and a single repository, you can force this with the `single_repo` config.
 
-``` yaml
+```yaml
 output:
   default: git
   git:
@@ -64,15 +63,14 @@ output:
 
 ```
 
-### Output: Git-Crypt
+## Output: Git-Crypt
 
 This uses the gem git and system git-crypt interfaces. Have a look at [GIT-Crypt](https://www.agwa.name/projects/git-crypt/) documentation to know how to install it.
 Additionally to user and email informations, you have to provide the users ID that can be a key ID, a full fingerprint, an email address, or anything else that uniquely identifies a public key to GPG (see "HOW TO SPECIFY A USER ID" in the gpg man page).
 
-
 For a single repositories for all devices:
 
-``` yaml
+```yaml
 output:
   default: gitcrypt
   gitcrypt:
@@ -86,7 +84,7 @@ output:
 
 And for groups repositories:
 
-``` yaml
+```yaml
 output:
   default: gitcrypt
   gitcrypt:
@@ -101,14 +99,14 @@ output:
 Oxidized will create a repository for each group in the same directory as the `default`. For
 example:
 
-``` csv
+```csv
 host1:ios:first
 host2:nxos:second
 ```
 
 This will generate the following repositories:
 
-``` bash
+```bash
 $ ls /var/lib/oxidized/git-repos
 
 default.git first.git second.git
@@ -116,7 +114,7 @@ default.git first.git second.git
 
 If you would like to use groups and a single repository, you can force this with the `single_repo` config.
 
-``` yaml
+```yaml
 output:
   default: gitcrypt
   gitcrypt:
@@ -130,11 +128,11 @@ output:
 
 Please note that user list is only updated once at creation.
 
-### Output: Http
+## Output: Http
 
 POST a config to the specified URL
 
-```
+```yaml
 output:
   default: http
   http:
@@ -143,13 +141,13 @@ output:
     url: "http://192.168.162.50:8080/db/coll"
 ```
 
-### Output types
+## Output types
 
 If you prefer to have different outputs in different files and/or directories, you can easily do this by modifying the corresponding model. To change the behaviour for IOS, you would edit `lib/oxidized/model/ios.rb` (run `gem contents oxidized` to find out the full file path).
 
 For example, let's say you want to split out `show version` and `show inventory` into separate files in a directory called `nodiff` which your tools will not send automated diffstats for. You can apply a patch along the lines of
 
-```
+```text
 -  cmd 'show version' do |cfg|
 -    comment cfg.lines.first
 +  cmd 'show version' do |state|
@@ -183,7 +181,7 @@ For example, let's say you want to split out `show version` and `show inventory`
 
 which will result in the following layout
 
-```
+```text
 diff/$FQDN--show_running_config
 nodiff/$FQDN--show_version
 nodiff/$FQDN--show_inventory

--- a/docs/Ruby-API.md
+++ b/docs/Ruby-API.md
@@ -3,33 +3,39 @@
 The following objects exist in Oxidized.
 
 ## Input
- * gets config from nodes
- * must implement 'connect', 'get', 'cmd'
- * 'ssh', 'telnet, ftp, and tftp' implemented
+
+* gets config from nodes
+* must implement 'connect', 'get', 'cmd'
+* 'ssh', 'telnet, ftp, and tftp' implemented
 
 ## Output
- * stores config
- * must implement 'store' (may implement 'fetch')
- * 'git' and 'file' (store as flat ascii) implemented
+
+* stores config
+* must implement 'store' (may implement 'fetch')
+* 'git' and 'file' (store as flat ascii) implemented
 
 ## Source
- * gets list of nodes to poll
- * must implement 'load'
- * source can have 'name', 'model', 'group', 'username', 'password', 'input', 'output', 'prompt'
-   * name - name of the devices
-   * model - model to use ios/junos/xyz, model is loaded dynamically when needed (Also default in config file)
-   * input - method to acquire config, loaded dynamically as needed (Also default in config file)
-   * output - method to store config, loaded dynamically as needed (Also default in config file)
-   * prompt - prompt used for node (Also default in config file, can be specified in model too)
- * 'sql', 'csv' and 'http' (supports any format with single entry per line, like router.db)
+
+* gets list of nodes to poll
+* must implement 'load'
+* source can have 'name', 'model', 'group', 'username', 'password', 'input', 'output', 'prompt'
+  * name - name of the devices
+  * model - model to use ios/junos/xyz, model is loaded dynamically when needed (Also default in config file)
+  * input - method to acquire config, loaded dynamically as needed (Also default in config file)
+  * output - method to store config, loaded dynamically as needed (Also default in config file)
+  * prompt - prompt used for node (Also default in config file, can be specified in model too)
+* 'sql', 'csv' and 'http' (supports any format with single entry per line, like router.db)
 
 ## Model
+
 ### At the top level
+
 A model may use several methods at the top level in the class. `cfg` is
 executed in input/output/source context. `cmd` is executed within an instance
 of the model.
 
 #### `cfg`
+
 `cfg` may be called with a list of methods (`:ssh`, `:telnet`) and a block with
 zero parameters.  Calling `cfg` registers the given access methods and calling
 it at least once is required for a model to work.
@@ -38,6 +44,7 @@ The block may contain commands to change some behaviour for the given methods
 (e.g. calling `post_login` to disable the pager).
 
 #### `cmd`
+
 Is used to specify commands that should be executed on a model in order to
 gather its configuration. It can be called with:
 
@@ -69,18 +76,21 @@ Execution order is `:all`, `:secret`, and lastly the command specific block, if
 given.
 
 #### `comment`
+
 Called with a single string containing the string to prepend for comments in
 emitted configuration for this model.
 
 If not specified the default of `'# '` will be used (note the trailing space).
 
 #### `prompt`
+
 Is called with a regular expression that is used to detect when command output
 ends after a command has been executed.
 
 If not specified, a default of `/^([\w.@-]+[#>]\s?)$/` is used.
 
 #### `expect`
+
 Called with a regular expression and a block. The block takes two parameters:
 the regular expression, and the data containing the match.
 
@@ -90,26 +100,32 @@ The passed data is replaced by the return value of the block.
 it's further processed.
 
 ### At the second level
+
 The following methods are available:
 
 #### `comment`
+
 Used inside `cmd` invocations. Comments out every line in the passed string and
 returns the result.
 
 #### `password`
+
 Used inside `cfg` invocations to specify the regular expression used to detect
 the password prompt. If not specified, the default of `/^Password/` is used.
 
 #### `post_login`
+
 Used inside `cfg` invocations to specify commands to run once Oxidized has
 logged in to the switch. Takes one argument that is either a block (taking zero
 parameters) or a string containing a command to execute.
 
 #### `pre_logout`
+
 Used to specify commands to run before Oxidized closes the connection to the
 switch. Takes one argument that is either a block (taking zero parameters) or a
 string containing a command to execute.
 
 #### `send`
+
 Usually used inside `expect` or blocks passed to `post_login`/`pre_logout`.
 Takes a single parameter: a string to be sent to the switch.

--- a/docs/Sources.md
+++ b/docs/Sources.md
@@ -1,10 +1,10 @@
-## Source
+# Sources
 
-### Source: CSV
+## Source: CSV
 
 One line per device, colon seperated. If `ip` isn't present, a DNS lookup will be done against `name`.  For large installations, setting `ip` will dramatically reduce startup time.
 
-```
+```yaml
 source:
   default: csv
   csv:
@@ -22,7 +22,7 @@ source:
 
 Example csv `/var/lib/oxidized/router.db`:
 
-```
+```text
 rtr01.local:192.168.1.1:ios:oxidized:5uP3R53cR3T:T0p53cR3t
 ```
 
@@ -41,25 +41,31 @@ source:
       model: 1
 ```
 
-> Please note, if you are running GPG v2 then you will be prompted for your gpg password on start up, if you use GPG >= 2.1 then you can add the following config to stop that behaviour:
+Please note, if you are running GPG v2 then you will be prompted for your gpg password on start up, if you use GPG >= 2.1 then you can add the following config to stop that behaviour:
 
-> Within `~/.gnupg/gpg-agent.conf`
+Within `~/.gnupg/gpg-agent.conf`
 
-> `allow-loopback-pinentry`
+```text
+allow-loopback-pinentry
+```
 
-> and within: `~/.gnupg/gpg.conf`
+and within: `~/.gnupg/gpg.conf`
 
-> `pinentry-mode loopback`
+```text
+pinentry-mode loopback
+```
 
-### Source: SQL
+## Source: SQL
+
  Oxidized uses the `sequel` ruby gem. You can use a variety of databases that aren't explicitly listed. For more information visit https://github.com/jeremyevans/sequel Make sure you have the correct adapter!
-### Source: MYSQL
+
+## Source: MYSQL
 
 `sudo apt-get install libmysqlclient-dev`
 
 The values correspond to your fields in the DB such that ip, model, etc are field names in the DB
 
-```
+```yaml
 source:
   default: sql
   sql:
@@ -77,11 +83,11 @@ source:
       enable: enable
 ```
 
-### Source: SQLite
+## Source: SQLite
 
 One row per device, filtered by hostname.
 
-```
+```yaml
 source:
   default: sql
   sql:
@@ -97,12 +103,11 @@ source:
       enable: enable
 ```
 
-### Custom SQL Query Support
+## Custom SQL Query Support
 
 You may also implement a custom SQL query to retreive the nodelist using  SQL syntax with the `query:` configuration parameter under the `sql:` stanza.
 
-
-#### Custom SQL Query Examples
+### Custom SQL Query Examples
 
 You may have a table named `nodes` which contains a boolean to indicate if the nodes should be enabled (fetched via oxidized). This can be used in the custom SQL query to avoid fetching from known impacted nodes.
 
@@ -119,21 +124,20 @@ In this example we limit the nodes to two "POPs" of `mypop1` and `mypop2`. We al
 ```sql
 query: "SELECT * FROM nodes WHERE pop IN ('mypop1','mypop2') AND enabled = True"
 ```
+
 The order of the nodes returned will influence the order that nodes are fetched by oxidized. You can use standard SQL `ORDER BY` clauses to influence the node order.
 
 You should always test your SQL query before using it in the oxidized configuration as there is no syntax or error checking performed before sending it to the database engine.
 
 Consult your database documentation for more information on query language and table optimization.
 
-
-
-### Source: HTTP
+## Source: HTTP
 
 One object per device.
 
 HTTP Supports basic auth, configure the user and pass you want to use under the http: section.
 
-```
+```yaml
 source:
   default: http
   http:
@@ -155,7 +159,7 @@ source:
 
 You can also pass `secure: false` if you want to disable ssl certificate verification:
 
-```
+```yaml
 source:
   default: http
   http:

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -1,159 +1,160 @@
 # Supported OS types
- * Vendor
-   * OS model
- * A10 Networks
-   * [ACOS](/lib/oxidized/model/acos.rb)
- * Accedian Performance Elements (NIDs)
-   * [AEN](/lib/oxidized/model/aen.rb)
- * Alcatel-Lucent
-   * [AOS](/lib/oxidized/model/aos.rb)
-   * [AOS7](/lib/oxidized/model/aos7.rb)
-   * [ISAM](/lib/oxidized/model/isam.rb)
-   * [SR OS (Formerly TiMOS)](/lib/oxidized/model/timos.rb)
-   * Wireless
- * Allied Telesis
-   * [Alliedware Plus](/lib/oxidized/model/awplus.rb)
- * Alvarion
-   * [BreezeACCESS](/lib/oxidized/model/alvarion.rb)
- * APC
-   * [AOS](/lib/oxidized/model/apc_aos.rb)
- * Arbor Networks
-   * [ArbOS](/lib/oxidized/model/arbos.rb)
- * Arista
-   * [EOS](/lib/oxidized/model/eos.rb)
- * Arris
-   * [C4CMTS](/lib/oxidized/model/c4cmts.rb)
- * Aruba
-   * [AOSW](/lib/oxidized/model/aosw.rb)
- * AudioCodes
-   * [AudioCodes](/lib/oxdized/model/audiocodes.rb)
- * Avaya
-   * [VOSS (VSP Operating System Software)](/lib/oxidized/model/voss.rb)
-   * [BOSS (Baystack Operating System Software)](/lib/oxidized/model/boss.rb)
- * Brocade
-   * [FabricOS](lib/oxidized/model/fabricos.rb)
-   * [Ironware](lib/oxidized/model/ironware.rb)
-   * [NOS (Network Operating System)](lib/oxidized/model/nos.rb)
-   * [Vyatta](lib/oxidized/model/vyatta.rb)
-   * [6910](lib/oxidized/model/br6910.rb)
-   * [SLX-OS](lib/oxidized/model/slxos.rb)
- * Casa
-   * [Casa](/lib/oxidized/model/casa.rb)
- * Check Point
-   * [GaiaOS](/lib/oxidized/model/gaiaos.rb)
- * Ciena
-   * [SAOS](/lib/oxidized/model/saos.rb)
- * Cisco
-   * [ACSW](/lib/oxidized/model/acsw.rb)
-   * [AireOS](/lib/oxidized/model/aireos.rb)
-   * [ASA](/lib/oxidized/model/asa.rb)
-   * [AsyncOS](/lib/oxidized/model/asyncos.rb)
-   * [CatOS](/lib/oxidized/model/catos.rb)
-   * [IOS](/lib/oxidized/model/ios.rb)
-   * [IOSXR](/lib/oxidized/model/iosxr.rb)
-   * [NGA](/lib/oxidized/model/cisconga.rb)
-   * [NXOS](/lib/oxidized/model/nxos.rb)
-   * [SMA](/lib/oxidized/model/ciscosma.rb)
-   * [SMB (Nikola series)](/lib/oxidized/model/ciscosmb.rb)
-   * [UCS](/lib/oxidized/model/ucs.rb)
- * Citrix
-   * [NetScaler (Virtual Applicance)](/lib/oxidized/model/netscaler.rb)
- * Coriant (former Tellabs)
-   * [TMOS (8800)](/lib/oxidized/model/corianttmos.rb)
-   * [8600](/lib/oxidized/model/coriant8600.rb)
-   * [Groove](/lib/oxidized/model/coriantgroove.rb)
- * Cumulus
-   * [Linux](/lib/oxidized/model/cumulus.rb)
- * DataCom
-   * [DmSwitch 3000](/lib/oxidized/model/datacom.rb)
- * DCN
-   * [DCN](/lib/oxidized/model/ios.rb) - Map this to ios.
- * DELL
-   * [PowerConnect](/lib/oxidized/model/powerconnect.rb)
-   * [AOSW](/lib/oxidized/model/aosw.rb)
- * D-Link
-   * [D-Link](/lib/oxidized/model/dlink.rb)
- * Ericsson/Redback
-   * [IPOS (former SEOS)](/lib/oxidized/model/ipos.rb)
- * Extreme Networks
-   * [Enterasys](/lib/oxidized/model/enterasys.rb)
-   * [WM](/lib/oxidized/model/mtrlrfs.rb)
-   * [XOS](/lib/oxidized/model/xos.rb)
- * F5
-   * [TMOS](/lib/oxidized/model/tmos.rb)
- * Fiberstore
-   * [S3800](/lib/oxidized/model/gcombnps.rb)
- * Force10
-   * [DNOS](/lib/oxidized/model/dnos.rb)
-   * [FTOS](/lib/oxidized/model/ftos.rb)
- * FortiGate
-   * [FortiOS](/lib/oxidized/model/fortios.rb)
- * Fujitsu
-   * [PRIMERGY Blade switch 1/10Gbe](/lib/oxidized/model/fujitsupy.rb)
- * GCOM Technologies
-   * [Broadband Network Platform Software](/lib/oxidized/model/gcombnps.rb)
- * Hatteras
-   * [Hatteras](/lib/oxidized/model/hatteras.rb)
- * Hirschmann
-   * [HiOS](/lib/oxidized/model/hirschmann.rb)
- * HP
-   * [Comware (HP A-series, H3C, 3Com)](/lib/oxidized/model/comware.rb)
-   * [Procurve](/lib/oxidized/model/procurve.rb)
-   * [BladeSystem (Onboard Administrator)](/lib/oxidized/model/hpebladesystem.rb)
-   * [MSA](/lib/oxidized/model/hpemsa.rb)
- * Huawei
-   * [VRP](/lib/oxidized/model/vrp.rb)
- * Juniper
-   * [JunOS](/lib/oxidized/model/junos.rb)
-   * [ScreenOS (Netscreen)](/lib/oxidized/model/screenos.rb)
- * Mellanox
-   * [MLNX-OS](/lib/oxidized/model/mlnxos.rb)
-   * [Voltaire](/lib/oxidized/model/voltaire.rb)
- * Mikrotik
-   * [RouterOS](/lib/oxidized/model/routeros.rb)
- * Motorola
-   * [RFS](/lib/oxidized/model/mtrlrfs.rb)
- * MRV
-   * [MasterOS](/lib/oxidized/model/masteros.rb)
-   * [FiberDriver](/lib/oxidized/model/fiberdriver.rb)
- * Netgear
-   * [Netgear](/lib/oxidized/model/netgear.rb)
- * Netonix
-   * [WISP Switch (As Netonix)](/lib/oxidized/model/netonix.rb)
- * Nokia (formerly TiMetra, Alcatel, Alcatel-Lucent)
-   * [SR OS (TiMOS)](/lib/oxidized/model/timos.rb)
- * OneAccess
-   * [OneOS](/lib/oxidized/model/oneos.rb)
- * Opengear
-   * [Opengear](/lib/oxidized/model/opengear.rb)
- * [OPNsense](/lib/oxidized/model/opnsense.rb)
- * Palo Alto
-   * [PANOS](/lib/oxidized/model/panos.rb)
- * [PLANET SG/SGS Switches](/lib/oxidized/model/planet.rb)
- * [pfSense](/lib/oxidized/model/pfsense.rb)
- * Radware
-   * [AlteonOS](/lib/oxidized/model/alteonos.rb)
- * Quanta
-   * [Quanta / VxWorks 6.6 (1.1.0.8)](/lib/oxidized/model/quantaos.rb)
- * Siklu
-   * [EtherHaul](/lib/oxidized/model/siklu.rb)
- * Supermicro
-   * [Supermicro](/lib/oxidized/model/supermicro.rb)
- * Symantec
-   * [Blue Coat ProxySG / Security Gateway OS (SGOS)](/lib/oxidized/model/sgos.rb)
- * Trango Systems
-   * [Trango](/lib/oxidized/model/trango.rb)
- * TPLink
-   * [TPLink](/lib/oxidized/model/tplink.rb)
- * Ubiquiti
-   * [AirOS](/lib/oxidized/model/airos.rb)
-   * [Edgeos](/lib/oxidized/model/edgeos.rb)
-   * [EdgeSwitch](/lib/oxidized/model/edgeswitch.rb)
- * Watchguard
-   * [Fireware OS](/lib/oxidized/model/firewareos.rb)
- * Westell
-   * [Westell 8178G, Westell 8266G](/lib/oxidized/model/weos.rb)
- * Zhone
-   * [Zhone (OLT and MX)](/lib/oxidized/model/zhoneolt.rb)
- * Zyxel
-   * [ZyNOS](/lib/oxidized/model/zynos.rb)
+
+* Vendor
+  * OS model
+* A10 Networks
+  * [ACOS](/lib/oxidized/model/acos.rb)
+* Accedian Performance Elements (NIDs)
+  * [AEN](/lib/oxidized/model/aen.rb)
+* Alcatel-Lucent
+  * [AOS](/lib/oxidized/model/aos.rb)
+  * [AOS7](/lib/oxidized/model/aos7.rb)
+  * [ISAM](/lib/oxidized/model/isam.rb)
+  * [SR OS (Formerly TiMOS)](/lib/oxidized/model/timos.rb)
+  * Wireless
+* Allied Telesis
+  * [Alliedware Plus](/lib/oxidized/model/awplus.rb)
+* Alvarion
+  * [BreezeACCESS](/lib/oxidized/model/alvarion.rb)
+* APC
+  * [AOS](/lib/oxidized/model/apc_aos.rb)
+* Arbor Networks
+  * [ArbOS](/lib/oxidized/model/arbos.rb)
+* Arista
+  * [EOS](/lib/oxidized/model/eos.rb)
+* Arris
+  * [C4CMTS](/lib/oxidized/model/c4cmts.rb)
+* Aruba
+  * [AOSW](/lib/oxidized/model/aosw.rb)
+* AudioCodes
+  * [AudioCodes](/lib/oxdized/model/audiocodes.rb)
+* Avaya
+  * [VOSS (VSP Operating System Software)](/lib/oxidized/model/voss.rb)
+  * [BOSS (Baystack Operating System Software)](/lib/oxidized/model/boss.rb)
+* Brocade
+  * [FabricOS](lib/oxidized/model/fabricos.rb)
+  * [Ironware](lib/oxidized/model/ironware.rb)
+  * [NOS (Network Operating System)](lib/oxidized/model/nos.rb)
+  * [Vyatta](lib/oxidized/model/vyatta.rb)
+  * [6910](lib/oxidized/model/br6910.rb)
+  * [SLX-OS](lib/oxidized/model/slxos.rb)
+* Casa
+  * [Casa](/lib/oxidized/model/casa.rb)
+* Check Point
+  * [GaiaOS](/lib/oxidized/model/gaiaos.rb)
+* Ciena
+  * [SAOS](/lib/oxidized/model/saos.rb)
+* Cisco
+  * [ACSW](/lib/oxidized/model/acsw.rb)
+  * [AireOS](/lib/oxidized/model/aireos.rb)
+  * [ASA](/lib/oxidized/model/asa.rb)
+  * [AsyncOS](/lib/oxidized/model/asyncos.rb)
+  * [CatOS](/lib/oxidized/model/catos.rb)
+  * [IOS](/lib/oxidized/model/ios.rb)
+  * [IOSXR](/lib/oxidized/model/iosxr.rb)
+  * [NGA](/lib/oxidized/model/cisconga.rb)
+  * [NXOS](/lib/oxidized/model/nxos.rb)
+  * [SMA](/lib/oxidized/model/ciscosma.rb)
+  * [SMB (Nikola series)](/lib/oxidized/model/ciscosmb.rb)
+  * [UCS](/lib/oxidized/model/ucs.rb)
+* Citrix
+  * [NetScaler (Virtual Applicance)](/lib/oxidized/model/netscaler.rb)
+* Coriant (former Tellabs)
+  * [TMOS (8800)](/lib/oxidized/model/corianttmos.rb)
+  * [8600](/lib/oxidized/model/coriant8600.rb)
+  * [Groove](/lib/oxidized/model/coriantgroove.rb)
+* Cumulus
+  * [Linux](/lib/oxidized/model/cumulus.rb)
+* DataCom
+  * [DmSwitch 3000](/lib/oxidized/model/datacom.rb)
+* DCN
+  * [DCN](/lib/oxidized/model/ios.rb) - Map this to ios.
+* DELL
+  * [PowerConnect](/lib/oxidized/model/powerconnect.rb)
+  * [AOSW](/lib/oxidized/model/aosw.rb)
+* D-Link
+  * [D-Link](/lib/oxidized/model/dlink.rb)
+* Ericsson/Redback
+  * [IPOS (former SEOS)](/lib/oxidized/model/ipos.rb)
+* Extreme Networks
+  * [Enterasys](/lib/oxidized/model/enterasys.rb)
+  * [WM](/lib/oxidized/model/mtrlrfs.rb)
+  * [XOS](/lib/oxidized/model/xos.rb)
+* F5
+  * [TMOS](/lib/oxidized/model/tmos.rb)
+* Fiberstore
+  * [S3800](/lib/oxidized/model/gcombnps.rb)
+* Force10
+  * [DNOS](/lib/oxidized/model/dnos.rb)
+  * [FTOS](/lib/oxidized/model/ftos.rb)
+* FortiGate
+  * [FortiOS](/lib/oxidized/model/fortios.rb)
+* Fujitsu
+  * [PRIMERGY Blade switch 1/10Gbe](/lib/oxidized/model/fujitsupy.rb)
+* GCOM Technologies
+  * [Broadband Network Platform Software](/lib/oxidized/model/gcombnps.rb)
+* Hatteras
+  * [Hatteras](/lib/oxidized/model/hatteras.rb)
+* Hirschmann
+  * [HiOS](/lib/oxidized/model/hirschmann.rb)
+* HP
+  * [Comware (HP A-series, H3C, 3Com)](/lib/oxidized/model/comware.rb)
+  * [Procurve](/lib/oxidized/model/procurve.rb)
+  * [BladeSystem (Onboard Administrator)](/lib/oxidized/model/hpebladesystem.rb)
+  * [MSA](/lib/oxidized/model/hpemsa.rb)
+* Huawei
+  * [VRP](/lib/oxidized/model/vrp.rb)
+* Juniper
+  * [JunOS](/lib/oxidized/model/junos.rb)
+  * [ScreenOS (Netscreen)](/lib/oxidized/model/screenos.rb)
+* Mellanox
+  * [MLNX-OS](/lib/oxidized/model/mlnxos.rb)
+  * [Voltaire](/lib/oxidized/model/voltaire.rb)
+* Mikrotik
+  * [RouterOS](/lib/oxidized/model/routeros.rb)
+* Motorola
+  * [RFS](/lib/oxidized/model/mtrlrfs.rb)
+* MRV
+  * [MasterOS](/lib/oxidized/model/masteros.rb)
+  * [FiberDriver](/lib/oxidized/model/fiberdriver.rb)
+* Netgear
+  * [Netgear](/lib/oxidized/model/netgear.rb)
+* Netonix
+  * [WISP Switch (As Netonix)](/lib/oxidized/model/netonix.rb)
+* Nokia (formerly TiMetra, Alcatel, Alcatel-Lucent)
+  * [SR OS (TiMOS)](/lib/oxidized/model/timos.rb)
+* OneAccess
+  * [OneOS](/lib/oxidized/model/oneos.rb)
+* Opengear
+  * [Opengear](/lib/oxidized/model/opengear.rb)
+* [OPNsense](/lib/oxidized/model/opnsense.rb)
+* Palo Alto
+  * [PANOS](/lib/oxidized/model/panos.rb)
+* [PLANET SG/SGS Switches](/lib/oxidized/model/planet.rb)
+* [pfSense](/lib/oxidized/model/pfsense.rb)
+* Radware
+  * [AlteonOS](/lib/oxidized/model/alteonos.rb)
+* Quanta
+  * [Quanta / VxWorks 6.6 (1.1.0.8)](/lib/oxidized/model/quantaos.rb)
+* Siklu
+  * [EtherHaul](/lib/oxidized/model/siklu.rb)
+* Supermicro
+  * [Supermicro](/lib/oxidized/model/supermicro.rb)
+* Symantec
+  * [Blue Coat ProxySG / Security Gateway OS (SGOS)](/lib/oxidized/model/sgos.rb)
+* Trango Systems
+  * [Trango](/lib/oxidized/model/trango.rb)
+* TPLink
+  * [TPLink](/lib/oxidized/model/tplink.rb)
+* Ubiquiti
+  * [AirOS](/lib/oxidized/model/airos.rb)
+  * [Edgeos](/lib/oxidized/model/edgeos.rb)
+  * [EdgeSwitch](/lib/oxidized/model/edgeswitch.rb)
+* Watchguard
+  * [Fireware OS](/lib/oxidized/model/firewareos.rb)
+* Westell
+  * [Westell 8178G, Westell 8266G](/lib/oxidized/model/weos.rb)
+* Zhone
+  * [Zhone (OLT and MX)](/lib/oxidized/model/zhoneolt.rb)
+* Zyxel
+  * [ZyNOS](/lib/oxidized/model/zynos.rb)


### PR DESCRIPTION
Lint markdown docs for consistency, introduce language hints on code blocks for syntax highlighting where missing, and correct a typo or two.