### PR TITLE
use convenience methods in models for legibility

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,6 +33,9 @@ Style/RescueModifier:
 Style/MultilineBlockChain:
   Enabled: false
 
+Style/SymbolProc:
+  Enabled: false
+
 # Do not attempt to police vendored code, and exclude special cases
 AllCops:
   Exclude:

--- a/docs/Ruby-API.md
+++ b/docs/Ruby-API.md
@@ -180,3 +180,8 @@ single line was present.
 
 Returns a multi-line string without the first line, or an empty string if only a
 single line was present.
+
+#### `cut_both`
+
+Returns a multi-line string without the first and last lines, or an empty string
+if fewer than three lines were present.

--- a/lib/oxidized/model/acos.rb
+++ b/lib/oxidized/model/acos.rb
@@ -60,7 +60,7 @@ class ACOS < Oxidized::Model
 
   cmd :all do |cfg, cmdstring|
     new_cfg = comment "COMMAND: #{cmdstring}\n"
-    new_cfg << cfg.each_line.to_a[1..-2].join
+    new_cfg << cfg.cut_head.cut_tail
   end
 
   pre do

--- a/lib/oxidized/model/acos.rb
+++ b/lib/oxidized/model/acos.rb
@@ -60,7 +60,7 @@ class ACOS < Oxidized::Model
 
   cmd :all do |cfg, cmdstring|
     new_cfg = comment "COMMAND: #{cmdstring}\n"
-    new_cfg << cfg.cut_head.cut_tail
+    new_cfg << cfg.cut_both
   end
 
   pre do

--- a/lib/oxidized/model/acsw.rb
+++ b/lib/oxidized/model/acsw.rb
@@ -4,7 +4,7 @@ class ACSW < Oxidized::Model
 
   cmd :all do |cfg|
     cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/acsw.rb
+++ b/lib/oxidized/model/acsw.rb
@@ -4,7 +4,7 @@ class ACSW < Oxidized::Model
 
   cmd :all do |cfg|
     cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/aen.rb
+++ b/lib/oxidized/model/aen.rb
@@ -10,7 +10,7 @@ class AEN < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/aen.rb
+++ b/lib/oxidized/model/aen.rb
@@ -10,7 +10,7 @@ class AEN < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/aireos.rb
+++ b/lib/oxidized/model/aireos.rb
@@ -6,7 +6,7 @@ class Aireos < Oxidized::Model
   prompt /^\([^\)]+\)\s>/
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   # show sysinfo?

--- a/lib/oxidized/model/aireos.rb
+++ b/lib/oxidized/model/aireos.rb
@@ -6,7 +6,7 @@ class Aireos < Oxidized::Model
   prompt /^\([^\)]+\)\s>/
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   # show sysinfo?

--- a/lib/oxidized/model/aos.rb
+++ b/lib/oxidized/model/aos.rb
@@ -5,7 +5,7 @@ class AOS < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd 'show system' do |cfg|

--- a/lib/oxidized/model/aos.rb
+++ b/lib/oxidized/model/aos.rb
@@ -5,7 +5,7 @@ class AOS < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd 'show system' do |cfg|

--- a/lib/oxidized/model/aos7.rb
+++ b/lib/oxidized/model/aos7.rb
@@ -6,7 +6,7 @@ class AOS7 < Oxidized::Model
 
   cmd :all do |cfg, cmdstring|
     new_cfg = comment "COMMAND: #{cmdstring}\n"
-    new_cfg << cfg.each_line.to_a[1..-2].join
+    new_cfg << cfg.cut_head.cut_tail
   end
 
   cmd 'show system' do |cfg|

--- a/lib/oxidized/model/aos7.rb
+++ b/lib/oxidized/model/aos7.rb
@@ -6,7 +6,7 @@ class AOS7 < Oxidized::Model
 
   cmd :all do |cfg, cmdstring|
     new_cfg = comment "COMMAND: #{cmdstring}\n"
