### PR TITLE
add secrets to sanitize in JunOS

### DIFF
--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -13,7 +13,9 @@ class JunOS < Oxidized::Model
   end
 
   cmd :secret do |cfg|
-    cfg.gsub!(/encrypted-password (\S+).*/, '<secret removed>')
+    cfg.gsub!(/encrypted-password (\S+).*/, 'encrypted-password <secret removed>')
+    cfg.gsub!(/pre-shared-key ascii-text (\S+).*/, 'pre-shared-key ascii-text <secret removed>')
+    cfg.gsub!(/authentication-key (\S+).*/, 'authentication-key <secret removed>')
     cfg.gsub!(/community (\S+) {/, 'community <hidden> {')
     cfg
   end

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -15,6 +15,7 @@ class JunOS < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub!(/encrypted-password (\S+).*/, 'encrypted-password <secret removed>')
     cfg.gsub!(/pre-shared-key ascii-text (\S+).*/, 'pre-shared-key ascii-text <secret removed>')
+    cfg.gsub!(/pre-shared-key hexadecimal (\S+).*/, 'pre-shared-key hexadecimal <secret removed>')
     cfg.gsub!(/authentication-key (\S+).*/, 'authentication-key <secret removed>')
     cfg.gsub!(/community (\S+) {/, 'community <hidden> {')
     cfg


### PR DESCRIPTION
- Fix the `encrypted-password` sanitization to keep the `encrypted-password` command
- Add `pre-shared-key` sanitization for `ascii-text` and `hexadecimal`
- Add `authentication-key` sanitization

I was able to test the encrypted-password and pre-shared-key, I do not currently run BGP within my homelab.

However I know it's just `authentication-key` as I've done it for peering requests in other environments.