### PR TITLE
Supermicro support refactor (extends #1036) 

### DIFF
--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -141,8 +141,7 @@
 * Supermicro
   * [SSE-G2252, G2252P](/lib/oxidized/model/edgecos.rb)
   * [SSE-G48-TG4, G24-TG4](/lib/oxidized/model/aricentiss.rb)
-  * [SSE-X24S, X24SR, X3348S, X3348SR, X3348T,
-  * X3348TR](/lib/oxidized/model/aricentiss.rb)
+  * [SSE-X24S, X24SR, X3348S, X3348SR, X3348T, X3348TR](/lib/oxidized/model/aricentiss.rb)
   * [SBM-GEM-X2C, GEM-X2C+, GEM-X3S+, XEM-X10SM](/lib/oxidized/model/aricentiss.rb)
 * Symantec
   * [Blue Coat ProxySG / Security Gateway OS (SGOS)](/lib/oxidized/model/sgos.rb)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -128,7 +128,8 @@
  * Siklu
    * [EtherHaul](lib/oxidized/model/siklu.rb)
  * Supermicro
-   * [Supermicro](lib/oxidized/model/supermicro.rb)
+   * [Supermicro](lib/oxidized/model/supermicro.rb): Known to work with the Supermicro SSE-G2252.
+   * [Supermicro2](lib/oxidized/model/supermicro2.rb): Known to work with the Supermicro SSE-G48-TG4.
  * Symantec
    * [Blue Coat ProxySG / Security Gateway OS (SGOS)](lib/oxidized/model/sgos.rb)
  * Trango Systems

--- a/lib/oxidized/model/aricentiss.rb
+++ b/lib/oxidized/model/aricentiss.rb
@@ -8,7 +8,7 @@ class AricentISS < Oxidized::Model
   prompt (/^(\e\[27m)?[ \r]*\w+# ?$/)
 
   cfg :ssh do
-    post_login 'no cli pagignation'
+    post_login 'no cli pagination'
     pre_logout 'exit'
   end
 

--- a/lib/oxidized/model/aricentiss.rb
+++ b/lib/oxidized/model/aricentiss.rb
@@ -1,3 +1,8 @@
+# Developed against:
+# #show version
+# Switch ID       Hardware Version                Firmware Version
+# 0               SSE-G48-TG4   (P2-01)           1.0.16-9
+
 class AricentISS < Oxidized::Model
 
   prompt (/^(\e\[27m)?[ \r]*\w+# ?$/)

--- a/lib/oxidized/model/supermicro.rb
+++ b/lib/oxidized/model/supermicro.rb
@@ -1,0 +1,7 @@
+# Backward compatibility shim for deprecated model `supermicro`.
+# Migrate your source from `supermicro` to `edgecos`.
+
+require_relative 'edgecos.rb'
+
+Supermicro = EdgeCOS
+

--- a/lib/oxidized/model/supermicro.rb
+++ b/lib/oxidized/model/supermicro.rb
@@ -5,3 +5,5 @@ require_relative 'edgecos.rb'
 
 Supermicro = EdgeCOS
 
+Oxidized.logger.warn "Using deprecated model supermicro, use edgecos instead."
+


### PR DESCRIPTION
_Change is largely cosmetic, but untested. Assumes correctness of base PR #1036._

* Renames `supermicro.rb` to `edgecos.rb` to reflect which os type is actually being supported.
* Introduces a backward compatibility shim `supermicro.rb` which links to `edgecos.rb`.
* Renames proposed `supermicro2.rb` from #1036 to `aricentiss.rb` to reflect which os type is actually being supported. No backward compatibility shim here as this support is brand new.
* Documents the modules supported by each of the two types.