### PR TITLE
Require openssl for use of 'OpenSSL::SSL...' constants

### DIFF
--- a/lib/oxidized/source/http.rb
+++ b/lib/oxidized/source/http.rb
@@ -1,4 +1,5 @@
 module Oxidized
+  require 'openssl'
   class HTTP < Source
     def initialize
       @cfg = Oxidized.config.source.http

--- a/lib/oxidized/source/http.rb
+++ b/lib/oxidized/source/http.rb
@@ -1,5 +1,4 @@
 module Oxidized
-  require 'openssl'
   class HTTP < Source
     def initialize
       @cfg = Oxidized.config.source.http
@@ -13,6 +12,7 @@ module Oxidized
     end
 
     require "net/http"
+    require "net/https"
     require "uri"
     require "json"
 


### PR DESCRIPTION
## Description
Current issue:
When using an `http` source and `secure: false`, oxidized gives error:

```
# oxidized
I, [2018-07-30T01:54:56.900233 #128]  INFO -- : Oxidized starting, running as pid 128
I, [2018-07-30T01:54:56.923148 #128]  INFO -- : lib/oxidized/nodes.rb: Loading nodes
F, [2018-07-30T01:54:56.923327 #128] FATAL -- : Oxidized crashed, crashfile written in /root/.config/oxidized/crash
uninitialized constant Oxidized::HTTP::OpenSSL
```

## Fix
We require the 'openssl' package.