### PR TITLE
Huawei SmartAX support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FEATURE: add privilege escalation to the cumulus model (@user4574)
 * FEATURE: add adtran model (@CFUJoshWeepie)
 * FEATURE: add firebrick model (@lewisvive)
+* FEATURE: add huawei smartax model (@nyash)
 * BUGFIX: netgear telnet password prompt not detected
 * BUGFIX: xos model should not modify config on legacy Extreme Networks devices (@sq9mev)
 * BUGFIX: model dlink, edgecos, ciscosmb, openbsd

--- a/docs/Model-Notes/README.md
+++ b/docs/Model-Notes/README.md
@@ -12,6 +12,7 @@ Arbor Networks|[ArbOS](ArbOS.md)|27 Feb 2018
 Arista|[EOS](EOS.md)|05 Feb 2018
 Cumulus|[Cumulus](Cumulus.md)|11 Jun 2018
 Huawei|[VRP](VRP-Huawei.md)|17 Nov 2017
+Huawei|[SmartAX series](SmartAX-Huawei.md)|21 Jan 2019
 Juniper|[MX/QFX/EX/SRX/J Series](JunOS.md)|18 Jan 2018
 Netgear|[Netgear](Netgear.md)|11 Apr 2018
 Nokia|[Nokia ISAM](Nokia.md)|22 Aug 2018

--- a/docs/Model-Notes/SmartAX-Huawei.md
+++ b/docs/Model-Notes/SmartAX-Huawei.md
@@ -4,14 +4,14 @@ It is necessary to disable SSH keepalives in Oxidized for configuration retrieva
 
 To disable SSH keepalives globally edit the config's vars section and add:
 
-```
+```yaml
 vars:
   ssh_no_keepalive: true
 ```
 
 To disable SSH keepalives per device edit the config's source section and map ssh_no_keepalive to a column inside router.db file.
 
-```
+```yaml
 source:
   default: csv
   csv:
@@ -26,12 +26,10 @@ source:
       ssh_no_keepalive: 4
 ```
 
-```
+```text
 # router.db
 10.0.0.1:smartax:someusername:somepassword:true
 10.0.0.2:ios:someusername:somepassword:false
 ```
-
-
 
 Back to [Model-Notes](README.md)

--- a/docs/Model-Notes/SmartAX-Huawei.md
+++ b/docs/Model-Notes/SmartAX-Huawei.md
@@ -1,0 +1,37 @@
+# Huawei SmartAX GPON/EPON/DOCSIS network access devices
+
+It is necessary to disable SSH keepalives in Oxidized for configuration retrieval via SSH to work properly.
+
+To disable SSH keepalives globally edit the config's vars section and add:
+
+```
+vars:
+  ssh_no_keepalive: true
+```
+
+To disable SSH keepalives per device edit the config's source section and map ssh_no_keepalive to a column inside router.db file.
+
+```
+source:
+  default: csv
+  csv:
+    file: ~/.config/oxidized/router.db
+    delimiter: !ruby/regexp /:/
+    map:
+      name: 0
+      model: 1
+      username: 2
+      password: 3
+    vars_map:
+      ssh_no_keepalive: 4
+```
+
+```
+# router.db
+10.0.0.1:smartax:someusername:somepassword:true
+10.0.0.2:ios:someusername:somepassword:false
+```
+
+
+
+Back to [Model-Notes](README.md)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -122,6 +122,7 @@
   * [MSA](/lib/oxidized/model/hpemsa.rb)
 * Huawei
   * [VRP](/lib/oxidized/model/vrp.rb)
+  * [SmartAX series](/lib/oxidized/model/smartax.rb)
 * Juniper
   * [JunOS](/lib/oxidized/model/junos.rb)
   * [ScreenOS (Netscreen)](/lib/oxidized/model/screenos.rb)

--- a/lib/oxidized/model/smartax.rb
+++ b/lib/oxidized/model/smartax.rb
@@ -20,5 +20,4 @@ class SmartAX < Oxidized::Model
   # 'display current-configuration' returns current configuration stored in memory
   # 'display saved-configuration'   returns configuration stored in the file system which is used upon reboot
   cmd 'display current-configuration'
-
 end

--- a/lib/oxidized/model/smartax.rb
+++ b/lib/oxidized/model/smartax.rb
@@ -1,0 +1,24 @@
+class SmartAX < Oxidized::Model
+  # Huawei SmartAX GPON/EPON/DOCSIS network access devices
+  prompt /^([\w.-]+[>#])$/
+
+  comment '#'
+
+  cfg :telnet do
+    username /^>>User name:$/
+    password /^>>User password:$/
+  end
+
+  cfg :ssh, :telnet do
+    post_login "enable"
+    post_login "undo interactive"
+    post_login "undo smart"
+    post_login "scroll"
+    pre_logout "quit"
+  end
+
+  # 'display current-configuration' returns current configuration stored in memory
+  # 'display saved-configuration'   returns configuration stored in the file system which is used upon reboot
+  cmd 'display current-configuration'
+
+end


### PR DESCRIPTION
This PR adds support for Huawei SmartAX series devices. 

I have tested this extensively and it works flawlessly for both SSH and Telnet for configuration retrieval.

For proper SSH config retrieval it is necessary to disable SSH keepalives, otherwise net-ssh crashes randomly.

Some explaination for the commands used in the model as well as the order since it is important.

```
post_login "enable" #This enters the privileged mode, it is not necessary to provide any password. It is mandatory to be in privileged mode in order to fetch the config.
post_login "undo interactive" #This disables confirmation prompts, e.g. when entering "quit" it is otherwise necessary to input "Y" for confirmation.
post_login "undo smart" #This disables command help prompts. Normally once a valid command is entered it first displays the available parameters to which you need to input enter to proceed further or type the additional parameters.
post_login "scroll" #This disables paging. This is not obvious since it's not mentioned in the documentation and only works after entering the privileged mode by "enable".
```
 

This addresses issue #1295 and #1479 
