### PR TITLE
IOS-XR: formal running-config instead of normal running-config

### DIFF
--- a/lib/oxidized/model/iosxr.rb
+++ b/lib/oxidized/model/iosxr.rb
@@ -22,7 +22,7 @@ class IOSXR < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show running-config' do |cfg|
+  cmd 'show running-config formal' do |cfg|
     cfg = cfg.each_line.to_a[3..-1].join
     cfg
   end


### PR DESCRIPTION
I have changed the IOS-XR model to do "show running-config formal" instead of "show running-config".

## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
I have changed the IOS-XR model to do "show running-config formal" instead of "show running-config".
