### PR TITLE
added telnet password prompt detection for Netgears

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+* BUGFIX: netgear telnet password prompt not detected
 * BUGFIX: xos model should not modify config on legacy Extreme Networks devices (sq9mev)
 * BUGFIX: model edgecos, ciscosmb
 * MISC: bump Dockerfile phusion/baseimage:0.10.0 -> 0.10.1

--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -10,6 +10,7 @@ class Netgear < Oxidized::Model
 
   cfg :telnet do
     username /^(User:|Applying Interface configuration, please wait ...)/
+    password /^Password:/i
   end
 
   cfg :telnet, :ssh do


### PR DESCRIPTION
Tested on Netgear M5300's running firmware 10.0.0.53, 11.0.0.23 & 11.0.0.31

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fixes issue with Netgear login via telnet.
The password prompt wasn't recognised after the latest update.

Closes issue #1385 for Netgear devices