### PR TITLE
model: Added IOSXE model which uses IOS model

### DIFF
--- a/lib/oxidized/model/iosxe.rb
+++ b/lib/oxidized/model/iosxe.rb
@@ -1,0 +1,5 @@
+# IOS parser should work here
+
+require_relative 'ios.rb'
+
+IOSXE = IOS


### PR DESCRIPTION
Fixes: #1118

I'm not fussed if this makes it in but as I saw the deprecated PR, seemed like this is one option to alias one model to another without requiring mapping within config files.

Feel free to close or merge :)