### PR TITLE
Tidy up logic for sending 'enable' with or without password

### DIFF
--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -14,15 +14,12 @@ class Netgear < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
-    if vars :enable
-      post_login do
-        send "enable\n"
-        # Interpret enable: true as meaning we won't be prompted for a password
-        unless vars(:enable).is_a? TrueClass
-          expect /[pP]assword:\s?$/
-          send vars(:enable) + "\n"
-        end
-        expect /^.+[#]$/
+    post_login do
+      if vars(:enable) == true
+        cmd "enable"
+      elsif vars(:enable)
+        cmd "enable", /[pP]assword:\s?$/
+        cmd vars(:enable)
       end
     end
     post_login 'terminal length 0'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Clearer implementation for the `enable` var in netgear.rb.  The logic is backwards-compatible:

* Any string (including empty string) sends "enable", waits for password prompt, sends the string
* `true` sends "enable" only, does not expect password prompt
* `false` or `nil` does not send "enable"

Discussion in tail end of #1413 