### PR TITLE
adding more gsubs for removing sensitive config on FTOS/DNOS

### DIFF
--- a/lib/oxidized/model/ftos.rb
+++ b/lib/oxidized/model/ftos.rb
@@ -11,8 +11,8 @@ class FTOS < Oxidized::Model
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /(secret \d* {0,1})\S+(.*)/, '\\1<secret hidden>\\2'
     cfg.gsub! /(password \d+) \S+(.*)/, '\\1 <hash hidden>\\2'
-    cfg.gsub! /(snmp-server.*version \S+) \S+(.*)/, '\\1 <community removed>\\2'
-    cfg.gsub! /(radius-server.*key \d )\S+/, '\\1<hash hidden>\\2'
+    cfg.gsub! /(^snmp-server.*version \S+) \S+(.*)/, '\\1 <community removed>\\2'
+    cfg.gsub! /(^radius-server.*key \d )\S+/, '\\1<hash hidden>\\2'
     cfg
   end
 

--- a/lib/oxidized/model/ftos.rb
+++ b/lib/oxidized/model/ftos.rb
@@ -11,6 +11,8 @@ class FTOS < Oxidized::Model
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /(secret \d* {0,1})\S+(.*)/, '\\1<secret hidden>\\2'
     cfg.gsub! /(password \d+) \S+(.*)/, '\\1 <hash hidden>\\2'
+    cfg.gsub! /(snmp-server.*version \S+) \S+(.*)/, '\\1 <community removed>\\2'
+    cfg.gsub! /(radius-server.*key \d )\S+/, '\\1<hash hidden>\\2'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Some additional sensitive data needed to be removed from ftos configs when using remove_secret: true.

Before:
```
radius-server host 192.168.1.1 key 7 somehashhere
snmp-server host 192.168.1.2 traps version 2c somecommunitystring udp-port 162
```

After:
```
radius-server host 192.168.1.1 key 7 <hash hidden> 
snmp-server host 192.168.1.2 traps version 2c <community removed> udp-port 162
```
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
