### PR TITLE
Ignore bandwidth usage on F5 bigip version 14

### DIFF
--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -26,6 +26,9 @@ class TMOS < Oxidized::Model
   cmd 'tmsh -q list' do |cfg|
     cfg.gsub!(/state (up|down|checking|irule-down)/, '')
     cfg.gsub!(/errors (\d+)/, '')
+    cfg.gsub!(/^        bandwidth-bps (\d+)\n/, '')
+    cfg.gsub!(/^        bandwidth-cps (\d+)\n/, '')
+    cfg.gsub!(/^        bandwidth-pps (\d+)\n/, '')
     cfg
   end
 

--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -26,9 +26,9 @@ class TMOS < Oxidized::Model
   cmd 'tmsh -q list' do |cfg|
     cfg.gsub!(/state (up|down|checking|irule-down)/, '')
     cfg.gsub!(/errors (\d+)/, '')
-    cfg.gsub!(/^        bandwidth-bps (\d+)\n/, '')
-    cfg.gsub!(/^        bandwidth-cps (\d+)\n/, '')
-    cfg.gsub!(/^        bandwidth-pps (\d+)\n/, '')
+    cfg.gsub!(/^\s+bandwidth-bps (\d+)/, '')
+    cfg.gsub!(/^\s+bandwidth-cps (\d+)/, '')
+    cfg.gsub!(/^\s+bandwidth-pps (\d+)\n/, '')
     cfg
   end
 


### PR DESCRIPTION
## Description
Starting in F5's bigip software version 14, the 'tmsh -q list' command reports real time bandwidth usage for each pool. This causes oxidized to perform an update on every query of the F5 as the bandwidth usage is always changing. Added gsubs to tmos.rb to remove the bandwidth usage lines.
