### PR TITLE
relax d-link prompt expectations, closes #1389 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * FEATURE: honour MAX_STAT in mtime, to store last N mtime
 * FEATURE: configurable stats history size
 * FEATURE: model callback enhancements for customizing existing models (@ytti)
-* BUGFIX: model ciscosmb
+* BUGFIX: models ciscosmb, dlink
 
 ## 0.23.0
 

--- a/lib/oxidized/model/dlink.rb
+++ b/lib/oxidized/model/dlink.rb
@@ -26,8 +26,8 @@ class Dlink < Oxidized::Model
   cmd 'show config current'
 
   cfg :telnet do
-    username /\r*username:/
-    password /\r*password:/
+    username /\r*[Uu]ser{Nn]ame:/
+    password /\r*[Pp]ass[Ww]ord:/
   end
 
   cfg :telnet, :ssh do


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Relaxes prompt expectations for D-Link model

Closes #1389
