### PR TITLE
Rebranded (hardware compatibile) devices

### DIFF
--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -174,6 +174,7 @@
 * TPLink
   * [TPLink](/lib/oxidized/model/tplink.rb)
   * [TL-SL5428](/lib/oxidized/model/edgecos.rb)
+  * [TL-SL3428](/lib/oxidized/model/powerconnect.rb)
 * Ubiquiti
   * [AirOS](/lib/oxidized/model/airos.rb)
   * [Edgeos](/lib/oxidized/model/edgeos.rb)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -16,6 +16,7 @@
   * Wireless
 * Allied Telesis
   * [Alliedware Plus](/lib/oxidized/model/awplus.rb)
+  * [AT-8000S, AT-8000GS series](/lib/oxidized/model/powerconnect.rb)
 * Alvarion
   * [BreezeACCESS](/lib/oxidized/model/alvarion.rb)
 * APC
@@ -172,6 +173,7 @@
   * [Trango](/lib/oxidized/model/trango.rb)
 * TPLink
   * [TPLink](/lib/oxidized/model/tplink.rb)
+  * [TL-SL5428](/lib/oxidized/model/edgecos.rb)
 * Ubiquiti
   * [AirOS](/lib/oxidized/model/airos.rb)
   * [Edgeos](/lib/oxidized/model/edgeos.rb)


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->

* Allied Telesis AT-8000s and AT-8000GS series switches are  RADLAN switches, same as powerconnect and can use powerconnect.rb model.
* TP-link switch TL-SL5428 (not JetStream) with Marvell 98DX106-B0, 88E6095[F] same as EdgeCore - ES352x or SMC TigerSwitch 10/100 SMC6128L2 Manager and can use edgecos.rb model
* TP-link switch TL-SL3428 can use powerconnect.rb model.
