### PR TITLE
Improve regex for hiding secrets on EOS

### DIFF
--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -15,6 +15,7 @@ class EOS < Oxidized::Model
     cfg.gsub! /username (\S+) role (\S+).*/, '<secret hidden>'
     cfg.gsub! /^(enable secret).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(tacacs-server key \d+).*/, '\\1 <configuration removed>'
+    cfg.gsub /neighbor (\S+) password \d+ (\S+).*/, '\\1 <bgp password hidden>'
     cfg
   end
 

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -12,6 +12,7 @@ class EOS < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /username (\S+) privilege (\d+) (\S+).*/, '<secret hidden>'
+    cfg.gsub! /username (\S+) role (\S+).*/, '<secret hidden>'
     cfg.gsub! /^(enable secret).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(tacacs-server key \d+).*/, '\\1 <configuration removed>'
     cfg


### PR DESCRIPTION
Without this change, when the configuration diff contains 'role' in place of
'privilege', the secret is not hidden.  This change extends the regex to include
the term 'role' when hiding secrets.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)
