### PR TITLE
Errorhandling for broken AOS output

### DIFF
--- a/lib/oxidized/model/aos.rb
+++ b/lib/oxidized/model/aos.rb
@@ -14,14 +14,17 @@ class AOS < Oxidized::Model
   end
 
   cmd 'show chassis' do |cfg|
+    raise "AOS ERROR:" if cfg.match /ERROR:/
     comment cfg
   end
 
   cmd 'show hardware info' do |cfg|
+    raise "AOS ERROR:" if cfg.match /ERROR:/
     comment cfg
   end
 
   cmd 'show configuration snapshot' do |cfg|
+    raise "AOS ERROR:" if cfg.match /ERROR:/
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Alcatel/Lucent AOS boxes will error frequently so you get a bunch of revisions of configs.  This will handle those errors.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
