### PR TITLE
transition from TimeoutError to Timeout::Error

### DIFF
--- a/lib/oxidized/hook/exec.rb
+++ b/lib/oxidized/hook/exec.rb
@@ -52,11 +52,11 @@ class Exec < Oxidized::Hook
         raise msg
       end
     end
-  rescue TimeoutError
+  rescue Timeout::Error
     kill "TERM", pid
     msg = "#{@cmd} timed out"
     log msg, :error
-    raise TimeoutError, msg
+    raise Timeout::Error, msg
   end
 
   def make_env ctx

--- a/lib/oxidized/input/telnet.rb
+++ b/lib/oxidized/input/telnet.rb
@@ -102,7 +102,7 @@ class Net::Telnet
     rest = ''
     until prompt === line and not IO::select([@sock], nil, nil, waittime)
       unless IO::select([@sock], nil, nil, time_out)
-        raise TimeoutError, "timed out while waiting for more data"
+        raise Timeout::Error, "timed out while waiting for more data"
       end
       begin
         c = @sock.readpartial(1024 * 1024)


### PR DESCRIPTION
Avoids recent Ruby from throwing deprecation warnings.

https://bugs.ruby-lang.org/issues/11398