### PR TITLE
Coriant Groove FP3.x only accepts a line length of 4000 chars

### DIFF
--- a/lib/oxidized/model/coriantgroove.rb
+++ b/lib/oxidized/model/coriantgroove.rb
@@ -22,7 +22,7 @@ class CoriantGroove < Oxidized::Model
   end
 
   cfg :ssh do
-    post_login 'set -f cli-config cli-columns 65535'
+    post_login 'set -f cli-config cli-columns 4000'
     pre_logout 'quit -f'
   end
 end


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)

## Description

Coriant reduced the maximum line length from 65536 chars to 4000. Specifying `set -f cli-config cli-columns 65535` returns an error on recent software.  Changing this to 400 chars fixes the problem.

There are no open issues about this.  Discovered on internal testing.