### PR TITLE
Netonix Model Prompt Update

### DIFF
--- a/lib/oxidized/model/netonix.rb
+++ b/lib/oxidized/model/netonix.rb
@@ -1,5 +1,5 @@
 class Netonix < Oxidized::Model
-  prompt /^[\w\s.@_\/:-]+#/
+  prompt /^[\w\s\(\).@_\/:-]+#/
 
   cmd :all do |cfg|
     cfg.cut_both


### PR DESCRIPTION
Prompts can include parentheses.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Prompts for Netonix devices can have parentheses in them. 

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->