### PR TITLE
[AOSW] Add show license passphrase

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -58,6 +58,11 @@ class AOSW < Oxidized::Model
     rstrip_cfg comment cfg
   end
 
+  cmd 'show license passphrase' do |cfg|
+    cfg = "" if cfg.match /(Invalid input detected at '\^' marker|Parse error)/ # Don't show for unsupported devices (IAP and MAS)
+    rstrip_cfg comment cfg
+  end
+
   cmd 'show running-config' do |cfg|
     out = []
     cfg.each_line do |line|


### PR DESCRIPTION
Used instead of a serial number for virtual mobility master and virtual controllers

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
