### PR TITLE
Fix ciscospark hook when diff is false

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * BUGFIX: xos model should not modify config on legacy Extreme Networks devices (@sq9mev)
 * BUGFIX: model dlink, edgecos, ciscosmb, openbsd
 * BUGFIX: hide 'lighttpd_ls_password' as potential secret in pfsense model (@dra)
+* BUGFIX: ciscospark hook error when diff is set to false
 * MISC: bump Dockerfile phusion/baseimage:0.10.0 -> 0.11, revert to one-stage build
 * MISC: add sqlite3 and mysql2 drivers for sequel to Dockerfile
 * MISC: Added verbiage to set OXIDIZED_HOME correctly under Debian 8.8 w/systemd

--- a/lib/oxidized/hook/ciscosparkdiff.rb
+++ b/lib/oxidized/hook/ciscosparkdiff.rb
@@ -43,7 +43,9 @@ class CiscoSparkDiff < Oxidized::Hook
       msg = cfg.message % { :node => ctx.node.name.to_s, :group => ctx.node.group.to_s, :commitref => ctx.commitref, :model => ctx.node.model.class.name.to_s.downcase }
       log msg
       log "Posting message to #{cfg.space}"
-      client.chat_postMessage(channel: cfg.channel, text: msg, as_user: true)
+      message = CiscoSpark::Message.new(text: msg)
+      room = CiscoSpark::Room.new(id: space)
+      room.send_message(message)
     end
     log "Finished"
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Used the same logic from diff: true section. The original line was invalid. 

Closes issue #1643 
