### PR TITLE
Added verbiage to set OXIDIZED_HOME correctly under Debian 8.8 w/systemd

### DIFF
--- a/extra/oxidized.service
+++ b/extra/oxidized.service
@@ -1,4 +1,10 @@
 #For debian 8 put it in /lib/systemd/system/
+#To set OXIDIZED_HOME instead of the default:
+# ~${oxidized_user}/.config/oxidized in debian 8, then uncomment
+#(and modify as required) the "Environment" variable below so
+#systemd sets the correct environment. Tested only on Debian 8.8.
+#YMMV otherwise.
+#
 #For RHEL / CentOS 7 put it in /etc/systemd/system/
 #and call it with systemctl start oxidized.service
 
@@ -11,6 +17,7 @@ Wants=network-online.target
 ExecStart=/usr/local/bin/oxidized
 User=oxidized
 KillSignal=SIGKILL
+#Environment="OXIDIZED_HOME=/etc/oxidized"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)

Not sure what the rubocop stuff is, sorry :(

- [ ] Tests added or adapted (try `rake test`)

Not sure what the rake test stuff is, sorry :(

- [ ] Changes are reflected in the documentation

None required?  I inserted a comment into the modified file itself

- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

Whoops. No :(

## Description
<!-- Describe your changes here. -->

Added verbiage to set OXIDIZED_HOME correctly under Debian 8.8 w/systemd

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Closes issue #1441  and issue #1440