### PR TITLE
tmos: ZebOS configuration should only be captured if it's configured

### DIFF
--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -42,7 +42,7 @@ class TMOS < Oxidized::Model
     comment cfg
   end
 
-  cmd('cat /config/zebos/*/ZebOS.conf') { |cfg| comment cfg }
+  cmd('[ -d "/config/zebos" ] && cat /config/zebos/*/ZebOS.conf') { |cfg| comment cfg }
 
   cmd('cat /config/partitions/*/bigip.conf') { |cfg| comment cfg }
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [] Tests added or adapted (try `rake test`)
- [] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
In #1501 ZebOS is captured, however ZebOS is used when the F5 has Dynamic Routing licensed + provisioned. This adds a check for the `/config/zebos` directory before it attempts to read the ZebOS configuration.

Makes #1501 more robust
