### PR TITLE
Update netscaler.rb with better secret handling

### DIFF
--- a/lib/oxidized/model/netscaler.rb
+++ b/lib/oxidized/model/netscaler.rb
@@ -15,10 +15,7 @@ class NetScaler < Oxidized::Model
   end
 
   cmd :secret do |cfg|
-    cfg.gsub! /(-password)\s\w+/, '\\1 <secret hidden>'
-    cfg.gsub! /(-keyValue)\s\w+/, '\\1 <secret hidden>'
-    cfg.gsub! /(-radKey)\s\w+/, '\\1 <secret hidden>'
-    cfg.gsub! /(-ldapBindDnPassword)\s\w+/, '\\1 <secret hidden>'
+    cfg.gsub! /\w+\s(-encrypted)/, '<secret hidden> \\1'
     cfg
   end
 


### PR DESCRIPTION
More generic regex for finding secrets. Testing shows all secrets are followed by `-encrypted`. Makes up for some additional secrets found on new production deployments from my previous commit.