### PR TITLE
Add counters to correctly track the number of runs, successes and failures

### DIFF
--- a/lib/oxidized/node/stats.rb
+++ b/lib/oxidized/node/stats.rb
@@ -14,6 +14,11 @@ module Oxidized
         @stats[job.status] ||= []
         @stats[job.status].shift if @stats[job.status].size > MAX_STAT
         @stats[job.status].push stat
+        if job.status.equal? :success
+          @stats[:success_count] += 1
+        else
+          @stats[:failure_count] += 1
+        end
       end
 
       # @param [Symbol] status stats for specific status
@@ -26,6 +31,8 @@ module Oxidized
 
       def initialize
         @stats = {}
+        @stats[:success_count] = 0
+        @stats[:failure_count] = 0
       end
     end
   end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -41,6 +41,28 @@ describe Oxidized::Node do
       status, = @node.run
       status.must_equal :success
     end
+    it 'should record the success' do
+      stub_oxidized_ssh
+
+      before_successes = @node.stats.get(:success_count)
+      j = Oxidized::Job.new @node
+      j.join
+      @node.stats.add j
+      after_successes = @node.stats.get(:success_count)
+      successes = after_successes - before_successes
+      successes.must_equal 1
+    end
+    it 'should record a failure' do
+      stub_oxidized_ssh_fail
+
+      before_fails = @node.stats.get(:failure_count)
+      j = Oxidized::Job.new @node
+      j.join
+      @node.stats.add j
+      after_fails = @node.stats.get(:failure_count)
+      fails = after_fails - before_fails
+      fails.must_equal 1
+    end
   end
 
   describe '#repo' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,3 +20,12 @@ def stub_oxidized_ssh
   Oxidized::SSH.any_instance.stubs(:disconnect).returns(true)
   Oxidized::SSH.any_instance.stubs(:disconnect_cli).returns(true)
 end
+
+def stub_oxidized_ssh_fail
+  Oxidized::SSH.any_instance.stubs(:connect).returns(false)
+  Oxidized::SSH.any_instance.stubs(:node).returns(@node)
+  Oxidized::SSH.any_instance.expects(:cmd).never
+  Oxidized::SSH.any_instance.stubs(:connect_cli).returns(false)
+  Oxidized::SSH.any_instance.stubs(:disconnect).returns(false)
+  Oxidized::SSH.any_instance.stubs(:disconnect_cli).returns(false)
+end


### PR DESCRIPTION
This PR implements the following changes:

* Adds additional counter variables to allow the config download success and failure count to remain accurate beyond  the 11th run.
