### PR TITLE
xos false positive diffs, closes #1411 

### DIFF
--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -15,7 +15,7 @@ class XOS < Oxidized::Model
   end
 
   cmd 'show diagnostics' do |cfg|
-	  comment cfg.each_line.reject { |line| line.match /Type/ }.join
+    comment cfg.each_line.reject { |line| line.match /Type/ }.join
   end
 
   cmd 'show licenses' do |cfg|
@@ -23,7 +23,7 @@ class XOS < Oxidized::Model
   end
 
   cmd 'show switch' do |cfg|
-	  comment cfg.each_line.reject { |line| line.match /Time:/ or line.match /boot/i or line.match /Temperature:/ }.join
+    comment cfg.each_line.reject { |line| line.match /Time:/ or line.match /boot/i or line.match /Temperature:/ }.join
   end
 
   cmd 'show configuration' do |cfg|

--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -15,7 +15,7 @@ class XOS < Oxidized::Model
   end
 
   cmd 'show diagnostics' do |cfg|
-    comment cfg.each_line.reject { |line| line.match /Type/ }.join
+    comment cfg.each_line.reject { |line| line.match /Type \d+:/ }.join
   end
 
   cmd 'show licenses' do |cfg|

--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -15,7 +15,7 @@ class XOS < Oxidized::Model
   end
 
   cmd 'show diagnostics' do |cfg|
-    comment cfg
+	  comment cfg.each_line.reject { |line| line.match /Type/ }.join
   end
 
   cmd 'show licenses' do |cfg|
@@ -23,7 +23,7 @@ class XOS < Oxidized::Model
   end
 
   cmd 'show switch' do |cfg|
-    comment cfg.each_line.reject { |line| line.match /Time:/ or line.match /boot/i }.join
+	  comment cfg.each_line.reject { |line| line.match /Time:/ or line.match /boot/i or line.match /Temperature:/ }.join
   end
 
   cmd 'show configuration' do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added filtering for temperature from "show switch" output (Summit200-48) and also filtering for interfaces total bandwith from "show diagnostic"(Extreme Alpine3804)

Closes issue #1411 
