### PR TITLE
add sequel and gpgme source deps to Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * MISC: Added verbiage to set OXIDIZED_HOME correctly under Debian 8.8 w/systemd
 * FEATURE: add viptela model (@bobthebutcher)
 * FEATURE: add ECI Telecom Appolo platform bij arien.vijn@linklight.nl
-
+* MISC: add gpgme and sequel gems to Dockerfile for sources
 
 ## 0.24.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ RUN dpkg -i /tmp/*.deb
 # dependencies for hooks
 RUN gem install aws-sdk slack-api xmpp4r cisco_spark
 
+# dependencies for sources
+RUN gem install gpgme sequel
+
 # build and install oxidized
 COPY . /tmp/oxidized/
 WORKDIR /tmp/oxidized


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Adds ```sequel``` and ```gpgme``` gems to Dockerfile to enable more functionality out of the box.

Closes #1484 
