### PR TITLE
Add ssh_host_key setting

### DIFF
--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -145,6 +145,7 @@ module Oxidized
       ssh_opts[:keys]       = [vars(:ssh_keys)].flatten if vars(:ssh_keys)
       ssh_opts[:kex]        = vars(:ssh_kex).split(/,\s*/) if vars(:ssh_kex)
       ssh_opts[:encryption] = vars(:ssh_encryption).split(/,\s*/) if vars(:ssh_encryption)
+      ssh_opts[:host_key]   = vars(:ssh_host_key).split(/,\s*/) if vars(:ssh_host_key)
 
       if Oxidized.config.input.debug?
         ssh_opts[:logger]  = Oxidized.logger


### PR DESCRIPTION
## Description
When connecting to old equipment it is sometimes necesary to force the 
host_key to something old like ssh-dss.

Since it is already possible to force the encryption and kex settings, 
this one is added as well.