### PR TITLE
Comware 7 with accounting prompt change

### DIFF
--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -2,7 +2,7 @@ class Comware < Oxidized::Model
   # HP (A-series)/H3C/3Com Comware
 
   # sometimes the prompt might have a leading nul or trailing ASCII Bell (^G)
-  prompt /^\0*(<[\w.-]+>).?$/
+  prompt /^\0*(<[\w\s.-]+>|Accounting completed successfully\.).?$/  
   comment '# '
 
   # example how to handle pager
@@ -44,6 +44,7 @@ class Comware < Oxidized::Model
       end
     end
 
+    post-login ''
     post_login 'screen-length disable'
     post_login 'undo terminal monitor'
     pre_logout 'quit'


### PR DESCRIPTION
When accounting is enabled in Comware 7 devices( and possibly older version as well), the user gets "Accounting completed successfully."  instead of the typical <$HOSTNAME> prompt.
The proposed change works with devices running Comware 5 and 7, either when the accounting message appears or not.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