-    new_cfg << cfg.cut_head.cut_tail
+    new_cfg << cfg.cut_both
   end
 
   cmd 'show system' do |cfg|

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -13,7 +13,7 @@ class AOSW < Oxidized::Model
   prompt /^\(?.+\)?\s[#>]/
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -13,7 +13,7 @@ class AOSW < Oxidized::Model
   prompt /^\(?.+\)?\s[#>]/
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -6,7 +6,7 @@ class ASA < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -6,7 +6,7 @@ class ASA < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/awplus.rb
+++ b/lib/oxidized/model/awplus.rb
@@ -16,7 +16,7 @@ class AWPlus < Oxidized::Model
     cfg.gsub! /\e\[K/, ''         # example how to handle pager - cleareol EL0
     cfg.gsub! /\e\[7m\e\[m/, ''   # example how to handle pager - Reverse SGR7
     cfg.gsub! /\r/, '' # Filters rogue ^M - see issue #415
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   # Remove passwords from config file.

--- a/lib/oxidized/model/awplus.rb
+++ b/lib/oxidized/model/awplus.rb
@@ -16,7 +16,7 @@ class AWPlus < Oxidized::Model
     cfg.gsub! /\e\[K/, ''         # example how to handle pager - cleareol EL0
     cfg.gsub! /\e\[7m\e\[m/, ''   # example how to handle pager - Reverse SGR7
     cfg.gsub! /\r/, '' # Filters rogue ^M - see issue #415
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   # Remove passwords from config file.

--- a/lib/oxidized/model/c4cmts.rb
+++ b/lib/oxidized/model/c4cmts.rb
@@ -18,7 +18,7 @@ class C4CMTS < Oxidized::Model
 
   cmd 'show environment' do |cfg|
     cfg.gsub! /\s+[\-\d]+\s+C\s+[\(\s\d]+\s+\F\)/, ''	# remove temperature readings
-    comment cfg.cut_head.cut_tail
+    comment cfg.cut_both
   end
 
   cmd 'show version' do |cfg|
@@ -28,7 +28,7 @@ class C4CMTS < Oxidized::Model
   end
 
   cmd 'show running-config' do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/c4cmts.rb
+++ b/lib/oxidized/model/c4cmts.rb
@@ -18,8 +18,7 @@ class C4CMTS < Oxidized::Model
 
   cmd 'show environment' do |cfg|
     cfg.gsub! /\s+[\-\d]+\s+C\s+[\(\s\d]+\s+\F\)/, ''	# remove temperature readings
-    cfg.each_line.to_a[1..-2].join
-    comment cfg
+    comment cfg.cut_head.cut_tail
   end
 
   cmd 'show version' do |cfg|
@@ -29,8 +28,7 @@ class C4CMTS < Oxidized::Model
   end
 
   cmd 'show running-config' do |cfg|
-    cfg = cfg.each_line.to_a[1..-2].join
-    cfg
+    cfg.cut_head.cut_tail
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/casa.rb
+++ b/lib/oxidized/model/casa.rb
@@ -14,7 +14,7 @@ class Casa < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd 'show system' do |cfg|

--- a/lib/oxidized/model/casa.rb
+++ b/lib/oxidized/model/casa.rb
@@ -14,7 +14,7 @@ class Casa < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd 'show system' do |cfg|

--- a/lib/oxidized/model/catos.rb
+++ b/lib/oxidized/model/catos.rb
@@ -3,7 +3,7 @@ class Catos < Oxidized::Model
   comment '# '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd 'show system' do |cfg|

--- a/lib/oxidized/model/catos.rb
+++ b/lib/oxidized/model/catos.rb
@@ -3,7 +3,7 @@ class Catos < Oxidized::Model
   comment '# '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd 'show system' do |cfg|

--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -15,7 +15,7 @@ class Comware < Oxidized::Model
     # cfg.gsub! /^.*\e\[42D/, ''        # example how to handle pager
     # skip rogue ^M
     cfg = cfg.gsub /\r/, ''
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -15,7 +15,7 @@ class Comware < Oxidized::Model
     # cfg.gsub! /^.*\e\[42D/, ''        # example how to handle pager
     # skip rogue ^M
     cfg = cfg.gsub /\r/, ''
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/coriantgroove.rb
+++ b/lib/oxidized/model/coriantgroove.rb
@@ -8,17 +8,15 @@ class CoriantGroove < Oxidized::Model
   end
 
   cmd 'show inventory' do |cfg|
-    cfg = cfg.each_line.to_a[0..-2].join
-    comment cfg
+    comment cfg.cut_tail
   end
 
   cmd 'show softwareload' do |cfg|
-    cfg = cfg.each_line.to_a[0..-2].join
-    comment cfg
+    comment cfg.cut_tail
   end
 
   cmd 'show config | display commands' do |cfg|
-    cfg.each_line.to_a[1..-1].join
+    cfg.cut_head
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -8,7 +8,7 @@ class Cumulus < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   # show the persistent configuration

--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -8,7 +8,7 @@ class Cumulus < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   # show the persistent configuration

--- a/lib/oxidized/model/datacom.rb
+++ b/lib/oxidized/model/datacom.rb
@@ -7,7 +7,7 @@ class DataCom < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_head.cut_tail.cut_tail
+    cfg.cut_head.cut_both.cut_tail
   end
 
   cmd 'show firmware' do |cfg|

--- a/lib/oxidized/model/datacom.rb
+++ b/lib/oxidized/model/datacom.rb
@@ -7,8 +7,7 @@ class DataCom < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
-    cfg.cut_head.cut_tail
+    cfg.cut_head.cut_head.cut_tail.cut_tail
   end
 
   cmd 'show firmware' do |cfg|

--- a/lib/oxidized/model/dcnos.rb
+++ b/lib/oxidized/model/dcnos.rb
@@ -8,7 +8,7 @@ class DCNOS < Oxidized::Model
   comment '! '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-1].join
+    cfg.cut_head
   end
 
   cmd 'show version' do |cfg|

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -6,7 +6,7 @@ class EOS < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -6,7 +6,7 @@ class EOS < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/fiberdriver.rb
+++ b/lib/oxidized/model/fiberdriver.rb
@@ -3,7 +3,7 @@ class FiberDriver < Oxidized::Model
   comment "! "
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
   cmd 'show inventory' do |cfg|
     comment cfg

--- a/lib/oxidized/model/fiberdriver.rb
+++ b/lib/oxidized/model/fiberdriver.rb
@@ -3,7 +3,7 @@ class FiberDriver < Oxidized::Model
   comment "! "
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
   cmd 'show inventory' do |cfg|
     comment cfg

--- a/lib/oxidized/model/firewareos.rb
+++ b/lib/oxidized/model/firewareos.rb
@@ -3,7 +3,7 @@ class FirewareOS < Oxidized::Model
   comment  '-- '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   # Handle Logon Disclaimer added in XTM 11.9.3

--- a/lib/oxidized/model/firewareos.rb
+++ b/lib/oxidized/model/firewareos.rb
@@ -3,7 +3,7 @@ class FirewareOS < Oxidized::Model
   comment  '-- '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   # Handle Logon Disclaimer added in XTM 11.9.3

--- a/lib/oxidized/model/fujitsupy.rb
+++ b/lib/oxidized/model/fujitsupy.rb
@@ -3,7 +3,7 @@ class FujitsuPY < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   # 1Gbe switch

--- a/lib/oxidized/model/fujitsupy.rb
+++ b/lib/oxidized/model/fujitsupy.rb
@@ -3,7 +3,7 @@ class FujitsuPY < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   # 1Gbe switch

--- a/lib/oxidized/model/gaiaos.rb
+++ b/lib/oxidized/model/gaiaos.rb
@@ -8,7 +8,7 @@ class GaiaOS < Oxidized::Model
   comment  '# '
 
   cmd :all do |cfg|
-    cfg = cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/gaiaos.rb
+++ b/lib/oxidized/model/gaiaos.rb
@@ -8,7 +8,7 @@ class GaiaOS < Oxidized::Model
   comment  '# '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/gcombnps.rb
+++ b/lib/oxidized/model/gcombnps.rb
@@ -22,7 +22,7 @@ class GcomBNPS < Oxidized::Model
 
   cmd :all do |cfg|
     cfg = cfg.gsub " \e[73D\e[K", '' # remove garbage remaining from the pager
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/gcombnps.rb
+++ b/lib/oxidized/model/gcombnps.rb
@@ -22,7 +22,7 @@ class GcomBNPS < Oxidized::Model
 
   cmd :all do |cfg|
     cfg = cfg.gsub " \e[73D\e[K", '' # remove garbage remaining from the pager
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/hatteras.rb
+++ b/lib/oxidized/model/hatteras.rb
@@ -17,7 +17,7 @@ class Hatteras < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd "show switch\r" do |cfg|

--- a/lib/oxidized/model/hatteras.rb
+++ b/lib/oxidized/model/hatteras.rb
@@ -17,7 +17,7 @@ class Hatteras < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd "show switch\r" do |cfg|

--- a/lib/oxidized/model/hirschmann.rb
+++ b/lib/oxidized/model/hirschmann.rb
@@ -10,7 +10,7 @@ class Hirschmann < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd 'show sysinfo' do |cfg|

--- a/lib/oxidized/model/hirschmann.rb
+++ b/lib/oxidized/model/hirschmann.rb
@@ -10,7 +10,7 @@ class Hirschmann < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd 'show sysinfo' do |cfg|

--- a/lib/oxidized/model/hpebladesystem.rb
+++ b/lib/oxidized/model/hpebladesystem.rb
@@ -11,7 +11,7 @@ class HPEBladeSystem < Oxidized::Model
 
   cmd :all do |cfg|
     cfg = cfg.delete("\r").each_line.to_a[0..-1].map { |line| line.rstrip }.join("\n") + "\n"
-    cfg.each_line.to_a[0..-2].join
+    cfg.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -20,7 +20,7 @@ class IOS < Oxidized::Model
     # cfg.gsub! /\cH+/, ''              # example how to handle pager
     # get rid of errors for commands that don't work on some devices
     cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -20,7 +20,7 @@ class IOS < Oxidized::Model
     # cfg.gsub! /\cH+/, ''              # example how to handle pager
     # get rid of errors for commands that don't work on some devices
     cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/ipos.rb
+++ b/lib/oxidized/model/ipos.rb
@@ -6,15 +6,15 @@ class IPOS < Oxidized::Model
   comment '! '
 
   cmd 'show chassis' do |cfg|
-    comment cfg.each_line.to_a[0..-2].join
+    comment cfg.cut_tail
   end
 
   cmd 'show hardware' do |cfg|
-    comment cfg.each_line.to_a[0..-2].join
+    comment cfg.cut_tail
   end
 
   cmd 'show release' do |cfg|
-    comment cfg.each_line.to_a[0..-2].join
+    comment cfg.cut_tail
   end
 
   cmd 'show configuration' do |cfg|

--- a/lib/oxidized/model/isam.rb
+++ b/lib/oxidized/model/isam.rb
@@ -5,7 +5,7 @@ class ISAM < Oxidized::Model
   comment '# '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/isam.rb
+++ b/lib/oxidized/model/isam.rb
@@ -5,7 +5,7 @@ class ISAM < Oxidized::Model
   comment '# '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -6,7 +6,7 @@ class JunOS < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg = cfg.cut_head.cut_tail if screenscrape
+    cfg = cfg.cut_both if screenscrape
     cfg.gsub!(/  scale-subscriber (\s+)(\d+)/, '  scale-subscriber                <count>')
     cfg.lines.map { |line| line.rstrip }.join("\n") + "\n"
   end

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -6,7 +6,7 @@ class JunOS < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg = cfg.lines.to_a[1..-2].join if screenscrape
+    cfg = cfg.cut_head.cut_tail if screenscrape
     cfg.gsub!(/  scale-subscriber (\s+)(\d+)/, '  scale-subscriber                <count>')
     cfg.lines.map { |line| line.rstrip }.join("\n") + "\n"
   end

--- a/lib/oxidized/model/masteros.rb
+++ b/lib/oxidized/model/masteros.rb
@@ -10,7 +10,7 @@ class MasterOS < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
     cfg.gsub /^(! Configuration ).*/, '!'
   end
 

--- a/lib/oxidized/model/masteros.rb
+++ b/lib/oxidized/model/masteros.rb
@@ -10,13 +10,12 @@ class MasterOS < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
     cfg.gsub /^(! Configuration ).*/, '!'
   end
 
   cmd 'show inventory' do |cfg|
-    cfg = cfg.each_line.to_a[0..-2].join
-    comment cfg
+    comment cfg.cut_tail
   end
 
   cmd 'show plugins' do |cfg|

--- a/lib/oxidized/model/ndms.rb
+++ b/lib/oxidized/model/ndms.rb
@@ -11,7 +11,7 @@ class NDMS < Oxidized::Model
   end
 
   cmd 'show running-config' do |cfg|
-    cfg = cfg.each_line.to_a[1..-2]
+    cfg = cfg.cut_head.cut_tail
     cfg = cfg.reject { |line| line.match /(clock date|checksum)/ }.join
     cfg
   end

--- a/lib/oxidized/model/ndms.rb
+++ b/lib/oxidized/model/ndms.rb
@@ -11,7 +11,7 @@ class NDMS < Oxidized::Model
   end
 
   cmd 'show running-config' do |cfg|
-    cfg = cfg.cut_head.cut_tail
+    cfg = cfg.cut_both
     cfg = cfg.reject { |line| line.match /(clock date|checksum)/ }.join
     cfg
   end

--- a/lib/oxidized/model/netonix.rb
+++ b/lib/oxidized/model/netonix.rb
@@ -2,7 +2,7 @@ class Netonix < Oxidized::Model
   prompt /^[\w\s.@_\/:-]+#/
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd 'cat config.json;echo'

--- a/lib/oxidized/model/netonix.rb
+++ b/lib/oxidized/model/netonix.rb
@@ -2,7 +2,7 @@ class Netonix < Oxidized::Model
   prompt /^[\w\s.@_\/:-]+#/
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd 'cat config.json;echo'

--- a/lib/oxidized/model/nos.rb
+++ b/lib/oxidized/model/nos.rb
@@ -5,7 +5,7 @@ class NOS < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd 'show version' do |cfg|

--- a/lib/oxidized/model/nos.rb
+++ b/lib/oxidized/model/nos.rb
@@ -5,7 +5,7 @@ class NOS < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd 'show version' do |cfg|

--- a/lib/oxidized/model/oneos.rb
+++ b/lib/oxidized/model/oneos.rb
@@ -18,7 +18,7 @@ class OneOS < Oxidized::Model
   cmd :all do |cfg|
     # cfg.gsub! /\cH+\s{8}/, ''         # example how to handle pager
     # cfg.gsub! /\cH+/, ''              # example how to handle pager
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/oneos.rb
+++ b/lib/oxidized/model/oneos.rb
@@ -18,7 +18,7 @@ class OneOS < Oxidized::Model
   cmd :all do |cfg|
     # cfg.gsub! /\cH+\s{8}/, ''         # example how to handle pager
     # cfg.gsub! /\cH+/, ''              # example how to handle pager
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/opnsense.rb
+++ b/lib/oxidized/model/opnsense.rb
@@ -3,7 +3,7 @@ class OpnSense < Oxidized::Model
   # must enable SSH and password-based SSH access
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-1].join
+    cfg.cut_head
   end
 
   cmd 'cat /conf/config.xml' do |cfg|

--- a/lib/oxidized/model/pfsense.rb
+++ b/lib/oxidized/model/pfsense.rb
@@ -2,7 +2,7 @@ class PfSense < Oxidized::Model
   # use other use than 'admin' user, 'admin' user cannot get ssh/exec. See issue #535
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-1].join
+    cfg.cut_head
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/planet.rb
+++ b/lib/oxidized/model/planet.rb
@@ -18,7 +18,7 @@ class Planet < Oxidized::Model
   cmd :all do |cfg|
     # cfg.gsub! /\cH+\s{8}/, ''         # example how to handle pager
     # cfg.gsub! /\cH+/, ''              # example how to handle pager
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/planet.rb
+++ b/lib/oxidized/model/planet.rb
@@ -18,7 +18,7 @@ class Planet < Oxidized::Model
   cmd :all do |cfg|
     # cfg.gsub! /\cH+\s{8}/, ''         # example how to handle pager
     # cfg.gsub! /\cH+/, ''              # example how to handle pager
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -26,7 +26,7 @@ class Procurve < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg = cfg.each_line.to_a[1..-2].join
+    cfg = cfg.cut_head.cut_tail
     cfg = cfg.gsub /^\r/, ''
   end
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -26,7 +26,7 @@ class Procurve < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg = cfg.cut_head.cut_tail
+    cfg = cfg.cut_both
     cfg = cfg.gsub /^\r/, ''
   end
 

--- a/lib/oxidized/model/saos.rb
+++ b/lib/oxidized/model/saos.rb
@@ -5,7 +5,7 @@ class SAOS < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd 'configuration show' do |cfg|

--- a/lib/oxidized/model/saos.rb
+++ b/lib/oxidized/model/saos.rb
@@ -5,7 +5,7 @@ class SAOS < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd 'configuration show' do |cfg|

--- a/lib/oxidized/model/sros.rb
+++ b/lib/oxidized/model/sros.rb
@@ -10,7 +10,7 @@ class SROS < Oxidized::Model
 
   cmd :all do |cfg, cmdstring|
     new_cfg = comment "COMMAND: #{cmdstring}\n"
-    new_cfg << cfg.each_line.to_a[1..-2].join
+    new_cfg << cfg.cut_head.cut_tail
   end
 
   #

--- a/lib/oxidized/model/sros.rb
+++ b/lib/oxidized/model/sros.rb
@@ -10,7 +10,7 @@ class SROS < Oxidized::Model
 
   cmd :all do |cfg, cmdstring|
     new_cfg = comment "COMMAND: #{cmdstring}\n"
-    new_cfg << cfg.cut_head.cut_tail
+    new_cfg << cfg.cut_both
   end
 
   #

--- a/lib/oxidized/model/stoneos.rb
+++ b/lib/oxidized/model/stoneos.rb
@@ -10,7 +10,7 @@ class StoneOS < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd 'show configuration running'

--- a/lib/oxidized/model/stoneos.rb
+++ b/lib/oxidized/model/stoneos.rb
@@ -10,7 +10,7 @@ class StoneOS < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd 'show configuration running'

--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -11,7 +11,7 @@ class VRP < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -11,7 +11,7 @@ class VRP < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/weos.rb
+++ b/lib/oxidized/model/weos.rb
@@ -4,7 +4,7 @@ class WEOS < Oxidized::Model
   prompt /^(\s[\w.@-]+[#>]\s?)$/
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].join
+    cfg.cut_head.cut_tail
   end
 
   cmd 'show running-config' do |cfg|

--- a/lib/oxidized/model/weos.rb
+++ b/lib/oxidized/model/weos.rb
@@ -4,7 +4,7 @@ class WEOS < Oxidized::Model
   prompt /^(\s[\w.@-]+[#>]\s?)$/
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_tail
+    cfg.cut_both
   end
 
   cmd 'show running-config' do |cfg|

--- a/lib/oxidized/string.rb
+++ b/lib/oxidized/string.rb
@@ -13,6 +13,11 @@ module Oxidized
       Oxidized::String.new each_line.to_a[1..-1].join
     end
 
+    # @return [Oxidized::String] copy of self with first and last lines removed
+    def cut_both
+      Oxidized::String.new each_line.to_a[1..-2].join
+    end
+
     # sets @cmd and @name unless @name is already set
     def set_cmd command
       @cmd = command


### PR DESCRIPTION
Transitions all models where applicable to the (very few) convenience methods currently provided by Oxidized expanded string class. This should improve model legibility, set an example and open up the idea of adding convenience methods for contributors.

Untested (and could benefit from a run by anyone who makes use of the affected models) but presumed to be purely cosmetic.