### PR TITLE
Enable 'enable' support for HP Procurves

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+* FEATURE: add enable to procurve model (@khobbits)
 * FEATURE: openwrt model (@z00nx)
 
 ## 0.21.0

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -79,6 +79,13 @@ class Procurve < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
+    # preferred way to handle additional passwords
+    if vars :enable
+      post_login do
+        send "enable\n"
+        cmd vars(:enable)
+      end
+    end
     post_login 'no page'
     pre_logout "logout\ny\nn"
   end


### PR DESCRIPTION
Found this enable snippit on another device, fixed login on a couple of my older devices.