### PR TITLE
add configurable per node ssh_no_keepalive boolean

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * MISC: Added verbiage to set OXIDIZED_HOME correctly under Debian 8.8 w/systemd
 * FEATURE: add viptela model (@bobthebutcher)
 * FEATURE: add ECI Telecom Appolo platform bij arien.vijn@linklight.nl
+* FEATURE: ssh keepalive now configurable per node with ssh_keepalive boolean
 * MISC: add gpgme and sequel gems to Dockerfile for sources
 
 ## 0.24.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * MISC: Added verbiage to set OXIDIZED_HOME correctly under Debian 8.8 w/systemd
 * FEATURE: add viptela model (@bobthebutcher)
 * FEATURE: add ECI Telecom Appolo platform bij arien.vijn@linklight.nl
-* FEATURE: ssh keepalive now configurable per node with ssh_keepalive boolean
+* FEATURE: ssh keepalive now configurable per node with ssh_no_keepalive boolean
 * MISC: add gpgme and sequel gems to Dockerfile for sources
 
 ## 0.24.0

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -62,13 +62,22 @@ vars:
   ssh_no_exec: true
 ```
 
+## Disabling SSH keepalives
+
+Oxidized SSH input makes use of SSH keepalives to prevent timeouts from slower devices and to quickly tear down stale sessions in larger deployments. There have been reports of SSH keepalives breaking compatibility with certain OS types. They can be disabled using the `ssh_no_keepalive` variable on a per-node basis (by specifying it in the source) or configured application-wide.
+
+```yaml
+vars:
+  ssh_no_keepalive: true
+```
+
 ## SSH Auth Methods
 
 By default, Oxidized registers the following auth methods: `none`, `publickey` and `password`. However you can configure this globally, by groups, models or nodes.
 
 ```yaml
 vars:
-    auth_methods: [ "none", "publickey", "password", "keyboard-interactive" ]
+  auth_methods: [ "none", "publickey", "password", "keyboard-interactive" ]
 ```
 
 ## SSH Proxy Command

--- a/docs/Model-Notes/Nokia.md
+++ b/docs/Model-Notes/Nokia.md
@@ -1,0 +1,9 @@
+# Nokia
+
+## Nokia ISAM and SSH keepalives
+
+Nokia ISAM might require disabling SSH keepalives.
+
+[Reference](https://github.com/ytti/oxidized/issues/1482)
+
+Back to [Model-Notes](README.md)

--- a/docs/Model-Notes/README.md
+++ b/docs/Model-Notes/README.md
@@ -14,6 +14,7 @@ Cumulus|[Cumulus](Cumulus.md)|11 Jun 2018
 Huawei|[VRP](VRP-Huawei.md)|17 Nov 2017
 Juniper|[MX/QFX/EX/SRX/J Series](JunOS.md)|18 Jan 2018
 Netgear|[Netgear](Netgear.md)|11 Apr 2018
+Nokia|[Nokia ISAM](Nokia.md)|22 Aug 2018
 Viptela|[Viptela](Viptela.md)|1 Jul 2018
 Zyxel|[XGS4600 Series](XGS4600-Zyxel.md)|1 Feb 2018
 

--- a/docs/Model-Notes/Viptela.md
+++ b/docs/Model-Notes/Viptela.md
@@ -1,9 +1,11 @@
 # Viptela
 
-This model collects running config and other desired commands from Viptela devices. 
+This model collects running config and other desired commands from Viptela devices.
+
 Pagination is disabled post login.
 
 ## Supported Commands
+
 - show running-config
 - show version
 

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -122,7 +122,7 @@ module Oxidized
       ssh_opts = {
         port:         (vars(:ssh_port) || 22).to_i,
         paranoid:     secure,
-        keepalive:    vars(:ssh_keepalive) || true,
+        keepalive:    vars(:ssh_no_keepalive) ? false : true,
         password:     @node.auth[:password],
         timeout:      Oxidized.config.timeout,
         number_of_password_prompts: 0

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -122,7 +122,7 @@ module Oxidized
       ssh_opts = {
         port:         (vars(:ssh_port) || 22).to_i,
         paranoid:     secure,
-        keepalive:    true,
+        keepalive:    vars(:ssh_keepalive) || true,
         password:     @node.auth[:password],
         timeout:      Oxidized.config.timeout,
         number_of_password_prompts: 0


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
ssh keepalive support was turned on in #1276 but appears to have side effect in rare edge cases, such as #1482
 
This makes ssh input keepalive setting configurable to deal with rare devices which don't correctly support keep-alive

Closes #1482
