### PR TITLE
Netscaler multiple partition support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - xmppdiff now persists its connection to the XMPP server and MUC (@jplitza)
 - routeros no longer backups infos on available updates (@jplitza)
 - avoid /humidity hardware field in tmos (F5) to be reported (@albsga)
+- netscaler, backup all partitions (@smallsam)
 
 ### Fixed
 

--- a/lib/oxidized/model/netscaler.rb
+++ b/lib/oxidized/model/netscaler.rb
@@ -51,7 +51,7 @@ class NetScaler < Oxidized::Model
       partitions.each do |part|
         allcfg = allcfg + "\n\n####################### [ partition " + part.join(" ") + " ] #######################\n\n"
         cmd "switch ns partition " + part.join(" ") + "; show ns ns.conf; switch ns partition default" do |cfgpartition|
-            allcfg = allcfg + cfgpartition
+          allcfg += cfgpartition
         end
       end
       allcfg

--- a/lib/oxidized/model/netscaler.rb
+++ b/lib/oxidized/model/netscaler.rb
@@ -14,12 +14,49 @@ class NetScaler < Oxidized::Model
     comment cfg
   end
 
+  cmd 'show partition' do |cfg|
+    comment cfg
+  end
+
   cmd :secret do |cfg|
     cfg.gsub! /\w+\s(-encrypted)/, '<secret hidden> \\1'
     cfg
   end
 
-  cmd 'show ns ns.conf'
+  # check for multiple partitions
+  cmd 'show partition' do |cfg|
+    @is_multiple_partition = cfg.include? 'Name:'
+  end
+
+  post do
+    if @is_multiple_partition
+      multiple_partition
+    else
+      single_partition
+    end
+  end
+
+  def single_partition
+    # Single partition mode
+    cmd 'show ns ns.conf' do |cfg|
+      cfg
+    end
+  end
+
+  def multiple_partition
+    # Multiple partition mode
+    cmd 'show partition' do |cfg|
+      allcfg = ""
+      partitions = [["default"]] + cfg.scan(/Name: (\S+)$/)
+      partitions.each do |part|
+        allcfg = allcfg + "\n\n####################### [ partition " + part.join(" ") + " ] #######################\n\n"
+        cmd "switch ns partition " + part.join(" ") + "; show ns ns.conf; switch ns partition default" do |cfgpartition|
+            allcfg = allcfg + cfgpartition
+        end
+      end
+      allcfg
+    end
+  end
 
   cfg :ssh do
     pre_logout 'exit'


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Citrix Netscalers have functionality for logical partitioning, where each partition has its own config. This pull request enhances oxidized to check for presence of these additional config partitions and retrieves the configuration from them if present.

It is modeled on the asa model which has similar logical config separation in contexts.
