### PR TITLE
Remove 'Time Last Saved' line in sros.rb model

### DIFF
--- a/lib/oxidized/model/sros.rb
+++ b/lib/oxidized/model/sros.rb
@@ -27,9 +27,10 @@ class SROS < Oxidized::Model
   #
   cmd 'show system information' do |cfg|
     #
-    # Strip uptime.
+    # Strip uptime & last save.
     #
     cfg.sub! /^System Up Time.*\n/, ''
+    cfg.sub! /^Time Last Saved.*\n/, ''
     cfg.gsub! /# Finished .*/, ''
     cfg.gsub! /# Generated .*/, ''
     comment cfg


### PR DESCRIPTION
## Description
The 'Time Last Saved' line in cmd 'show system information' is updated when a user executes 'admin save', even if no configuration was changed. This causes false positive diffs.
This change strips the line from the output.