### PR TITLE
FTOS secret filtering fixes

### DIFF
--- a/lib/oxidized/model/ftos.rb
+++ b/lib/oxidized/model/ftos.rb
@@ -9,7 +9,8 @@ class FTOS < Oxidized::Model
 
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
-    cfg.gsub! /secret (\d+) (\S+).*/, '<secret hidden>'
+    cfg.gsub! /(secret \d* {0,1})\S+(.*)/, '\\1<secret hidden>\\2'
+    cfg.gsub! /(password \d+) \S+(.*)/, '\\1 <hash hidden>\\2'
     cfg
   end
 


### PR DESCRIPTION

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Fixed secret regex which would strip config after secret string
(like "privilege 15") and which would not match on:
"bsd-username test secret $1$FAKESTRINGblahblah" which is created
whenever username secret is created.

Added regex to filter password hashes for configs using
password 7 instead of secret such as:
username test password 7 8888blahblah8888 privilege 4
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
