### PR TITLE
Huawei SmartAX minor fix for cfg consistency

### DIFF
--- a/lib/oxidized/model/smartax.rb
+++ b/lib/oxidized/model/smartax.rb
@@ -19,5 +19,7 @@ class SmartAX < Oxidized::Model
 
   # 'display current-configuration' returns current configuration stored in memory
   # 'display saved-configuration'   returns configuration stored in the file system which is used upon reboot
-  cmd 'display current-configuration'
+  cmd 'display current-configuration' do |cfg|
+    cfg.cut_both
+  end
 end


### PR DESCRIPTION
Just noticed different cfg output between recent fw versions that I run and a very old box that just got configured for cfg retrieval that mandates the usage of `cut_both` to have consistent cfg output. 

I couldn't seem to reopen the older PR to put the modification there unfortunately.
