### PR TITLE
Collect config from all logical partitions

### DIFF
--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -42,7 +42,7 @@ class TMOS < Oxidized::Model
     comment cfg
   end
 
-  cmd('cat /config/partitions/*/bigip.conf') { |cfg| comment cfg }
+  cmd('cd /config/partitions/; for i in *; do echo "##CONFIG OF PARTITION \"$i\"##"; cat $i/bigip*.conf; done ; cd ~;') { |cfg| comment cfg }
 
   cfg :ssh do
     exec true # don't run shell, run each command in exec channel


### PR DESCRIPTION
Adding support for collecting configurations from all logical containers / partitions on BIG-IP box. All configuration will be listed one after another separated by line ##CONFIG OF PARTITION "partition1"##

In Big-ip, configs are stored in separated files in subfolders of /config/partitions. This is example directory from my installation:

[user@ba-dc-lb-02:Standby:In Sync] partitions # pwd
/config/partitions

[user@ba-dc-lb-02:Standby:In Sync] partitions # ls -LR
.:
EXCHANGE  LYNC  SP  SSO

./EXCHANGE:
bigip.conf  bigip_gtm.conf

./LYNC:
bigip.conf

./SP:
bigip.conf

./SSO:
bigip_gtm.conf

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
