### PR TITLE
Scrub uptime in ciscosmb more carefully, closes #1398

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master
 
-* BUGFIX: model edgecos
+* BUGFIX: model edgecos, ciscosmb
 
 ## 0.24.0
 

--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -24,7 +24,7 @@ class CiscoSMB < Oxidized::Model
   end
 
   cmd 'show system' do |cfg|
-    cfg.gsub! /System Up Time.*/, ''
+    cfg.gsub! /System Up Time.*\n/, ''
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Scrub uptime in `ciscosmb.rb` more carefully

Closes #1398 
