### PR TITLE
standardize on verbose hash methods

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -1033,17 +1033,6 @@ Style/PerlBackrefs:
     - 'lib/oxidized/model/junos.rb'
     - 'lib/oxidized/model/powerconnect.rb'
 
-# Offense count: 5
-# Cop supports --auto-correct.
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: short, verbose
-Style/PreferredHashMethods:
-  Exclude:
-    - 'lib/oxidized/manager.rb'
-    - 'lib/oxidized/source/csv.rb'
-    - 'lib/oxidized/source/http.rb'
-    - 'lib/oxidized/source/sql.rb'
-
 # Offense count: 1
 # Cop supports --auto-correct.
 Style/Proc:

--- a/lib/oxidized/manager.rb
+++ b/lib/oxidized/manager.rb
@@ -49,13 +49,13 @@ module Oxidized
       @model.merge! _model
     end
     def add_source _source
-      return nil if @source.key? _source
+      return nil if @source.has_key? _source
       _source = Manager.load Config::SourceDir, _source
       return false if _source.empty?
       @source.merge! _source
     end
     def add_hook _hook
-      return nil if @hook.key? _hook
+      return nil if @hook.has_key? _hook
       name = _hook
       _hook = Manager.load File.join(Config::Root, 'hook'), name
       _hook = Manager.load Config::HookDir, name if _hook.empty?

--- a/lib/oxidized/source/csv.rb
+++ b/lib/oxidized/source/csv.rb
@@ -36,7 +36,7 @@ class CSV < Source
       @cfg.map.each do |key, position|
         keys[key.to_sym] = node_var_interpolate data[position]
       end
-      keys[:model] = map_model keys[:model] if keys.key? :model
+      keys[:model] = map_model keys[:model] if keys.has_key? :model
 
       # map node specific vars
       vars = {}

--- a/lib/oxidized/source/http.rb
+++ b/lib/oxidized/source/http.rb
@@ -43,7 +43,7 @@ class HTTP < Source
         want_positions = want_position.split('.')
         keys[key.to_sym] = node_var_interpolate node.dig(*want_positions)
       end
-      keys[:model] = map_model keys[:model] if keys.key? :model
+      keys[:model] = map_model keys[:model] if keys.has_key? :model
 
       # map node specific vars
       vars = {}

--- a/lib/oxidized/source/sql.rb
+++ b/lib/oxidized/source/sql.rb
@@ -27,7 +27,7 @@ class SQL < Source
       # map node parameters
       keys = {}
       @cfg.map.each { |key, sql_column| keys[key.to_sym] = node_var_interpolate node[sql_column.to_sym] }
-      keys[:model] = map_model keys[:model] if keys.key? :model
+      keys[:model] = map_model keys[:model] if keys.has_key? :model
 
       # map node specific vars
       vars = {}


### PR DESCRIPTION
While there is some [discussion](https://bugs.ruby-lang.org/issues/10177) about `has_key` and `has_value` methods, the bulk of oxidized codebase currently uses these verbose variants. This eliminates the few short variants currently in use to make the entire codebase consistent.

Passes `Rubocop` with:
```yaml
Style/PreferredHashMethods:
  EnforcedStyle: verbose
```