### PR TITLE
Disable paging for "show full-configuration" on FortiOS

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -49,7 +49,7 @@ class FortiOS < Oxidized::Model
 
 cfg << cmd('end') if @vdom_enabled
 
-    cfg << cmd('show full-configuration')
+    cfg << cmd('show full-configuration | grep .')
     cfg.join "\n"
   end
 


### PR DESCRIPTION
Disable output paging on FortiOS, speeding up the execution and avoiding job timeouts when using SSH.

New take on PR #894 without changing the device configuration.
