### PR TITLE
model/netgear.rb support for older models

### DIFF
--- a/docs/Model-Notes/Netgear.md
+++ b/docs/Model-Notes/Netgear.md
@@ -38,9 +38,9 @@ The main differences are:
 
 Configuration for older/newer models: make sure you have defined variable 'enable':
 - `'true'` for newer models
-- `''` empty strgng: for older models
+- `''` empty string: for older models
 
-One possoble configuration:
+One possible configuration:
 - oxidized config
 ```
 source:

--- a/docs/Model-Notes/Netgear.md
+++ b/docs/Model-Notes/Netgear.md
@@ -1,0 +1,66 @@
+Netgear Configuration
+=====================
+
+There are several models available with CLI management via telnet (port 60000), but they all behave like one of the following:
+- older models:
+```
+Connected to 192.168.3.201.
+
+(GS748Tv4) 
+Applying Interface configuration, please wait ...admin
+Password:********
+(GS748Tv4) >enable
+Password:
+
+(GS748Tv4) #terminal length 0
+
+(GS748Tv4) #show running-config
+```
+
+- newer models:
+```
+Connected to 172.0.3.203.
+
+User:admin
+Password:********
+(GS724Tv4) >enable
+
+(GS724Tv4) #terminal length 0
+
+(GS724Tv4) #show running-config
+```
+
+The main differences are:
+- the prompt for username is different (looks quite strange for older models)
+- enable password
+  - the older model prompts for enable password and it expects empty string
+  - the newer model does not prompt for enable password at all
+
+Configuration for older/newer models: make sure you have defined variable 'enable':
+- `'true'` for newer models
+- `''` empty strgng: for older models
+
+One possoble configuration:
+- oxidized config
+```
+source:
+  default: csv
+  csv:
+    file: "/home/oxidized/.config/oxidized/router.db"
+    delimiter: !ruby/regexp /:/
+    map:
+      name: 0
+      model: 1
+      username: 2
+      password: 3
+    vars_map:
+      enable: 4
+      telnet_port: 5
+```
+- router.db
+```
+switchOldFW:netgear:admin:adminpw::60000
+switchNewFW:netgear:admin:adminpw:true:60000
+```
+
+[Reference](https://github.com/ytti/oxidized/pull/1268)

--- a/docs/Model-Notes/README.md
+++ b/docs/Model-Notes/README.md
@@ -12,6 +12,7 @@ AireOS|[AireOS](AireOS.md)|29 Nov 2017
 Arbor Networks|[ArbOS](ArbOS.md)|27 Feb 2018
 Huawei|[VRP](VRP-Huawei.md)|17 Nov 2017
 Juniper|[MX/QFX/EX/SRX/J Series](JunOS.md)|18 Jan 2018
+Netgear|[Netgear](Netgear.md)|11 Apr 2018
 Zyxel|[XGS4600 Series](XGS4600-Zyxel.md)|23 Jan 2018
 
 If you discover additional caveats or problems please make sure to consult the [GitHub issues for oxidized](https://github.com/ytti/oxidized/issues) known issues.

--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -1,7 +1,7 @@
 class Netgear < Oxidized::Model
 
   comment '!'
-  prompt /^(\([\w\s-.]+\)\s[#>])$/
+  prompt /^(\([\w\s\-.]+\)\s[#>])$/
 
   cmd :secret do |cfg|
     cfg.gsub!(/password (\S+)/, 'password <hidden>')

--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -1,15 +1,16 @@
 class Netgear < Oxidized::Model
 
   comment '!'
-  prompt /^(\([\w\-.]+\)\s[#>])$/
+  prompt /^(\([\w\s-.]+\)\s[#>])$/
 
   cmd :secret do |cfg|
     cfg.gsub!(/password (\S+)/, 'password <hidden>')
+    cfg.gsub!(/encrypted (\S+)/, 'encrypted <hidden>')
     cfg
   end
 
   cfg :telnet do
-    username /^User:/
+    username /^(User:|Applying Interface configuration, please wait ...)/
   end
 
   cfg :telnet, :ssh do


### PR DESCRIPTION
Hi,
At first, thanks for this nice piece of software.

This pull request will add support for older models with FW version 5.x.y.z, like GS110TP, GS748v4.
- accepts spaces in prompt as the default prompt is '(Broadcom FASTPATH Switching)' without quotes
- hides password hashes following 'encrypted' as the config line looks as follows:
`users passwd "admin" encrypted 0b4....5d3`
unlike the newer fw versions:
`username "admin" password 335....2df level 15 encrypted`
- expects either 'User:' or 'Applying Interface configuration, please wait ...' as request for entering username. The later looks strange, but that is how it is.

It has been tested with following devices:
GS110TP fw 5.4.2.30 (latest available)
GS748Tv4H1 fw 5.4.2.27 (not latest)
Original function tested with:
GS724Tv4 fw 6.3.1.16 (latest available)
GS748Tv5 fw 6.3.1.16 (latest available)

This is how I configured my Netgear devices with old/new FW in:
- oxidized config:
```
    map:
      name: 0
      model: 1
      username: 2
      password: 3
    vars_map:
      enable: 4
      telnet_port: 5
```
- router.db
```
switchOldFW:netgear:admin:adminpw::60000
switchNewFW:netgear:admin:adminpw:true:60000
```
Note that both older and newer fw versions need 'enable', but:
- the older model prompts for 'Password:' and expects empty password (enable='')
- newer model does not prompt for password at all. (enable=true)