### PR TITLE
Fix debug mode, properly comment NX-OS configs and normalize their line endings.

### DIFF
--- a/bin/oxidized
+++ b/bin/oxidized
@@ -8,6 +8,6 @@ begin
   Oxidized::CLI.new.run
 rescue => error
   warn "#{error}"
-  debug = Oxidied.config.debug rescue true
+  debug = Oxidized.config.debug rescue true
   raise if debug
 end

--- a/lib/oxidized/model/nxos.rb
+++ b/lib/oxidized/model/nxos.rb
@@ -2,6 +2,11 @@ class NXOS < Oxidized::Model
   prompt /^(\r?[\w.@_()-]+[#]\s?)$/
   comment '! '
 
+  def filter cfg
+    cfg.gsub! /\r\n?/, "\n"
+    cfg.gsub! prompt, ''
+  end
+
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(snmp-server user (\S+) (\S+) auth (\S+)) (\S+) (priv) (\S+)/, '\\1 <configuration removed> '
@@ -11,16 +16,21 @@ class NXOS < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
+    cfg = filter cfg
     cfg = cfg.each_line.take_while { |line| not line.match(/uptime/i) }
     comment cfg.join ""
   end
 
   cmd 'show inventory' do |cfg|
+    cfg = filter cfg
     comment cfg
   end
 
   cmd 'show running-config' do |cfg|
+    cfg = filter cfg
+    cfg.gsub! /^(show run.*)$/, '! \1'
     cfg.gsub! /^!Time:[^\n]*\n/, ''
+    cfg.gsub! /^[\w.@_()-]+[#].*$/, ''
     cfg
   end
 


### PR DESCRIPTION
This PR implements the following changes:

* Postprocessing of NXOS configs to have consistent Unix style line endings, remove lines containing exclusively a prompt, and comment all non-configuration lines. This allows the configuration taken from Oxidized to be directly supplied to a switch to revert to a specific version.

* Corrects inability to enable debug mode due to spelling error.