### PR TITLE
adding node group to worker logs

### DIFF
--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -29,7 +29,7 @@ module Oxidized
         node = @nodes.get
         node.running? ? next : node.running = true
         @jobs.push Job.new node
-        Oxidized.logger.debug "lib/oxidized/worker.rb: Added #{node.name} to the job queue"
+        Oxidized.logger.debug "lib/oxidized/worker.rb: Added #{node.group}/#{node.name} to the job queue"
       end
 
       run_done_hook if is_cycle_finished?
@@ -48,7 +48,7 @@ module Oxidized
         process_failure node, job
       end
     rescue NodeNotFound
-      Oxidized.logger.warn "#{node.name} not found, removed while collecting?"
+      Oxidized.logger.warn "#{node.group}/#{node.name} not found, removed while collecting?"
     end
 
     private
@@ -57,7 +57,7 @@ module Oxidized
       @jobs_done += 1 # needed for :nodes_done hook
       Oxidized.Hooks.handle :node_success, node: node,
                                            job: job
-      msg = "update #{node.name}"
+      msg = "update #{node.group}/#{node.name}"
       msg += " from #{node.from}" if node.from
       msg += " with message '#{node.msg}'" if node.msg
       output = node.output.new
@@ -73,7 +73,7 @@ module Oxidized
     end
 
     def process_failure node, job
-      msg = "#{node.name} status #{job.status}"
+      msg = "#{node.group}/#{node.name} status #{job.status}"
       if node.retry < Oxidized.config.retries
         node.retry += 1
         msg += ", retry attempt #{node.retry}"


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [NA ] Tests added or adapted (try `rake test`)
- [NA ] Changes are reflected in the documentation
- [NA ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Standardises the syslog messages in `worker.rb` by prefixing a node name with it's group.

`node.group/node.name` is now shown in all logs generated by `worker.rb`
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
