### PR TITLE
Cisco SMB - hide system uptime in Switch stacks

### DIFF
--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -25,6 +25,7 @@ class CiscoSMB < Oxidized::Model
 
   cmd 'show system' do |cfg|
     cfg.gsub! /System Up Time.*\n/, ''
+    cfg.gsub! /Unit.*Up time(.*\n)*\n/, ''
     comment cfg
   end
 


### PR DESCRIPTION
When there are more hardware switches connected in one logical stack, command "show system" displays uptime for each of them. 
This results in new configuration version after every config pull. 

This change hides all related 'uptime' content. 
Example output of such "show system":

```
sw-access-se0#show system

Unit          Type          
---- ---------------------- 
 1          SG500-52        
 2          SG500-52        


Unit        Fan1                Fan2                Fan3                Fan4                Fan5         
---- ------------------- ------------------- ------------------- ------------------- ------------------- 
 1           OK              NOT PRESENT         NOT PRESENT         NOT PRESENT         NOT PRESENT     
 2           OK              NOT PRESENT         NOT PRESENT         NOT PRESENT         NOT PRESENT     


Unit   Temperature (Celsius)   Temperature Sensor Status 
---- ------------------------- ------------------------- 
 1                                    UNAVAILABLE        
 2                                    UNAVAILABLE        


Unit     Up time     
---- --------------- 
 1     17,00:13:28   
 2     83,02:06:42   

sw-access-se0#
```

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
