### PR TITLE
Fortios secret filtering: Fixed greedy regex's eating configuration

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -19,9 +19,9 @@ class FortiOS < Oxidized::Model
     cfg.gsub! /(set .*secret) .+/, '\\1 <configuration removed>'
     # A number of other statements also contains sensitive strings
     cfg.gsub! /(set (?:passwd|password|key|group-password|auth-password-l1|auth-password-l2|rsso|history0|history1)) .+/, '\\1 <configuration removed>'
-    cfg.gsub! /(set private-key).*-+END ENCRYPTED PRIVATE KEY-*"$/m, '\\1 <configuration removed>'
-    cfg.gsub! /(set ca ).*-+END CERTIFICATE-*"$/m, '\\1 <configuration removed>'
-    cfg.gsub! /(set csr ).*-+END CERTIFICATE REQUEST-*"$/m, '\\1 <configuration removed>'
+    cfg.gsub! /(set private-key ).*?-+END ENCRYPTED PRIVATE KEY-*"$/m, '\\1<configuration removed>'
+    cfg.gsub! /(set ca ).*?-+END CERTIFICATE-*"$/m, '\\1<configuration removed>'
+    cfg.gsub! /(set csr ).*?-+END CERTIFICATE REQUEST-*"$/m, '\\1<configuration removed>'
     cfg.gsub! /(Cluster uptime:).*/, '\\1 <stripped>'
     cfg
   end


### PR DESCRIPTION


## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Just made first .* portion of regex not greedy. The multi-line match would eat all config between the first and last certificate in my configs when I turned on remove_secret. Also adjusted spacing slightly so that there would always be a single-space before "<configuration removed>".
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
