### PR TITLE
AricentISS: Fix pagination for old OS versions

### DIFF
--- a/lib/oxidized/model/aricentiss.rb
+++ b/lib/oxidized/model/aricentiss.rb
@@ -8,7 +8,10 @@ class AricentISS < Oxidized::Model
   prompt (/^(\e\[27m)?[ \r]*\w+# ?$/)
 
   cfg :ssh do
+    # "pagination" was misspelled in some (earlier) versions (at least 1.0.16-9)
+    # 1.0.18-15 is known to include the corrected spelling
     post_login 'no cli pagination'
+    post_login 'no cli pagignation'
     pre_logout 'exit'
   end
 


### PR DESCRIPTION
Always issue both 'no cli pagination' and 'no cli pagignation'.

Conditionally issuing only the correct variant would require sending the
same number of commands to the switch ('show version', 'no cli
pagi(g)nation') and also require extra logic in the model.

Additionally, always issuing both removes the need for storing
information about what OS versions require which command in the model.