### PR TITLE
Add ssh_proxy_port

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -82,11 +82,11 @@ vars:
 
 ## SSH Proxy Command
 
-Oxidized can `ssh` through a proxy as well. To do so we just need to set `ssh_proxy` variable with the proxy host information.
+Oxidized can `ssh` through a proxy as well. To do so we just need to set `ssh_proxy` variable with the proxy host information and optionally set the `ssh_proxy_port` with the SSH port if it is not listening no port 22.
 
 This can be provided on a per-node basis by mapping the proper fields from your source.
 
-An example for a `csv` input source that maps the 4th field as the `ssh_proxy` value.
+An example for a `csv` input source that maps the 4th field as the `ssh_proxy` value and the 5th field as `ssh_proxy_port`.
 
 ```yaml
 ...
@@ -96,6 +96,7 @@ map:
 vars_map:
   enable: 2
   ssh_proxy: 3
+  ssh_proxy_port: 4
 ...
 ```
 

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -137,6 +137,9 @@ module Oxidized
       if proxy_host = vars(:ssh_proxy)
         proxy_command =  "ssh "
         proxy_command += "-o StrictHostKeyChecking=no " unless secure
+        if proxy_port = vars(:ssh_proxy_port)
+          proxy_command += "-p #{proxy_port} "
+        end
         proxy_command += "#{proxy_host} -W %h:%p"
         proxy = Net::SSH::Proxy::Command.new(proxy_command)
         ssh_opts[:proxy] = proxy


### PR DESCRIPTION
## Description
This setting is useful when SSH is not listening on port 22 on the proxy 
host. It closes #1537 
