### PR TITLE
Basic support for NDMS OS (Zyxel Keenetic)

### DIFF
--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -163,3 +163,4 @@
   * [Zhone (OLT and MX)](/lib/oxidized/model/zhoneolt.rb)
 * Zyxel
   * [ZyNOS](/lib/oxidized/model/zynos.rb)
+  * [NDMS](/lib/oxidized/model/ndms.rb)

--- a/lib/oxidized/model/ndms.rb
+++ b/lib/oxidized/model/ndms.rb
@@ -1,0 +1,25 @@
+class NDMS < Oxidized::Model
+
+  # Pull config from Zyxel Keenetic devices from version NDMS >= 2.0
+
+  comment  '! '
+
+  prompt /^([\w.@()-]+[#>]\s?)/m
+
+  cmd 'show version' do |cfg|
+    cfg = cfg.each_line.to_a[1..-3].join
+    comment cfg
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg = cfg.each_line.to_a[1..-2]
+    cfg = cfg.reject { |line| line.match /(clock date|checksum)/ }.join
+    cfg
+  end
+
+  cfg :telnet do
+    username /^Login:/
+    password /^Password:/
+    pre_logout 'exit'
+  end
+end


### PR DESCRIPTION
**supported devices:**

- Keenetic 4G (KN-1210)
- Keenetic Giga (KN-1010)
- Keenetic Lite (KN-1310)
- Keenetic Omni (KN-1410)
- Keenetic Start (KN-1110)
- Zyxel Keenetic
- Zyxel Keenetic II
- Zyxel Keenetic III
- Zyxel Keenetic 4G
- Zyxel Keenetic 4G Rev.B
- Zyxel Keenetic 4G II
- Zyxel Keenetic 4G III
- Zyxel Keenetic 4G III Rev.B
- Zyxel Keenetic Air
- Zyxel Keenetic DSL
- Zyxel Keenetic Extra
- Zyxel Keenetic Extra II
- Zyxel Keenetic Giga
- Zyxel Keenetic Giga II
- Zyxel Keenetic Giga III
- Zyxel Keenetic Lite
- Zyxel Keenetic Lite Rev.B
- Zyxel Keenetic Lite II
- Zyxel Keenetic Lite III
- Zyxel Keenetic Lite III Rev.B
- Zyxel Keenetic LTE
- Zyxel Keenetic Omni
- Zyxel Keenetic Omni II
- Zyxel Keenetic Start
- Zyxel Keenetic Start II
- Zyxel Keenetic Ultra
- Zyxel Keenetic Ultra II
- Zyxel Keenetic Viva
- Zyxel Keenetic VOX
