### PR TITLE
Updated HPE Comware - Issue #611 Fix

### DIFF
--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -38,6 +38,9 @@ class Comware < Oxidized::Model
         send "_cmdline-mode on\n"
         send "y\n"
         send vars(:comware_cmdline) + "\n"
+        send "xtd-cli-mode on\n"
+        send "y\n"
+        send vars(:comware_cmdline) + "\n"
       end
     end
 


### PR DESCRIPTION
This change works for newer HPE Comware model switches and *shouldn't* cause any issues with the previous Comware models although past functionality hasn't been tested as I don't have an older model.