### PR TITLE
Capability to pipe diffs into post_store exec hooks, misc bug fixes

### DIFF
--- a/bin/oxidized
+++ b/bin/oxidized
@@ -8,6 +8,6 @@ begin
   Oxidized::CLI.new.run
 rescue => error
   warn "#{error}"
-  debug = Oxidied.config.debug rescue true
+  debug = Oxidized.config.debug rescue true
   raise if debug
 end

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -18,7 +18,7 @@ Following configuration keys need to be defined for all hooks:
 
 ## Hook type: exec
 
-The `exec` hook type allows users to run an arbitrary shell command or a binary when triggered.
+The `exec` hook type allows users to run an arbitrary shell command or a binary when triggered. The config diff may optionally be piped to standard input of such command.
 
 The command is executed on a separate child process either in synchronous or asynchronous fashion. Non-zero exit values cause errors to be logged. STDOUT and STDERR are currently not collected.
 
@@ -43,6 +43,7 @@ Exec hook recognizes the following configuration keys:
 * `timeout`: hard timeout (in seconds) for the command execution. SIGTERM will be sent to the child process after the timeout has elapsed. Default: `60`
 * `async`: Execute the command in an asynchronous fashion. The main thread by default will wait for the hook command execution to complete. Set this to `true` for long running commands so node configuration pulls are not blocked. Default: `false`
 * `cmd`: command to run.
+* `diff`: Pipe the config diff to STDIN of the command being executed. Only applies to post\_store events. Default: `false`
 
 ### exec hook configuration example
 
@@ -57,6 +58,13 @@ hooks:
     events: [post_store, node_fail]
     cmd: 'echo "Doing long running stuff for $OX_NODE_NAME" >> /tmp/ox_node_stuff.log; sleep 60'
     async: true
+    timeout: 120
+  name_for_example_hook_with_pipe:
+    type: exec
+    events: [post_store]
+    cmd: 'cat /dev/stdin >> /tmp/test_diff.txt'
+    async: true
+    diff: true
     timeout: 120
 ```
 

--- a/lib/oxidized/model/nxos.rb
+++ b/lib/oxidized/model/nxos.rb
@@ -2,6 +2,11 @@ class NXOS < Oxidized::Model
   prompt /^(\r?[\w.@_()-]+[#]\s?)$/
   comment '! '
 
+  def filter cfg
+    cfg.gsub! /\r\n?/, "\n"
+    cfg.gsub! prompt, ''
+  end
+
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(snmp-server user (\S+) (\S+) auth (\S+)) (\S+) (priv) (\S+)/, '\\1 <configuration removed> '
@@ -11,16 +16,21 @@ class NXOS < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
+    cfg = filter cfg
     cfg = cfg.each_line.take_while { |line| not line.match(/uptime/i) }
     comment cfg.join ""
   end
 
   cmd 'show inventory' do |cfg|
+    cfg = filter cfg
     comment cfg
   end
 
   cmd 'show running-config' do |cfg|
+    cfg = filter cfg
+    cfg.gsub! /^(show run.*)$/, '! \1'
     cfg.gsub! /^!Time:[^\n]*\n/, ''
+    cfg.gsub! /^[\w.@_()-]+[#].*$/, ''
     cfg
   end
 

--- a/lib/oxidized/node/stats.rb
+++ b/lib/oxidized/node/stats.rb
@@ -14,6 +14,11 @@ module Oxidized
         @stats[job.status] ||= []
         @stats[job.status].shift if @stats[job.status].size > MAX_STAT
         @stats[job.status].push stat
+        if job.status.equal? :success
+          @stats[:success_count] += 1
+        else
+          @stats[:failure_count] += 1
+        end
       end
 
       # @param [Symbol] status stats for specific status
@@ -26,6 +31,8 @@ module Oxidized
 
       def initialize
         @stats = {}
+        @stats[:success_count] = 0
+        @stats[:failure_count] = 0
       end
     end
   end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -41,6 +41,28 @@ describe Oxidized::Node do
       status, = @node.run
       status.must_equal :success
     end
+    it 'should record the success' do
+      stub_oxidized_ssh
+
+      before_successes = @node.stats.get(:success_count)
+      j = Oxidized::Job.new @node
+      j.join
+      @node.stats.add j
+      after_successes = @node.stats.get(:success_count)
+      successes = after_successes - before_successes
+      successes.must_equal 1
+    end
+    it 'should record a failure' do
+      stub_oxidized_ssh_fail
+
+      before_fails = @node.stats.get(:failure_count)
+      j = Oxidized::Job.new @node
+      j.join
+      @node.stats.add j
+      after_fails = @node.stats.get(:failure_count)
+      fails = after_fails - before_fails
+      fails.must_equal 1
+    end
   end
 
   describe '#repo' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,12 @@ def stub_oxidized_ssh
   Oxidized::SSH.any_instance.stubs(:disconnect).returns(true)
   Oxidized::SSH.any_instance.stubs(:disconnect_cli).returns(true)
 end
+
+def stub_oxidized_ssh_fail
+  Oxidized::SSH.any_instance.stubs(:connect).returns(false)
+  Oxidized::SSH.any_instance.stubs(:node).returns(@node)
+  Oxidized::SSH.any_instance.expects(:cmd).never
+  Oxidized::SSH.any_instance.stubs(:connect_cli).returns(false)
+  Oxidized::SSH.any_instance.stubs(:disconnect).returns(false)
+  Oxidized::SSH.any_instance.stubs(:disconnect_cli).returns(false)
+end


### PR DESCRIPTION
This PR implements the following changes:

* Adds the optional capability to pipe the config diff to standard input of handler scripts/binaries in the exec hook.

* Adds additional counter variables to allow the config download success and failure count to remain accurate beyond  the 11th run.

* Postprocessing of NXOS configs to have consistent Unix style line endings, remove lines containing exclusively a prompt, and comment all non-configuration lines. This allows the configuration taken from Oxidized to be directly supplied to a switch to revert to a specific version.

* Documentation of changes to the exec hook.