### PR TITLE
New model for AudioCodes MediaPack MP1xx and Mediant 1000 devices (firmware v4.xx, v5.xx, v6.xx)

### DIFF
--- a/lib/oxidized/model/audiocodesmp.rb
+++ b/lib/oxidized/model/audiocodesmp.rb
@@ -1,0 +1,37 @@
+class AudioCodesMP < Oxidized::Model
+  # AudioCodes MediaPack MP1xx and Mediant 1000 devices (firmware v4.xx, v5.xx, v6.xx)
+  # Created by pedjajks@gmail.com
+  # 2019 v3.0
+
+
+#   prompt /(\/.*?>)/
+   prompt /\/>|\/CONFiguration>/
+
+  comment ';'
+
+  cmd 'cf get' do |cfg|
+    # remove Unnecessary Lines
+    # cfg.gsub! /^AutoUPDate SaveAndReset*/, ''
+    cfg.gsub! /^cf get*/, ''
+    cfg.gsub! /^SIP\/ SECurity.*/, ''
+    cfg.gsub! /^SaveAndReset RestoreFactorySettings.*/, ''
+    cfg.gsub! /^\/CONFiguration>.*/, ''
+    cfg.gsub! /^PING SHow*/, ''
+    cfg.gsub! /\/>.*/, ''
+    cfg
+  end
+
+
+  cfg :ssh do
+    username /^login as:\s$/
+    password /^.+password:\s$/
+    pre_logout 'exit'
+  end
+
+  cfg :telnet do
+    username /login:/
+    password /password:/
+    post_login 'conf'
+    pre_logout 'exit'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
