### PR TITLE
capture ZebOS configuration from F5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * FEATURE: add ECI Telecom Appolo platform bij arien.vijn@linklight.nl
 * FEATURE: ssh keepalive now configurable per node with ssh_no_keepalive boolean
 * MISC: add gpgme and sequel gems to Dockerfile for sources
+* MISC: capture ZebOS configuration for TMOS model
 
 ## 0.24.0
 

--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -42,6 +42,8 @@ class TMOS < Oxidized::Model
     comment cfg
   end
 
+  cmd('cat /config/zebos/*/ZebOS.conf') { |cfg| comment cfg }
+
   cmd('cat /config/partitions/*/bigip.conf') { |cfg| comment cfg }
 
   cfg :ssh do


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
When running an F5, you can configure Advanced Routing, this in generally BGP. This BGP configuration is done through `imish`, which drops you in ZebOS. This configuration is useful to capture/audit for changes as it affects traffic as much as any other configuration
