### PR TITLE
Add keepalive => true to the ssh_opt.

### DIFF
--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -28,6 +28,7 @@ module Oxidized
       ssh_opts = {
                 :port => port.to_i,
                 :password => @node.auth[:password], :timeout => Oxidized.config.timeout,
+                :keepalive => true,
                 :paranoid => secure,
                 :auth_methods => %w(none publickey password keyboard-interactive),
                 :number_of_password_prompts => 0,

--- a/spec/input/ssh_spec.rb
+++ b/spec/input/ssh_spec.rb
@@ -28,7 +28,7 @@ describe Oxidized::SSH do
 
       proxy = mock()
       Net::SSH::Proxy::Command.expects(:new).with("ssh test.com -W %h:%p").returns(proxy)
-      Net::SSH.expects(:start).with('93.184.216.34', 'alma', {:port => 22, :password => 'armud', :timeout => Oxidized.config.timeout,
+      Net::SSH.expects(:start).with('93.184.216.34', 'alma', {:port => 22, :password => 'armud', :timeout => Oxidized.config.timeout, :keepalive => true,
                                     :paranoid => Oxidized.config.input.ssh.secure, :auth_methods => ['none', 'publickey', 'password', 'keyboard-interactive'],
                                     :number_of_password_prompts => 0, :proxy => proxy})
 


### PR DESCRIPTION
This will help to detect SSH sessions that zombie out at the protocol level by sending SSH Keepalives on the session.

This has been tested in a production environment for 3-weeks.

This may be the reason that oxidized 'slows down' by having worker thread slots occupied by wedged and non-productive SSH sessions. Discussion in https://github.com/ytti/oxidized/issues/887

Even if this is not the core of the problem mentioned in #887 - it is a good thing to have active.
