### PR TITLE
Add logrotate file

### DIFF
--- a/extra/oxidized.logrotate
+++ b/extra/oxidized.logrotate
@@ -1,0 +1,7 @@
+/var/log/oxidized/*.log {
+    weekly
+    rotate 3
+    size 10M
+    compress
+    delaycompress
+}


### PR DESCRIPTION
Assuming `log:` is set to:

> log: /var/log/oxidized/<something>.log

/var/log/oxidized will need to be owned by the user running oxidized