### PR TITLE
TPLINK: Remove runtime and system time

### DIFF
--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -31,8 +31,10 @@ class TPLink < Oxidized::Model
   end
 
   cmd 'show system-info' do |cfg|
-    cfg.gsub! /^ System\ Time\s.+/, '' # Omit constantly changing time info
+    cfg = cfg.each_line.to_a[1..-3].join
+    cfg.gsub! /^ System\ Time\s.+/, '' # Omit constantly changing uptime info
     cfg.gsub! /^ Running\ Time\s.+/, '' # Omit constantly changing uptime info
+    cfg.gsub! /^\S+/, ''
     comment cfg
   end
 

--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -31,7 +31,9 @@ class TPLink < Oxidized::Model
   end
 
   cmd 'show system-info' do |cfg|
-    comment cfg.each_line.to_a[3..-3].join
+    cfg.gsub! /^ System\ Time\s.+/, '' # Omit constantly changing time info
+    cfg.gsub! /^ Running\ Time\s.+/, '' # Omit constantly changing uptime info
+    comment cfg
   end
 
   cmd 'show running-config' do |cfg|


### PR DESCRIPTION
Remove runtime and system time from tplink switch output

Tested on:
Hardware: TL-SG2210P 1.0
Operating System: TP-Link Switch 1.0.3 Build 20160218 Rel.62575