### PR TITLE
ciscosmb uptime filter is for show system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * FEATURE: add frr support to cumulus model (@User4574 / @bobthebutcher)
 * FEATURE: honour MAX_STAT in mtime, to store last N mtime
 * FEATURE: configurable stats history size
+* BUGFIX: model ciscosmb
 
 ## 0.23.0
 

--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -16,7 +16,6 @@ class CiscoSMB < Oxidized::Model
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /username (\S+) privilege (\d+) (\S+).*/, '<secret hidden>'
     cfg.gsub! /^(encrypted radius-server key).*/, '\\1 <configuration removed>'
-    cfg.gsub! /System Up Time.*/, ''
     cfg
   end
 
@@ -25,6 +24,7 @@ class CiscoSMB < Oxidized::Model
   end
 
   cmd 'show system' do |cfg|
+    cfg.gsub! /System Up Time.*/, ''
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Moves the uptime filter from :secret to `show system` which actually produces the message in `ciscosmb.rb`. This ensures the uptime line gets scrubbed even if secret scrubbing is disabled.

