### PR TITLE
temporarily disable ruby 2.3 build from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,5 @@ before_install:
 rvm:
   - 2.1
   - 2.2
-  - 2.3
   - 2.4
   - 2.5


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
temporarily disable ruby 2.3 build from travis due to bundler issues since bundler 2.0 release

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
