### PR TITLE
Allow build without git repo / .git directory

### DIFF
--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary           = 'feeble attempt at rancid'
   s.description       = 'software to fetch configuration from network devices and store them'
   s.rubyforge_project = s.name
-  s.files             = %x(git ls-files -z).split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  s.files             = `find * -type f`.split("\n").reject { |f| f.match(%r{^(.*\.gem|test/|spec/|features/)}) }
   s.executables       = %w[oxidized]
   s.require_path      = 'lib'
 


### PR DESCRIPTION
This allows to build oxidized with local sources (which has no .git directory).