### PR TITLE
bring back ruby 2.3 build with old bundler into travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: ruby
 sudo: false
 cache: bundler
 before_install:
-  - gem install bundler -v '< 2'
+    - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+    - gem install bundler -v '< 2'
 rvm:
   - 2.1
   - 2.2
+  - 2.3
   - 2.4
   - 2.5


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Bring back ruby 2.3 build with travis using a workaround

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
