### PR TITLE
implement probot no-response

### DIFF
--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,0 +1,13 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 14
+# Label requiring a response
+responseRequiredLabel: user_pending 
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >
+  This issue has been automatically closed because there has been no response
+  to our request for more information from the original author. The information 
+  that is currently in the issue is insufficient to take further action.
+  Feel free to re-open this issue if additional information becomes available,
+  or if you believe it has been closed in error.

--- a/.github/no-response.yml
+++ b/.github/no-response.yml
@@ -1,7 +1,7 @@
 # Configuration for probot-no-response - https://github.com/probot/no-response
 
 # Number of days of inactivity before an Issue is closed for lack of response
-daysUntilClose: 14
+daysUntilClose: 21
 # Label requiring a response
 responseRequiredLabel: user_pending 
 # Comment to post when closing an Issue for lack of response. Set to `false` to disable


### PR DESCRIPTION
Configuration for the [Probot: no-response](https://github.com/probot/no-response) GitHub app that automatically closes issues tagged with `user_pending` after 21 days if they haven't received any feedback from the original author.

Requires a collaborator to activate the GitHub App at https://github.com/apps/no-response