### PR TITLE
add https proxy info in slackdiff and ciscosparkdiff hook docs

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -184,6 +184,18 @@ hooks:
 
 Note the channel name must be in quotes.
 
+An HTTPS proxy can optionally be specified if needed to reach the Slack API endpoint.
+
+```yaml
+hooks:
+  slack:
+    type: slackdiff
+    events: [post_store]
+    token: SLACK_BOT_TOKEN
+    channel: "#network-changes"
+    proxy: http://myproxy:8080
+```
+
 ## Hook type: ciscosparkdiff
 
 The `ciscosparkdiff` hook posts config diffs to a [Cisco Spark](https://www.ciscospark.com/) space of your choice. It only triggers for `post_store` events.
@@ -220,6 +232,19 @@ hooks:
 ```
 
 Note the space and access tokens must be in quotes.
+
+An HTTPS proxy can optionally be specified if needed to reach the Spark API endpoint.
+
+```yaml
+hooks:
+  ciscospark:
+    type: ciscosparkdiff
+    events: [post_store]
+    accesskey: SPARK_BOT_API_OR_OAUTH_KEY
+    space: SPARK_SPACE_ID
+    diff: true
+    proxy: http://myproxy:8080
+```
 
 ## Hook type: xmppdiff
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -184,7 +184,7 @@ hooks:
 
 Note the channel name must be in quotes.
 
-An HTTPS proxy can optionally be specified if needed to reach the Slack API endpoint.
+A proxy can optionally be specified if needed to reach the Slack API endpoint.
 
 ```yaml
 hooks:
@@ -233,7 +233,7 @@ hooks:
 
 Note the space and access tokens must be in quotes.
 
-An HTTPS proxy can optionally be specified if needed to reach the Spark API endpoint.
+A proxy can optionally be specified if needed to reach the Spark API endpoint.
 
 ```yaml
 hooks:


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

### rubocop output

`rubocop` output resulted in a set of changes, but not to any files I had touched.  This is purely a documentation update.  I left the rubocop auto-correct changes out of this commit/PR as I don't want ot mess with anything currently in flight but outside the scope of this PR.

rubocop output:

```
Offenses:

extra/syslog.rb:51:35: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
      /(.*)\.ip\.fi/       => '\1',
                                  ^
extra/syslog.rb:57:48: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
      :nxos  => /%VSHD-5-VSHD_SYSLOG_CONFIG_I:/,
                                               ^
lib/oxidized/node/stats.rb:13:30: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
          :time   => job.time,
                             ^
lib/oxidized/config.rb:53:29: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
        'juniper' => 'junos',
                            ^
lib/oxidized/node.rb:102:35: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
        :mtime     => @stats.mtime,
                                  ^
lib/oxidized/node.rb:110:32: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
          :time   => @last.time,
                               ^
lib/oxidized/node.rb:148:52: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
        password:       resolve_key(:password, opt),
                                                   ^
lib/oxidized/input/ssh.rb:9:29: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of an array.
        Net::SSH::Disconnect,
                            ^
lib/oxidized/input/ssh.rb:13:39: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of an array.
        Net::SSH::AuthenticationFailed,
                                      ^
lib/oxidized/input/ssh.rb:14:8: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
      ],
       ^
lib/oxidized/input/ftp.rb:14:8: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
      ],
       ^
lib/oxidized/input/input.rb:8:28: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of an array.
        Errno::ECONNREFUSED,
                           ^
lib/oxidized/input/input.rb:18:25: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of an array.
        Errno::ETIMEDOUT,
                        ^
lib/oxidized/input/input.rb:19:8: C: [Corrected] Style/TrailingCommaInLiteral: Avoid comma after the last item of a hash.
      ],
       ^

162 files inspected, 14 offenses detected, 14 offenses corrected
```

### rake tests

No new code, but confirmed rake tests passed:

```
Finished in 5.122694s, 6.6371 runs/s, 24.7916 assertions/s.

34 runs, 127 assertions, 0 failures, 0 errors, 0 skips
Coverage report generated for RSpec to /home/hslabbert/repos/oxidized-hs/coverage. 932 / 1497 LOC (62.26%) covered.
```

### documentation

This is a documentation update, so it touches only documentation and is necessarily reflected in documentation.

### user visible changes added to [CHANGELOG.md](/CHANGELOG.md)

Didn't touch [CHANGELOG.md](/CHANGELOG.md) as this isn't adding functionality, just adding documentation for existing functionality.

## Description

This just adds references and examples for the `proxy` option under the existing slackdiff and ciscosparkdiff documentation.  I needed to leverage that for slackdiff; got it from the actual slackdiff hook code and validated it works, so adding it to docs for discoverability.