### PR TITLE
Update boss.rb

### DIFF
--- a/lib/oxidized/model/boss.rb
+++ b/lib/oxidized/model/boss.rb
@@ -1,5 +1,5 @@
 class Boss < Oxidized::Model
-  # Avaya Baystack Operating System Software(BOSS)
+  # Extreme Baystack Operating System Software(BOSS)
   # Created by danielcoxman@gmail.com
   # May 15, 2017
   # This was tested on ers3510, ers5530, ers4850, ers5952
@@ -27,6 +27,8 @@ class Boss < Oxidized::Model
   # to disable them menu on BOSS the configuration parameter is "cmd-interface cli"
   expect /ommand Line Interface\.\.\./ do |data, re|
     send "c"
+    data.sub re, ''
+    send "\n"
     data.sub re, ''
   end
 


### PR DESCRIPTION
Issues with some older boss switches that have the banner turned off.  They still display the banner but it is just scrolls and no pause.   The send "c" gets put at the prompt and you are now stuck.  An easy fix is to just send new line so you get a new prompt and the next command does not get corrupted and the backup of the configuration can continue.  Tested on about 100 BOSS switches and all working now.  Also Extreme now owns the BOSS platform after being purchased from Avaya.