### PR TITLE
Update openbsd.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * FEATURE: add viptela model (@bobthebutcher)
 * FEATURE: add ECI Telecom Appolo platform bij arien.vijn@linklight.nl
 * MISC: add gpgme and sequel gems to Dockerfile for sources
+* BUGFIX: model openbsd
 
 ## 0.24.0
 

--- a/lib/oxidized/model/openbsd.rb
+++ b/lib/oxidized/model/openbsd.rb
@@ -39,9 +39,6 @@ class Openbsd < Oxidized::Model
     cfg += add_comment('INTERFACE FILES')
     cfg += cmd('tail -n +1 /etc/hostname.*')
 
-    cfg += add_comment('RESOLV.CONF FILE')
-    cfg += cmd('cat /etc/resolv.conf')
-
     cfg += add_comment('SNMP FILE')
     cfg += cmd('cat /etc/snmpd.conf')
 

--- a/lib/oxidized/model/openbsd.rb
+++ b/lib/oxidized/model/openbsd.rb
@@ -24,6 +24,15 @@ class Openbsd < Oxidized::Model
     cfg = add_comment('HOSTNAME FILE')
     cfg += cmd('cat /etc/myname')
 
+    cfg += add_comment('RESOLV.CONF FILE')
+    cfg += cmd('cat /etc/resolv.conf')
+
+    cfg += add_comment('NTP.CONF FILE')
+    cfg += cmd('cat /etc/ntp.conf')
+
+    cfg += add_comment('PF FILE')
+    cfg += cmd('cat /etc/pf.conf')
+
     cfg += add_comment('HOSTS FILE')
     cfg += cmd('cat /etc/hosts')
 
@@ -33,28 +42,8 @@ class Openbsd < Oxidized::Model
     cfg += add_comment('RESOLV.CONF FILE')
     cfg += cmd('cat /etc/resolv.conf')
 
-    cfg += add_comment('NTP.CONF FILE')
-    cfg += cmd('cat /etc/ntp.conf')
-
-    cfg += add_comment('IP ROUTES PER ROUTING DOMAIN')
-    cfg += add_small_comment('Routing Domain 0')
-    cfg += cmd('route -T0 exec netstat -rn')
-    cfg += add_small_comment('Routing Domain 1')
-    cfg += cmd('route -T1 exec netstat -rn')
-    cfg += add_small_comment('Routing Domain 2')
-    cfg += cmd('route -T2 exec netstat -rn')
-    cfg += add_small_comment('Routing Domain 3')
-    cfg += cmd('route -T3 exec netstat -rn')
-    cfg += add_small_comment('Routing Domain 4')
-    cfg += cmd('route -T4 exec netstat -rn')
-    cfg += add_small_comment('Routing Domain 5')
-    cfg += cmd('route -T5 exec netstat -rn')
-
     cfg += add_comment('SNMP FILE')
     cfg += cmd('cat /etc/snmpd.conf')
-
-    cfg += add_comment('PF FILE')
-    cfg += cmd('cat /etc/pf.conf')
 
     cfg += add_comment('MOTD FILE')
     cfg += cmd('cat /etc/motd')


### PR DESCRIPTION
Routing table shows triggered diffs and the static routes are already in the /etc/hostname.* files defined

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
