### PR TITLE
ensure asetus is initialized in cli_spec.rb

### DIFF
--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -2,8 +2,14 @@ require 'spec_helper'
 require 'oxidized/cli'
 
 describe Oxidized::CLI do
-  before { @original = ARGV }
-  after  { ARGV.replace @original }
+  before(:each) do 
+    @original = ARGV 
+    Oxidized.asetus = Asetus.new 
+  end
+  
+  after(:each) do
+    ARGV.replace @original
+  end
 
   %w[-v --version].each do |option|
     describe option do


### PR DESCRIPTION
ensure asetus is initialized during Oxidized::CLI tests so that the test does not randomly fail under unusual execution order