### PR TITLE
Support for Calix AXOS Devices

### DIFF
--- a/lib/oxidized/model/axos.rb
+++ b/lib/oxidized/model/axos.rb
@@ -1,5 +1,5 @@
 class AxOS < Oxidized::Model
-  prompt /([\w.@()-]+[#]\s?)$/
+  prompt /(\x1b\[\?7h)?([\w.@()-]+[#]\s?)$/
   comment '! '
 
   cmd 'show running-config | nomore' do |cfg|

--- a/lib/oxidized/model/axos.rb
+++ b/lib/oxidized/model/axos.rb
@@ -1,0 +1,11 @@
+class AXOS < Oxidized::Model
+  prompt /([\w.@()-]+[#]\s?)$/
+  comment '! '
+  cmd 'show running-config | nomore' do |cfg|
+    cfg
+  end
+
+  cfg :ssh do
+    pre_logout 'exit'
+  end
+end

--- a/lib/oxidized/model/axos.rb
+++ b/lib/oxidized/model/axos.rb
@@ -1,8 +1,13 @@
-class AXOS < Oxidized::Model
+class AxOS < Oxidized::Model
   prompt /([\w.@()-]+[#]\s?)$/
   comment '! '
+
   cmd 'show running-config | nomore' do |cfg|
-    cfg
+    cfg.cut_head
+  end
+
+  cmd :all do |cfg|
+    cfg.cut_tail
   end
 
   cfg :ssh do


### PR DESCRIPTION
I have tested this on a Calix AxOS E5-16F, backups config perfectly. The first line in the config file is the command to show the config, i don't know how to remove this, so if someone tells me i can update it and test again.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add configuration backup support for Calix AXOS operating system, Tested with Calix E5-16F

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
