### PR TITLE
Dlink fast forward slash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 * FEATURE: add privilege escalation to the cumulus model (@user4574)
 * BUGFIX: netgear telnet password prompt not detected
 * BUGFIX: xos model should not modify config on legacy Extreme Networks devices (@sq9mev)
-* BUGFIX: model edgecos, ciscosmb, openbsd
+* BUGFIX: model dlink, edgecos, ciscosmb, openbsd
 * MISC: bump Dockerfile phusion/baseimage:0.10.0 -> 0.11, revert to one-stage build
 * MISC: add sqlite3 and mysql2 drivers for sequel to Dockerfile
 * MISC: Added verbiage to set OXIDIZED_HOME correctly under Debian 8.8 w/systemd

--- a/lib/oxidized/model/dlink.rb
+++ b/lib/oxidized/model/dlink.rb
@@ -1,7 +1,7 @@
 class Dlink < Oxidized::Model
   # D-LINK Switches
 
-  prompt /^(\r*[\w.@()\/:-]+[#>]\s?)$/ 
+  prompt /^(\r*[\w.@()\/:-]+[#>]\s?)$/
   comment '# '
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/dlink.rb
+++ b/lib/oxidized/model/dlink.rb
@@ -1,7 +1,7 @@
 class Dlink < Oxidized::Model
   # D-LINK Switches
 
-  prompt /^(\r*[\w.@():-]+[#>]\s?)$/
+  prompt /^(\r*[\w.@()\/:-]+[#>]\s?)$/ 
   comment '# '
 
   cmd :secret do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
D-Link defaults to using the model of the device as the hostname, which is displayed as prompt. Add support for forward slash (`/`) to accommodate D-Link DES 1210-10/ME.

Closes #1541 
