### PR TITLE
Add logic to check :enable to see if it is password String or a Boolean.

### DIFF
--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -43,7 +43,11 @@ class PowerConnect < Oxidized::Model
     if vars :enable
       post_login do
         send "enable\n"
-        cmd vars(:enable)
+        if :enable.instance_of?(String) then
+          cmd vars(:enable)
+        else
+          Oxidized.logger.debug "lib/oxidized/model/powerconnect: No enable password."
+        end
       end
     end
 

--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -40,14 +40,13 @@ class PowerConnect < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
-    if vars :enable
-      post_login do
-        send "enable\n"
-        if :enable.instance_of?(String)
-          cmd vars(:enable)
-        else
-          Oxidized.logger.debug "lib/oxidized/model/powerconnect: No enable password."
-        end
+
+    post_login do
+      if vars(:enable) == true
+        cmd "enable"
+      elsif vars(:enable)
+        cmd "enable", /^[pP]assword:/
+        cmd vars(:enable)
       end
     end
 

--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -43,7 +43,7 @@ class PowerConnect < Oxidized::Model
     if vars :enable
       post_login do
         send "enable\n"
-        if :enable.instance_of?(String) then
+        if :enable.instance_of?(String)
           cmd vars(:enable)
         else
           Oxidized.logger.debug "lib/oxidized/model/powerconnect: No enable password."


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Powerconnect.rb didn't work in my case because an enable password is not required.  

I updated the model to allow enable to be a true or a password.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
