### PR TITLE
Update netscaler.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * FEATURE: add ECI Telecom Appolo platform bij arien.vijn@linklight.nl
 * FEATURE: ssh keepalive now configurable per node with ssh_no_keepalive boolean
 * MISC: add gpgme and sequel gems to Dockerfile for sources
+* MISC: add secret filtering to netscaler (@shepherdjay)
 
 ## 0.24.0
 

--- a/lib/oxidized/model/netscaler.rb
+++ b/lib/oxidized/model/netscaler.rb
@@ -14,6 +14,14 @@ class NetScaler < Oxidized::Model
     comment cfg
   end
 
+  cmd :secret do |cfg|
+    cfg.gsub! /(-password)\s\w+/, '\\1 <secret hidden>'
+    cfg.gsub! /(-keyValue)\s\w+/, '\\1 <secret hidden>'
+    cfg.gsub! /(-radKey)\s\w+/, '\\1 <secret hidden>'
+    cfg.gsub! /(-ldapBindDnPassword)\s\w+/, '\\1 <secret hidden>'
+    cfg
+  end
+
   cmd 'show ns ns.conf'
 
   cfg :ssh do


### PR DESCRIPTION
Removes values that change on every `show ns ns.conf` command

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Removes the key lines in the netscaler model from the config save. We found in practice these values change on every pull of the show ns ns.conf command whether they change or not. As such I don't think its valuable to pollute the config history with these. Open to discussion

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
