### PR TITLE
Change the debug SSH log fsync to a flush

### DIFF
--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -100,7 +100,7 @@ module Oxidized
         ch.on_data do |_ch, data|
           if Oxidized.config.input.debug?
             @log.print data
-            @log.fsync
+            @log.flush
           end
           @output << data
           @output = @node.model.expects @output


### PR DESCRIPTION
`fsync` can be expensive due to blocking on OSes and induce timeout failures when running with input debugging of SSH sessions. 

Calling it each time the SSH channel gets data (a chunk of configuration) is a bit excessive.

This was noticed when setting up a dev environment and running a few simple devices with SSH input set for `debug: true`.

This caused timeouts (with a `timeout: 90`) for a device that has a large basic configuration (*cough* Fortigate *cough*). 

By changing the `fsync` to a `flush` - this reduced the time from hitting the 90sec timeout to finishing in 13seconds. This was measured from the `post_login` log event to the `pre_logout` log event.

 This was with a ~13K line configuration file with no other changes needed. The server was otherwise idle / normal server.

The flush should at least make the data leave the Ruby IO layer and get to the OS layer and make it available to other processes (Think of `tail -f logfile`). 

A test without the `fsync` or `flush` showed that the time to run was reduced to about 12-seconds. So about the same.

This is also very helpful to prevent accidental causes of timeouts when running under SSH input debug mode - which is commonly suggested to debug prompts and other model problems.

This should have minimal collateral impact.

