### PR TITLE
Introduce resolve_dns knob (closes #599)

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -214,3 +214,13 @@ next_adds_job: true
 ```
 
 This will allow for a more timely fetch of the device configuration.
+
+## Disabling DNS resolution
+
+In some instances it might not be desirable to attempt to resolve names of nodes. One such use case is when nodes are accessed through an SSH proxy, where the remote end resolves the names differently than the host on which Oxidized runs would.
+
+Names can instead be passed verbatim to the input:
+
+```yaml
+resolve_dns: false
+```

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -20,7 +20,7 @@ module Oxidized
       asetus.default.username      = 'username'
       asetus.default.password      = 'password'
       asetus.default.model         = 'junos'
-      asetus.default.resolve_dns   = true     # if false, don't resolve DNS to IP
+      asetus.default.resolve_dns   = true # if false, don't resolve DNS to IP
       asetus.default.interval      = 3600
       asetus.default.use_syslog    = false
       asetus.default.debug         = false

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -20,6 +20,7 @@ module Oxidized
       asetus.default.username      = 'username'
       asetus.default.password      = 'password'
       asetus.default.model         = 'junos'
+      asetus.default.resolve_dns   = true     # if false, don't resolve DNS to IP
       asetus.default.interval      = 3600
       asetus.default.use_syslog    = false
       asetus.default.debug         = false

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -15,7 +15,8 @@ module Oxidized
       ip_addr, _ = opt[:ip].to_s.split("/")
       Oxidized.logger.debug 'IPADDR %s' % ip_addr.to_s
       @name           = opt[:name]
-      @ip             = IPAddr.new(ip_addr).to_s rescue nil
+      @ip             = @name unless Oxidized.config.resolve_dns?
+      @ip           ||= IPAddr.new(ip_addr).to_s rescue nil
       @ip           ||= Resolv.new.getaddress @name
       @group          = opt[:group]
       @input          = resolve_input opt

--- a/spec/input/ssh_spec.rb
+++ b/spec/input/ssh_spec.rb
@@ -8,17 +8,19 @@ describe Oxidized::SSH do
     Oxidized::Node.any_instance.stubs(:resolve_repo)
     Oxidized::Node.any_instance.stubs(:resolve_input)
     Oxidized::Node.any_instance.stubs(:resolve_output)
-    @node = Oxidized::Node.new(name: 'example.com',
-                               input: 'ssh',
-                               output: 'git',
-                               model: 'junos',
-                               username: 'alma',
-                               password: 'armud',
-                               vars: { ssh_proxy: 'test.com' })
   end
 
   describe "#connect" do
-    it "should use proxy command when proxy host given" do
+    it "should use proxy command when proxy host given and connect by ip if resolve_dns is true" do
+      Oxidized.config.resolve_dns = true
+      @node = Oxidized::Node.new(name: 'example.com',
+                                 input: 'ssh',
+                                 output: 'git',
+                                 model: 'junos',
+                                 username: 'alma',
+                                 password: 'armud',
+                                 vars: { ssh_proxy: 'test.com' })
+
       ssh = Oxidized::SSH.new
 
       model = mock
@@ -35,6 +37,37 @@ describe Oxidized::SSH do
                                                               password: 'armud',
                                                               number_of_password_prompts: 0,
                                                               auth_methods: %w[none publickey password])
+
+      ssh.instance_variable_set("@exec", true)
+      ssh.connect(@node)
+    end
+
+    it "should use proxy command when proxy host given and connect by name if resolve_dns is false" do
+      Oxidized.config.resolve_dns = false
+      @node = Oxidized::Node.new(name: 'example.com',
+                                 input: 'ssh',
+                                 output: 'git',
+                                 model: 'junos',
+                                 username: 'alma',
+                                 password: 'armud',
+                                 vars: { ssh_proxy: 'test.com' })
+
+      ssh = Oxidized::SSH.new
+
+      model = mock
+      model.expects(:cfg).returns('ssh' => [])
+      @node.expects(:model).returns(model).at_least_once
+
+      proxy = mock
+      Net::SSH::Proxy::Command.expects(:new).with("ssh test.com -W %h:%p").returns(proxy)
+      Net::SSH.expects(:start).with('example.com', 'alma',  port:      22,
+                                                            timeout:   Oxidized.config.timeout,
+                                                            paranoid:  Oxidized.config.input.ssh.secure,
+                                                            keepalive: true,
+                                                            proxy:     proxy,
+                                                            password: 'armud',
+                                                            number_of_password_prompts: 0,
+                                                            auth_methods: %w[none publickey password])
 
       ssh.instance_variable_set("@exec", true)
       ssh.connect(@node)


### PR DESCRIPTION
Based off the `no-resolve` branch that was created to address #599 but never had a chance to be reviewed and tested. Includes documentation for the `resolve_dns` knob and an additional case in the ssh spec that validates its behavior.

Completely untested.