### PR TITLE
update dnos.rb to take account of EMC branding

### DIFF
--- a/lib/oxidized/model/dnos.rb
+++ b/lib/oxidized/model/dnos.rb
@@ -5,8 +5,7 @@ class DNOS < Oxidized::Model
 
   cmd :all do |cfg|
     cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
-    cfg.gsub! /^Dell Networking OS uptime is\s.+/, '' # Omit constantly changing uptime info
-    cfg.gsub! /^Dell EMC Networking OS uptime is\s.+/, '' # Omit constantly changing uptime info
+    cfg.gsub! /^Dell(\sEMC)? Networking OS uptime is\s.+/, '' # Omit changing uptime info, account for branding
     cfg.each_line.to_a[2..-2].join
   end
 

--- a/lib/oxidized/model/dnos.rb
+++ b/lib/oxidized/model/dnos.rb
@@ -6,6 +6,7 @@ class DNOS < Oxidized::Model
   cmd :all do |cfg|
     cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
     cfg.gsub! /^Dell Networking OS uptime is\s.+/, '' # Omit constantly changing uptime info
+    cfg.gsub! /^Dell EMC Networking OS uptime is\s.+/, '' # Omit constantly changing uptime info
     cfg.each_line.to_a[2..-2].join
   end
 


### PR DESCRIPTION
newer DNOS switches are branded EMC as well - this means the regex for excluding the uptime from config backups is no longer effective on these switches. A sample output on the newer switches is "Dell EMC Networking OS uptime is 6 day(s), 20 hour(s), 33 minute(s)"

I have added a seperate line for the new format.
I imagine its also possible to do this more gracefully by editing the regex but im not all that skilled in it.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
