### PR TITLE
update  netscaler model prompt

### DIFF
--- a/lib/oxidized/model/netscaler.rb
+++ b/lib/oxidized/model/netscaler.rb
@@ -1,5 +1,5 @@
 class NetScaler < Oxidized::Model
-  prompt /^>\s*$/
+  prompt /^([\w\.-]*>\s?)$/
   comment '# '
 
   cmd :all do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
The existing NetScaler prompt only allows for `>`. This PR updates the prompt to allow for the device hostname proceeding the `>`.

Closes issue #1215.
