### PR TITLE
Improved filtering for dnos and powerconnect

### DIFF
--- a/lib/oxidized/model/dnos.rb
+++ b/lib/oxidized/model/dnos.rb
@@ -5,13 +5,15 @@ class DNOS < Oxidized::Model
 
   cmd :all do |cfg|
     cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
-    cfg.gsub! /^Dell(\sEMC)? Networking OS uptime is\s.+/, '' # Omit changing uptime info, account for branding
+    cfg.gsub! /(uptime is)(\s.+)/, '\\1 <removed>' # Omit changing uptime info
     cfg.each_line.to_a[2..-2].join
   end
 
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /secret (\d+) (\S+).*/, '<secret hidden>'
+    cfg.gsub! /password (\d+) (\S+).*/, '<secret hidden>'
+    cfg.gsub! /^(tacacs-server key \d+) (\S+).*/, '\\1 <secret hidden>'
     cfg
   end
 

--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -14,6 +14,7 @@ class PowerConnect < Oxidized::Model
 
   cmd :secret do |cfg|
     cfg.gsub! /^(username \S+ password (?:encrypted )?)\S+(.*)/, '\1<hidden>\2'
+    cfg.gsub! /^(tacacs-server key) \S+/, '\\1 <secret hidden>'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Improved filtering for dnos and powerconnect switches.

dnos:
* improve uptime message filtering. On my switches uptime is reported like this:
```
! sw-541saw21 uptime is 3 year(s), 36 week(s), 0 day(s), 7 hour(s), 21 minute(s)
```
* filter secrets for local users passwords
* filter secrets for tacacs key

powerconnect:
* filter secrets for tacacs key
