### PR TITLE
Added ruby 2.3 install on centos 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ If you've installed Ruby 2.3 or greater via a 3rd party package rather than the 
 ```shell
 yum install make cmake which sqlite-devel openssl-devel libssh2-devel ruby gcc ruby-devel libicu-devel gcc-c++
 ```
+Then you have to install at least Ruby 2.3 for for the ruby requirements to work:
+
+```shell
+yum install centos-release-scl
+yum install rh-ruby22
+scl enable rh-ruby22 bash
+```
 
 Now let's install oxidized via Rubygems:
 

--- a/README.md
+++ b/README.md
@@ -98,22 +98,25 @@ gem install oxidized-script oxidized-web # If you don't install oxidized-web, en
 
 ### CentOS, Oracle Linux, Red Hat Linux
 
-On CentOS 6 and 7 / RHEL 6 and 7, begin by installing Ruby 2.3 or greater by following the instructions at [Installing Ruby 2.3 using RVM](#installing-ruby-23-using-rvm).
+On CentOS 6 and 7 / RHEL 6 and 7, begin by installing Ruby 2.3 or greater. This can be accomplished in one of two ways:
 
-If you've installed Ruby 2.3 or greater via a 3rd party package rather than the RVM instructions, additional dependencies will be required:
+Install Ruby 2.3 from [SCL](https://www.softwarecollections.org/en/scls/rhscl/rh-ruby23/):
+
+```shell
+yum install centos-release-scl
+yum install rh-ruby23
+scl enable rh-ruby23 bash
+```
+
+The following additional packages will be required to build the dependencies:
 
 ```shell
 yum install make cmake which sqlite-devel openssl-devel libssh2-devel ruby gcc ruby-devel libicu-devel gcc-c++
 ```
-Then you have to install at least Ruby 2.3 for for the ruby requirements to work:
 
-```shell
-yum install centos-release-scl
-yum install rh-ruby22
-scl enable rh-ruby22 bash
-```
+Alternatively, install Ruby 2.3 by following the instructions at [Installing Ruby 2.3 using RVM](#installing-ruby-23-using-rvm).
 
-Now let's install oxidized via Rubygems:
+Finally, install oxidized via Rubygems:
 
 ```shell
 gem install oxidized


### PR DESCRIPTION
net-telnet and puma both require Ruby to be over 2.2.

Either you install the old variants of those 2, or update ruby to 2.3

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
