### PR TITLE
add libicu60 next to libicu-dev so its not autoremoved

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ LABEL maintainer="Samer Abdel-Hafez <sam@arahant.net>"
 
 # set up dependencies for the build process
 RUN apt-get -yq update && \
-    apt-get -yq install ruby2.5 ruby2.5-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++ libffi-dev ruby-bundler libicu-dev
+    apt-get -yq install ruby2.5 ruby2.5-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++ libffi-dev ruby-bundler libicu60 libicu-dev
 
 # dependencies for hooks
 RUN gem install aws-sdk slack-api xmpp4r cisco_spark


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add libicu next to libicu-dev to Dockerfile to prevent it from being autoremoved after build.

Closes #1531 