### PR TITLE
Sudo for cumulus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * MISC: eos model removes user secrets and BGP secrets (@yzguy)
 * MISC: add secret filtering to netscaler (@shepherdjay)
 * MISC: capture ZebOS configuration for TMOS model (@yzguy)
+* FEATURE: add privilege escalation to the cumulus model (@user4574)
 
 ## 0.24.0
 

--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -91,7 +91,7 @@ class Cumulus < Oxidized::Model
     post_login do
       if vars(:enable) == true
         cmd "sudo su -", /^\[sudo\] password/
-        cmd vars(:password)
+        cmd @node.auth[:password]
       elsif vars(:enable)
         cmd "su -", /^Password:/
         cmd vars(:enable)

--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -88,6 +88,19 @@ class Cumulus < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
+    post_login do
+      if vars(:enable) == true then
+        cmd "sudo su -", /^\[sudo] password/
+        cmd vars(:password)
+      elsif vars(:enable)
+        cmd "su -", /^Password:/
+        cmd vars(:enable)
+      end
+    end
+
+    pre_logout do
+      cmd "exit" if vars(:enable)
+    end
     pre_logout 'exit'
   end
 end

--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -89,8 +89,8 @@ class Cumulus < Oxidized::Model
 
   cfg :telnet, :ssh do
     post_login do
-      if vars(:enable) == true then
-        cmd "sudo su -", /^\[sudo] password/
+      if vars(:enable) == true
+        cmd "sudo su -", /^\[sudo\] password/
         cmd vars(:password)
       elsif vars(:enable)
         cmd "su -", /^Password:/


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
This PR introduces a new feature: privilege escalation for cumulus devices.

If enable is set for the node to true, we will send a command to sudo up to root, then provide the node password.

If it is set to anything else, we will su to root, using the enable variable as the root password for the device.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->

This closes issue #1069.