### PR TITLE
scrub temperature from 'show system' in edgecos, closes #1394

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
-## 024.0
+## Master
+
+* BUGFIX: model edgecos
+
+## 0.24.0
 
 * FEATURE: add frr support to cumulus model (@User4574 / @bobthebutcher)
 * FEATURE: honour MAX_STAT in mtime, to store last N mtime

--- a/lib/oxidized/model/edgecos.rb
+++ b/lib/oxidized/model/edgecos.rb
@@ -15,6 +15,7 @@ class EdgeCOS < Oxidized::Model
 
   cmd 'show system' do |cfg|
     cfg.gsub! /^\s*System Up Time\s*:.*\n/i, ''
+    cfg.gsub! /^\s*(Temperature \d*:).*\n/i, '\\1 <removed>'
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Scrub temperature in `edgecos.rb` from `show system` output.

Closes #1394 
