### PR TITLE
Feature - Lockout by IP address

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -214,3 +214,35 @@ next_adds_job: true
 ```
 
 This will allow for a more timely fetch of the device configuration.
+
+
+## Node Lockout / Node Skip
+
+Sometimes it is helpful to temporarily prevent oxidized from polling a node without reloading the node source list or restarting the oxidized process.
+
+This can be accomplished by creating a lockfile with the node IP address as the filename in the `lockout_directory`. By default this is `~/.config/oxidized/lockout`. The contents of the file are not used by oxidized - just the existence of the file with the IP address of a node will prevent the node from being polled.
+
+This allows oxidized to skip polling of any nodes that may be down for an extended period of time or otherwise syncronized with external systems to prevent polling by having these systems create the lockout file.
+
+Example with linux/unix environments for a node with an IP address of `192.168.1.15` (as the oxidized user):
+
+```shell
+$ touch ~/.config/oxidized/lockout/192.168.1.15
+```
+
+The directory of the lockfiles can be adjusted within the global configuration section in your oxidized configuration file. As an example, to change the lockfile location to `/other/directory/name`:
+
+```yaml
+lockout_directory: /other/directory/name
+```
+
+Care should be taken to make sure that you only set the `lockout_directory` to a location where the permissions prevent unwanted lockfiles from being created or lockfiles from being removed.
+
+When you are ready to resume normal polling on the node - simply remove the lock file (as the oxidized user):
+
+```shell
+$ rm ~/.config/oxidized/lockout/192.168.1.15
+```
+
+The node will then be polled as normal during the next polling cycle.
+

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -40,6 +40,9 @@ module Oxidized
       asetus.default.input.ftp.passive  = true  # ftp passive mode
       asetus.default.input.utf8_encoded = true  # configuration is utf8 encoded or ascii-8bit
 
+      # Where we check for locks on a device by IP address
+      asetus.default.lockout_directory  = File.join(Oxidized::Config::Root, 'lockout')
+
       asetus.default.output.default = 'file'  # file, git
       asetus.default.source.default = 'csv'   # csv, sql
 

--- a/lib/oxidized/job.rb
+++ b/lib/oxidized/job.rb
@@ -6,7 +6,14 @@ module Oxidized
       @start        = Time.now.utc
       super do
         Oxidized.logger.debug "lib/oxidized/job.rb: Starting fetching process for #{@node.name} at #{Time.now.utc}"
-        @status, @config = @node.run
+        if node.is_lockedout?
+          Oxidized.logger.info "lib/oxidized/job.rb: Node [#{@node.name}] IP [#{@node.ip}] is locked. Skipping."
+          # Fake these up a bit
+          @status = :locked
+          @config = nil
+        else
+          @status, @config = @node.run
+        end
         @end             = Time.now.utc
         @time            = @end - @start
         Oxidized.logger.debug "lib/oxidized/job.rb: Config fetched for #{@node.name} at #{@end}"

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -125,6 +125,10 @@ module Oxidized
       @retry = 0
     end
 
+    def is_lockedout?
+      Oxidized.logger.debug "node.rb: Checking for lockout on node [%s] %s/%s" % [self.name, Oxidized.config.lockout_directory, self.ip]
+      File.exist?(File.join(Oxidized.config.lockout_directory, self.ip))
+    end
     private
 
     def resolve_prompt opt

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -42,9 +42,9 @@ module Oxidized
       node.stats.add job
       @jobs.duration job.time
       node.running = false
-      @jobs_done += 1 # needed for worker_done event
 
       if job.status == :success
+        @jobs_done += 1 # needed for :nodes_done hook
         Oxidized.Hooks.handle :node_success, :node => node,
                                              :job => job
         msg = "update #{node.name}"
@@ -59,6 +59,8 @@ module Oxidized
                                              :commitref => output.commitref
         end
         node.reset
+      elsif job.status == :locked
+          @jobs_done += 1
       else
         msg = "#{node.name} status #{job.status}"
         if node.retry < Oxidized.config.retries
@@ -66,6 +68,11 @@ module Oxidized
           msg += ", retry attempt #{node.retry}"
           @nodes.next node.name
         else
+          # Only increment the @jobs_done when we give up retries for a node (or success).
+          # As it would otherwise cause @jobs_done to be incremented with generic retries.
+          # This would cause :nodes_done hook to desync from running at the end of the nodelist and
+          # be fired when the @jobs_done > @nodes.count (could be mid-cycle on the next cycle).
+          @jobs_done += 1
           msg += ", retries exhausted, giving up"
           node.retry = 0
           Oxidized.Hooks.handle :node_fail, :node => node,


### PR DESCRIPTION
This implement a simple lockout by IP address methodology that the end-users can do when needed. 

This checks for a file in the lockout directory based on the IP address of the node about to be polled.
Only single IPs are locked, there is nothing fancy such as CIDR-based locking (yet).

If the file exists, the node is skipped for that polling interval/cycle. 

This allows for things to be locked out (not polled) in the event the user knows a node is going to be unreachable for some time - but doesn't want the polling and retries to build up on the offline nodes.
This also allows other things (such as external NMSes) to trigger a lockout etc as long as they have read/write to the lockout file directory (controlled by `lockout_directory:` configuration directive).

There were multiple ways to implement this - this seemed like the easiest/safest way for ease of use. There could be some impact to how job timing is calculated, since the job for a locked node is over instantly. 

Since this introduces a new status of `:locked` - I also will send in a PR for oxidized-web to see this status and render things properly in the UI.

Comments/feedback welcomed. I have had this sitting for a while - and trying to get it eye-ball checked by others or any different directions/thoughts.


