### PR TITLE
Additional secret filters in procurve model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * MISC: eos model removes user secrets and BGP secrets (@yzguy)
 * MISC: add secret filtering to netscaler (@shepherdjay)
 * MISC: capture ZebOS configuration for TMOS model (@yzguy)
-* MISC: additional secret filters in ios and asa models (@hexdump0x0200)
+* MISC: additional secret filters in ios, asa, procurve models (@hexdump0x0200)
 
 ## 0.24.0
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -31,10 +31,12 @@ class Procurve < Oxidized::Model
   end
 
   cmd :secret do |cfg|
-    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
-    cfg.gsub! /^(snmp-server host).*/, '\\1 <configuration removed>'
-    cfg.gsub! /^(radius-server host).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(snmp-server community) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(snmp-server host \S+) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(radius-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^(radius-server key).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(tacacs-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(tacacs-server key).*/, '\\1 <secret hidden>'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Additional secret filters in procurve model
-------------------------------------------------------------------------------
```
-    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(snmp-server community) \S+(.*)/, '\\1 <secret hidden> \\2'
```
config:
```
snmp-server community "community1" Operator
```
before:
```
snmp-server community <configuration removed>
```
after:
```
snmp-server community <secret hidden> Operator
```

-------------------------------------------------------------------------------
```
-    cfg.gsub! /^(snmp-server host).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(snmp-server host \S+) \S+(.*)/, '\\1 <secret hidden> \\2'
```
config:
```
snmp-server host 192.168.100.1 "COMMUNITY1" Critical
snmp-server host 192.168.100.2 "COMMUNITY2"
```
before:
```
snmp-server host <configuration removed>
snmp-server host <configuration removed>
```
after:
```
snmp-server host 192.168.100.1 <secret hidden>  Critical 
snmp-server host 192.168.100.2 <secret hidden>  
```

-------------------------------------------------------------------------------
```
-    cfg.gsub! /^(radius-server host).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(radius-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
```
config:
```
radius-server host 192.168.100.1 key KEY2 auth-port 3 acct-port 2
radius-server host 192.168.100.2 key KEY3
```
before:
```
radius-server host <configuration removed>
radius-server host <configuration removed>
```
after:
```
radius-server host 192.168.100.1 key <secret hidden>  auth-port 3 acct-port 2 
radius-server host 192.168.100.2 key <secret hidden>  
```

-------------------------------------------------------------------------------
```
+    cfg.gsub! /^(tacacs-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(tacacs-server key).*/, '\\1 <secret hidden>'
```
config:
```
tacacs-server key KEY4
tacacs-server host 192.168.100.1 key KEY1
tacacs-server host 192.168.100.2 key KEY2
```
before:
```
tacacs-server key KEY4
tacacs-server host 192.168.100.1 key KEY1
tacacs-server host 192.168.100.2 key KEY2
```
after:
```
tacacs-server key <secret hidden>
tacacs-server host 192.168.100.1 key <secret hidden> 
tacacs-server host 192.168.100.2 key <secret hidden> 
```
