### PR TITLE
Improve freebsd documentation (closes #1247)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ gem install oxidized-script oxidized-web
 
 ### FreeBSD
 
-[Use RVM to install Ruby v2.1.2](#installing-ruby-2.1.2-using-rvm), then install all required packages and gems:
+[Use RVM to install Ruby v2.1.2](#installing-ruby-212-using-rvm), then install all required packages and gems:
 
 ```shell
 pkg install cmake pkgconf

--- a/README.md
+++ b/README.md
@@ -95,14 +95,18 @@ gem install oxidized-script oxidized-web
 
 ### FreeBSD
 
-[Use RVM to install Ruby v2.1.2](#installing-ruby-2.1.2-using-rvm)
-
-Install all required packages and gems.
+[Use RVM to install Ruby v2.1.2](#installing-ruby-2.1.2-using-rvm), then install all required packages and gems:
 
 ```shell
 pkg install cmake pkgconf
 gem install oxidized
 gem install oxidized-script oxidized-web
+```
+
+Oxidized is also available via [FreeBSD ports](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=203374):
+
+```shell
+pkg install rubygem-oxidized rubygem-oxidized-script rubygem-oxidized-web
 ```
 
 ### Build from Git


### PR DESCRIPTION
Pending confirmation that the [upstream bug](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=227118) in the package is resolved. Updates documentation to reflect that a FreeBSD package is available as alternative to RVM + gems installation.