### PR TITLE
pessimistic net-telnet lock on 0.1 as 0.2 requires ruby 2.3+

### DIFF
--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -20,12 +20,9 @@ Gem::Specification.new do |s|
   s.required_ruby_version =           '>= 2.0.0'
   s.add_runtime_dependency 'asetus',  '~> 0.1'
   s.add_runtime_dependency 'net-ssh', '~> 4.1.0'
+  s.add_runtime_dependency 'net-telnet', '~> 0.1.1'
   s.add_runtime_dependency 'rugged',  '~> 0.21', '>= 0.21.4'
   s.add_runtime_dependency 'slop',    '~> 3.5'
-
-  if defined?(RUBY_VERSION) && RUBY_VERSION > '2.3'
-    s.add_runtime_dependency 'net-telnet', '~> 0.1.1'
-  end
 
   s.add_development_dependency 'simplecov'
   if ENV['CI'] == 'true'

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'slop',    '~> 3.5'
 
   if defined?(RUBY_VERSION) && RUBY_VERSION > '2.3'
-    s.add_runtime_dependency 'net-telnet', '~> 0'
+    s.add_runtime_dependency 'net-telnet', '~> 0.1.1'
   end
 
   s.add_development_dependency 'simplecov'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Pessimistic lock for net-telnet to 0.1 as 0.2 depends on Ruby 2.3+
Make dependency on net-telnet unconditional since the gemspec is evaluated as bundle time - avoids release master environment drift from having impact on published gems (0.21.0 release had no net-telnet dependency in the published gem, but 0.22.0+ does).

Closes #1472 

