### PR TITLE
Feature - config masking

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -499,7 +499,7 @@ Lint/Void:
 
 # Offense count: 60
 Metrics/AbcSize:
-  Max: 84
+  Max: 88
 
 # Offense count: 15
 # Configuration parameters: CountComments, ExcludedMethods.

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -18,6 +18,29 @@ input:
     secure: false
 ```
 
+## Password Masking in Debug Logs
+
+By default Oxidized will no longer log cleartext passwords in debug logs. This is designed to prevent Oxidized debug logs from containing all of your node authentication information. This makes submitting [GitHub issues for oxidized](https://github.com/ytti/oxidized/issues) and sharing debug logs easier and safer for everyone.
+
+NOTE - This only applies to the configuration of Oxidized itself - NOT any fetched device configurations. Model-specific code is used for model-specific configuration sanitization (see Removing secrets below).
+
+The value for `password` will instead be logged as `********`.
+
+These settings can be controlled by the global section in the Oxidized configuration file.
+
+```yaml
+..(other global configuration)...
+mask_value: "<Redacted by Security Directive 1234>"
+```
+
+If you need to log authentication information in your debug logs you can make the following adjustments:
+
+```yaml
+..(other global configuration)...
+mask_sensitive: false
+```
+
+
 ## Privileged mode
 
 To start privileged mode before pulling the configuration, Oxidized needs to send the enable command. You can globally enable this, by adding the following snippet to the global section of the configuration file.

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -28,7 +28,10 @@ module Oxidized
       asetus.default.retries       = 3
       asetus.default.prompt        = /^([\w.@-]+[#>]\s?)$/
       asetus.default.rest          = '127.0.0.1:8888' # or false to disable
-      asetus.default.next_adds_job = false            # if true, /next adds job, so device is fetched immmeiately
+      asetus.default.next_adds_job = false            # if true, /next adds job, so device is fetched immediately
+      asetus.default.mask_sensitive= true             # True to mask sensitive configuration fields from log output/display
+      asetus.default.mask_fields   = /^(password)$/i  # Our default regexp of configuration fields to mask
+      asetus.default.mask_value    = '*' * 8          # What we mask the sensitive configuration fields with
       asetus.default.vars          = {}               # could be 'enable'=>'enablePW'
       asetus.default.groups        = {}               # group level configuration
       asetus.default.models        = {}               # model level configuration

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -219,19 +219,19 @@ module Oxidized
         end
       end
 
-      Oxidized.logger.debug "node.rb: resolving node key '#{key}', with passed global value of '" + (is_key_masked ? "#{masked_value}" : "#{value}") + "' and node value '" + (is_key_masked ? "#{masked_value}" : "#{opt[key_sym]}") + "'"
+      Oxidized.logger.debug "node.rb: resolving node key '#{key}', with passed global value of '" + (is_key_masked ? masked_value.to_s : value.to_s) + "' and node value '" + (is_key_masked ? masked_value.to_s : opt[key_sym].to_s) + "'"
 
       #global
       if not value and Oxidized.config.has_key?(key_str)
         value = Oxidized.config[key_str]
-        Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '" + (is_key_masked ? "#{masked_value}" : "#{value}") + "' from global"
+        Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '" + (is_key_masked ? masked_value.to_s : value.to_s) + "' from global"
       end
 
       #group
       if Oxidized.config.groups.has_key?(@group)
         if Oxidized.config.groups[@group].has_key?(key_str)
           value = Oxidized.config.groups[@group][key_str]
-          Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '" + (is_key_masked ? "#{masked_value}" : "#{value}") + "' from group"
+          Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '" + (is_key_masked ? masked_value.to_s : value.to_s) + "' from group"
         end
       end
 
@@ -240,13 +240,13 @@ module Oxidized
       if Oxidized.config.models.has_key?(@model.class.name.to_s.downcase)
         if Oxidized.config.models[@model.class.name.to_s.downcase].has_key?(key_str)
           value = Oxidized.config.models[@model.class.name.to_s.downcase][key_str]
-          Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '" + (is_key_masked ? "#{masked_value}" : "#{value}") + "' from model"
+          Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '" + (is_key_masked ? masked_value.to_s : value.to_s) + "' from model"
         end
       end
 
       #node
       value = opt[key_sym] || value
-      Oxidized.logger.debug "node.rb: returning node key '#{key}' with value '" + (is_key_masked ? "#{masked_value}" : "#{value}") + "'"
+      Oxidized.logger.debug "node.rb: returning node key '#{key}' with value '" + (is_key_masked ? masked_value.to_s : value.to_s) + "'"
       value
     end
 


### PR DESCRIPTION
Implement basic config field masking for the `password` field.

The goal is to increase the safety of debugging by prevent the logging of the password unless the end-user disables the masking with `mask_sensitive: false` in the configuration.

This helps to keep debug logs a little cleaner from sensitive information and requiring less sanitization before opening Issues/etc. 

This sets the default behavior to `true` (masking enabled).  As debugging is not a feature enabled by default - this should have minimal collateral impact on the installed-base.

This is for Oxidized configuration only - this isn't about the device configurations - that belongs in model-specific areas with `remove_secret`. 

I used a regex to match the fields - it could also be adjusted to an array if that is preference. 
