### PR TITLE
gcc-c++ needed in oxidized-web 0.10.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ yum install cmake sqlite-devel openssl-devel libssh2-devel libicu-devel
 RHEL 7 / CentOS 7 will work out of the box with the following package list:
 
 ```shell
-yum install cmake sqlite-devel openssl-devel libssh2-devel ruby gcc ruby-devel libicu-devel
+yum install cmake sqlite-devel openssl-devel libssh2-devel ruby gcc ruby-devel libicu-devel gcc-c++
 ```
 
 Now let's install oxidized via Rubygems:


### PR DESCRIPTION
Oxidized-web 0.10.2 requires gcc-c++ to be able to install the gem in Centos 7. Updated docs.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
