### PR TITLE
Bump Dockerfile to phusion/baseimage v0.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * BUGFIX: netgear telnet password prompt not detected
 * BUGFIX: xos model should not modify config on legacy Extreme Networks devices (@sq9mev)
 * BUGFIX: model edgecos, ciscosmb, openbsd
-* MISC: bump Dockerfile phusion/baseimage:0.10.0 -> 0.10.1
+* MISC: bump Dockerfile phusion/baseimage:0.10.0 -> 0.11, revert to one-stage build
 * MISC: Added verbiage to set OXIDIZED_HOME correctly under Debian 8.8 w/systemd
 * MISC: add gpgme and sequel gems to Dockerfile for sources
 * MISC: eos model removes user secrets and BGP secrets (@yzguy)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Samer Abdel-Hafez <sam@arahant.net>"
 
 # set up dependencies for the build process
 RUN apt-get -yq update && \
-    apt-get -yq install ruby2.3 ruby2.3-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++ libffi-dev ruby-bundler libicu-dev
+    apt-get -yq install ruby2.5 ruby2.5-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++ libffi-dev ruby-bundler libicu-dev
 
 # dependencies for hooks
 RUN gem install aws-sdk slack-api xmpp4r cisco_spark

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,10 @@
-# -- stage 1: backport libssh2 1.7.0 from zesty for xenial, as githubrepo hook requires it
-FROM ubuntu:xenial as libssh2-backport
-
-# set up dependencies for the build process
-RUN apt-get -yq update && \
-    apt-get -yq install build-essential chrpath debhelper dh-autoreconf libgcrypt20-dev zlib1g-dev
-
-# build libssh2 1.7.0
-WORKDIR /tmp/libssh2-build
-ADD https://launchpad.net/ubuntu/+archive/primary/+files/libssh2_1.7.0-1ubuntu1.debian.tar.xz .
-ADD https://launchpad.net/ubuntu/+archive/primary/+files/libssh2_1.7.0.orig.tar.gz .
-RUN tar xvf libssh2_1.7.0.orig.tar.gz
-WORKDIR /tmp/libssh2-build/libssh2-1.7.0
-RUN tar xvf ../libssh2_1.7.0-1ubuntu1.debian.tar.xz
-
-WORKDIR /tmp/libssh2-build/libssh2-1.7.0
-ENV DEB_BUILD_OPTIONS nocheck
-RUN dpkg-buildpackage -b
-
-# -- stage 2: build the actual oxidized container
-FROM phusion/baseimage:0.10.1
+# Single-stage build of an oxidized container from phusion/baseimage-docker v0.11, derived from Ubuntu 18.04 (Bionic Beaver)
+FROM phusion/baseimage:0.11
 LABEL maintainer="Samer Abdel-Hafez <sam@arahant.net>"
 
 # set up dependencies for the build process
 RUN apt-get -yq update && \
     apt-get -yq install ruby2.3 ruby2.3-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++ libffi-dev ruby-bundler libicu-dev
-
-# upgrade libssh2 to self-built backport from stage 1
-COPY --from=libssh2-backport \
-    /tmp/libssh2-build/libssh2-1_1.7.0-1ubuntu1_amd64.deb \
-    /tmp/libssh2-build/libssh2-1-dev_1.7.0-1ubuntu1_amd64.deb \
-    /tmp/
-RUN dpkg -i /tmp/*.deb
 
 # dependencies for hooks
 RUN gem install aws-sdk slack-api xmpp4r cisco_spark
@@ -52,7 +26,6 @@ RUN gem install oxidized-web --no-ri --no-rdoc
 # clean up
 WORKDIR /
 RUN rm -rf /tmp/oxidized
-RUN rm /tmp/*.deb
 RUN apt-get -yq --purge autoremove ruby-dev pkg-config make cmake ruby-bundler
 
 # add runit services


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Bumps the base container to phusion/baseimage v0.11, based on Ubuntu 18.04 (Bionic Beaver). This distribution provides the requisite libssh2 version neccesary for compatibility with Github (`githubrepo` hook) out of the box. As a consequence, we can revert from the two-stage build process that included building a libssh2 1.7 backport first to a single-stage build.