### PR TITLE
Add ssh_hmac setting

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -101,9 +101,9 @@ vars_map:
 
 ## SSH enabling legacy algorithms
 
-When connecting to older firmware over SSH, it is sometimes necessary to enable legacy/disabled settings like KexAlgorithms, HostKeyAlgorithms or the Encryption.
+When connecting to older firmware over SSH, it is sometimes necessary to enable legacy/disabled settings like KexAlgorithms, HostKeyAlgorithms, MAC or the Encryption.
 
-These settings can be provided on a per-node basis by mapping the ssh_kex, ssh_host_key and the ssh_encryption fields from you source.
+These settings can be provided on a per-node basis by mapping the ssh_kex, ssh_host_key, ssh_hmac and the ssh_encryption fields from you source.
 
 ```yaml
 ...
@@ -114,7 +114,8 @@ vars_map:
   enable: 2
   ssh_kex: 3
   ssh_host_key: 4
-  ssh_encryption: 5
+  ssh_hmac: 5
+  ssh_encryption: 6
 ...
 ```
 

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -146,6 +146,7 @@ module Oxidized
       ssh_opts[:kex]        = vars(:ssh_kex).split(/,\s*/) if vars(:ssh_kex)
       ssh_opts[:encryption] = vars(:ssh_encryption).split(/,\s*/) if vars(:ssh_encryption)
       ssh_opts[:host_key]   = vars(:ssh_host_key).split(/,\s*/) if vars(:ssh_host_key)
+      ssh_opts[:hmac]       = vars(:ssh_hmac).split(/,\s*/) if vars(:ssh_hmac)
 
       if Oxidized.config.input.debug?
         ssh_opts[:logger]  = Oxidized.logger


### PR DESCRIPTION
## Description

This add the ssh_hmac setting. This completes all settings which might 
be needed when connecting to older firmware releases.
