### PR TITLE
add removal of secrets in edgeos, vyatta

### DIFF
--- a/lib/oxidized/model/edgeos.rb
+++ b/lib/oxidized/model/edgeos.rb
@@ -9,6 +9,10 @@ class Edgeos < Oxidized::Model
   end
 
   cmd :secret do |cfg|
+    cfg.gsub! /encrypted-password (\S+).*/, 'encrypted-password <secret removed>'
+    cfg.gsub! /plaintext-password (\S+).*/, 'plaintext-password <secret removed>'
+    cfg.gsub! /password (\S+).*/, 'password <secret removed>'
+    cfg.gsub! /pre-shared-secret (\S+).*/, 'pre-shared-secret <secret removed>'
     cfg.gsub! /community (\S+) {/, 'community <hidden> {'
     cfg
   end

--- a/lib/oxidized/model/vyatta.rb
+++ b/lib/oxidized/model/vyatta.rb
@@ -9,6 +9,10 @@ class Vyatta < Oxidized::Model
   end
 
   cmd :secret do |cfg|
+    cfg.gsub! /encrypted-password (\S+).*/, 'encrypted-password <secret removed>'
+    cfg.gsub! /plaintext-password (\S+).*/, 'plaintext-password <secret removed>'
+    cfg.gsub! /password (\S+).*/, 'password <secret removed>'
+    cfg.gsub! /pre-shared-secret (\S+).*/, 'pre-shared-secret <secret removed>'
     cfg.gsub! /community (\S+) {/, 'community <hidden> {'
     cfg
   end


### PR DESCRIPTION
Fixes https://github.com/ytti/oxidized/issues/1221

There are probably more, such as the MD5 authentication for BGP, etc. I don't have that configured in my environment so I am unable to make sure it's right.

However, the ones below should cover the most high risk secrets

Tested on Ubiquiti EdgeRouter X and VyOS devices.