### PR TITLE
fortios: mask "md5-key" secrets

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -19,6 +19,7 @@ class FortiOS < Oxidized::Model
     cfg.gsub! /(set .*secret) .+/, '\\1 <configuration removed>'
     # A number of other statements also contains sensitive strings
     cfg.gsub! /(set (?:passwd|password|key|group-password|auth-password-l1|auth-password-l2|rsso|history0|history1)) .+/, '\\1 <configuration removed>'
+    cfg.gsub! /(set md5-key [0-9]+) .+/, '\\1 <configuration removed>'
     cfg.gsub! /(set private-key ).*?-+END ENCRYPTED PRIVATE KEY-*"$/m, '\\1<configuration removed>'
     cfg.gsub! /(set ca ).*?-+END CERTIFICATE-*"$/m, '\\1<configuration removed>'
     cfg.gsub! /(set csr ).*?-+END CERTIFICATE REQUEST-*"$/m, '\\1<configuration removed>'


### PR DESCRIPTION
## Description

format of the strings to be excluded/removed:

```set md5-key <integer_id> "ENC <md5_key>"```

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Related PR: #1010