### PR TITLE
Clarify which kind of slack token to use in slackhook configuration.

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -158,6 +158,8 @@ You will need to manually install the `slack-api` gem on your system:
 gem install slack-api
 ```
 
+The token parameter is a "legacy token" and is generated [Here](https://api.slack.com/custom-integrations/legacy-tokens).
+
 ### slackdiff hook configuration example
 
 ```yaml

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -158,8 +158,6 @@ You will need to manually install the `slack-api` gem on your system:
 gem install slack-api
 ```
 
-The token parameter is a "legacy token" and is generated [Here](https://api.slack.com/custom-integrations/legacy-tokens).
-
 ### slackdiff hook configuration example
 
 ```yaml
@@ -170,6 +168,7 @@ hooks:
     token: SLACK_BOT_TOKEN
     channel: "#network-changes"
 ```
+The token parameter is a "legacy token" and is generated [Here](https://api.slack.com/custom-integrations/legacy-tokens).
 
 Optionally you can disable snippets and post a formatted message, for instance linking to a commit in a git repo. Named parameters `%{node}`, `%{group}`, `%{model}` and `%{commitref}` are available.
 


### PR DESCRIPTION
## Pre-Request Checklist
- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add help text describing how to generate the correct auth token for slackdiff.
