### PR TITLE
Improved secret filtering for ciscosmb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * MISC: eos model removes user secrets and BGP secrets (@yzguy)
 * MISC: add secret filtering to netscaler (@shepherdjay)
 * MISC: capture ZebOS configuration for TMOS model (@yzguy)
-* MISC: additional secret filters in ios, asa, procurve models (@hexdump0x0200)
+* MISC: additional secret filters in ios, asa, procurve, ciscosmb models (@hexdump0x0200)
 * MISC: remove volatile uptime data in nos model (@f0rkz)
 
 ## 0.24.0

--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -21,6 +21,7 @@ class CiscoSMB < Oxidized::Model
     cfg.gsub! /^(encrypted radius-server host .+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^(encrypted tacacs-server key).*/, '\\1 <secret hidden>'
     cfg.gsub! /^(encrypted tacacs-server host .+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(encrypted sntp authentication-key \d+ md5) .*/, '\\1 <secret hidden>'
     cfg
   end
 

--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -15,7 +15,12 @@ class CiscoSMB < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /username (\S+) privilege (\d+) (\S+).*/, '<secret hidden>'
+    cfg.gsub! /^(username \S+ password encrypted) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(enable password level \d+ encrypted) \S+/, '\\1 <secret hidden>'
     cfg.gsub! /^(encrypted radius-server key).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(encrypted radius-server host .+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(encrypted tacacs-server key).*/, '\\1 <secret hidden>'
+    cfg.gsub! /^(encrypted tacacs-server host .+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Improved secret filtering for ciscosmb
config before:
```
username TEST1 password encrypted da39a3ee5e6b4b0d3255bfef95601890afd80709
username TEST2 password encrypted 40fa37ec00c761c7dbb6ebdee6d4a260b922f5f4 privilege 7
enable password level 3 encrypted 40fa37ec00c761c7dbb6ebdee6d4a260b922f5f4
encrypted radius-server host 192.168.100.1 acct-port 222 retransmit 3 key tFnQUb+haZWjNZgGR+DHH3auI/XzjJYIwNicffDrNok=
encrypted tacacs-server key tFnQUb+haZWjNZgGR+DHH3auI/XzjJYIwNicffDrNok=
encrypted tacacs-server host 192.168.100.2 single-connection timeout 2 key tFnQUb+haZWjNZgGR+DHH3auI/XzjJYIwNicffDrNok= priority 5
encrypted sntp authentication-key 2 md5 tFnQUb+haZWjNZgGR+DHH3auI/XzjJYIwNicffDrNok=
```
after:
```
username TEST1 password encrypted <secret hidden> 
username TEST2 password encrypted <secret hidden>  privilege 7
enable password level 3 encrypted <secret hidden>
encrypted radius-server host 192.168.100.1 acct-port 222 retransmit 3 key <secret hidden>
encrypted tacacs-server key <secret hidden>
encrypted tacacs-server host 192.168.100.2 single-connection timeout 2 key <secret hidden> priority 5
encrypted sntp authentication-key 2 md5 <secret hidden>
```