### PR TITLE
Alter DNOS config. Remove constantly changing info

### DIFF
--- a/lib/oxidized/model/dnos.rb
+++ b/lib/oxidized/model/dnos.rb
@@ -6,6 +6,7 @@ class DNOS  < Oxidized::Model
 
   cmd :all do |cfg|
     cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
+    cfg.gsub! /^Dell Networking OS uptime is\s.+/, '' # Omit constantly changing uptime info
     cfg.each_line.to_a[2..-2].join
   end
 
@@ -24,10 +25,6 @@ class DNOS  < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    comment cfg
-  end
-
-  cmd 'show system' do |cfg|
     comment cfg
   end
 


### PR DESCRIPTION
Gsub out the uptime which changes constantly, and remove the output of "show system" which duplicates the info from "show version" and contains fan speed data which isn't helpful (and causes a bunch of spurious commits)