### PR TITLE
Fixed regexp error in dcnos.rb

### DIFF
--- a/lib/oxidized/model/dcnos.rb
+++ b/lib/oxidized/model/dcnos.rb
@@ -9,7 +9,7 @@ class DCNOS < Oxidized::Model
   comment '! '
 
   cmd 'show version' do |cfg|
-    cfg = cfg.gsub! /^(Uptime is ).*/, ''
+    cfg.gsub! /Uptime is.*/, ''
     comment cfg
   end
 


### PR DESCRIPTION
Fix error in regexp:

> 2018-04-05 13:25:02 UTC
> undefined method `gsub!' for nil:NilClass [NoMethodError]
> --------------------------------------------------
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/model/dcnos.rb:14:in `block in <class:DCNOS>'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/model/model.rb:94:in `instance_exec'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/model/model.rb:94:in `cmd'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/model/model.rb:136:in `block in get'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/model/model.rb:135:in `each'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/model/model.rb:135:in `get'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/input/cli.rb:14:in `get'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/node.rb:65:in `run_input'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/node.rb:42:in `block in run'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/node.rb:37:in `each'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/node.rb:37:in `run'
> /var/lib/gems/2.1.0/gems/oxidized-0.21.0/lib/oxidized/job.rb:9:in `block in initialize'