### PR TITLE
remove mention of ruby 1.9.3 from CentOS instructions in favor of 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ gem install oxidized-script oxidized-web # if you don't install oxidized-web, ma
 
 ### CentOS, Oracle Linux, Red Hat Linux
 
-On CentOS 6 / RHEL 6, install Ruby greater than 1.9.3 (for Ruby 2.1.2 installation instructions see [Installing Ruby 2.1.2 using RVM](#installing-ruby-212-using-rvm)), then install Oxidized dependencies
+On CentOS 6 / RHEL 6, install Ruby 2.0 or greater (for Ruby 2.1.2 installation instructions see [Installing Ruby 2.1.2 using RVM](#installing-ruby-212-using-rvm)), then install Oxidized dependencies
 
 ```shell
 yum install cmake sqlite-devel openssl-devel libssh2-devel


### PR DESCRIPTION
Rubies under 2.0.0 are not supported since Oxidized 0.13.0