### PR TITLE
allow node_want in csv.rb and ignore it (closes #1319)

### DIFF
--- a/lib/oxidized/source/csv.rb
+++ b/lib/oxidized/source/csv.rb
@@ -18,7 +18,7 @@ module Oxidized
       require 'gpgme' if @cfg.gpg?
     end
 
-    def load
+    def load node_want = nil
       nodes = []
       file = File.expand_path(@cfg.file)
       file = if @cfg.gpg?

--- a/lib/oxidized/source/csv.rb
+++ b/lib/oxidized/source/csv.rb
@@ -18,7 +18,7 @@ module Oxidized
       require 'gpgme' if @cfg.gpg?
     end
 
-    def load node_want = nil
+    def load _node_want = nil
       nodes = []
       file = File.expand_path(@cfg.file)
       file = if @cfg.gpg?


### PR DESCRIPTION
In  #1095, node_want was introduced to source loading, and is passed to all sources - however, while `http.rb` and `sql.rb` have been adjusted to do something meaningful with the parameter, `csv.rb` does not expect it, not has any use for it (the whole file needs to be processed to build a node list).

Allow and ignore node_want in `csv.rb`.