### PR TITLE
add sqlite3 and mysql2 drivers for sequel to Dockerfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,17 @@
 * FEATURE: add ECI Telecom Appolo platform bij arien.vijn@linklight.nl
 * FEATURE: ssh keepalive now configurable per node with ssh_no_keepalive boolean
 * FEATURE: add Comtrol model (@RobbFromIT)
+* FEATURE: add privilege escalation to the cumulus model (@user4574)
 * BUGFIX: netgear telnet password prompt not detected
 * BUGFIX: xos model should not modify config on legacy Extreme Networks devices (@sq9mev)
 * BUGFIX: model edgecos, ciscosmb, openbsd
 * MISC: bump Dockerfile phusion/baseimage:0.10.0 -> 0.11, revert to one-stage build
+* MISC: add sqlite3 and mysql2 drivers for sequel to Dockerfile
 * MISC: Added verbiage to set OXIDIZED_HOME correctly under Debian 8.8 w/systemd
 * MISC: add gpgme and sequel gems to Dockerfile for sources
 * MISC: eos model removes user secrets and BGP secrets (@yzguy)
 * MISC: add secret filtering to netscaler (@shepherdjay)
 * MISC: capture ZebOS configuration for TMOS model (@yzguy)
-* FEATURE: add privilege escalation to the cumulus model (@user4574)
 
 ## 0.24.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,13 +4,13 @@ LABEL maintainer="Samer Abdel-Hafez <sam@arahant.net>"
 
 # set up dependencies for the build process
 RUN apt-get -yq update && \
-    apt-get -yq install ruby2.5 ruby2.5-dev libsqlite3-dev libssl-dev pkg-config make cmake libssh2-1-dev git g++ libffi-dev ruby-bundler libicu60 libicu-dev
+    apt-get -yq install ruby2.5 ruby2.5-dev libssl1.1 libssl-dev pkg-config make cmake libssh2-1 libssh2-1-dev git g++ libffi-dev ruby-bundler libicu60 libicu-dev libsqlite3-0 libsqlite3-dev libmysqlclient20 libmysqlclient-dev
 
 # dependencies for hooks
-RUN gem install aws-sdk slack-api xmpp4r cisco_spark
+RUN gem install aws-sdk slack-api xmpp4r cisco_spark --no-ri --no-rdoc
 
 # dependencies for sources
-RUN gem install gpgme sequel
+RUN gem install gpgme sequel sqlite3 mysql2 --no-ri --no-rdoc
 
 # build and install oxidized
 COPY . /tmp/oxidized/
@@ -26,7 +26,7 @@ RUN gem install oxidized-web --no-ri --no-rdoc
 # clean up
 WORKDIR /
 RUN rm -rf /tmp/oxidized
-RUN apt-get -yq --purge autoremove ruby-dev pkg-config make cmake ruby-bundler
+RUN apt-get -yq --purge autoremove ruby-dev pkg-config make cmake ruby-bundler libssl-dev libssh2-1-dev libicu-dev libsqlite3-dev libmysqlclient-dev
 
 # add runit services
 ADD extra/oxidized.runit /etc/service/oxidized/run


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add the `sqlite3` and `mysql2` gems to Dockerfile for `sequel` (used by sql source) to be useful out of the box. 

Installs most gems with `--no-docs` and `--no-ri` option as well as removes more build dependencies after build to reduce size of resulting container.

Closes #1526 
