### PR TITLE
Update VOSS to filter out "show sys-info" changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
+* BUGFIX: voss model
 * FIX: add dependencies for net-ssh
 
 ## 0.26.3

--- a/lib/oxidized/model/voss.rb
+++ b/lib/oxidized/model/voss.rb
@@ -1,7 +1,7 @@
 class Voss < Oxidized::Model
-  # Avaya VSP Operating System Software(VOSS)
+  # Extreme/Avaya VSP Operating System Software(VOSS)
   # Created by danielcoxman@gmail.com
-  # May 25, 2017
+  # March 16, 2019
   # This was tested on vsp4k and vsp8k
 
   comment '# '
@@ -16,6 +16,9 @@ class Voss < Oxidized::Model
     cfg.gsub! /(^((.*)SysUpTime(.*))$)/, 'removed SysUpTime'
     cfg.gsub! /^((.*)Temperature Info :(.*\r?\n){4})/, 'removed Temperature Info and 3 more lines'
     cfg.gsub! /(^((.*)AmbientTemperature(.*):(.*))$)/, 'removed AmbientTemperature'
+    cfg.gsub! /(^((.*)Last Change(.*):(.*))$)/, 'remove Last Change'
+    cfg.gsub! /(^((.*)Last Statistic Reset(.*):(.*))$)/, 'removed Last Statistic Reset'
+    cfg.gsub! /(^((.*)Last Vlan Change(.*):(.*))$)/, 'removed Last Vlan Change'
     cfg.gsub! /(^((.*)Temperature(.*):(.*))$)/, 'removed Temperature'
     cfg.gsub! /(^((.*)Total Power Usage(.*):(.*))$)/, 'removed Total Power Usage'
     comment "#{cfg}\n"


### PR DESCRIPTION
show sys-info has the following information that changes even though the configuration has not changed.  This is causing a lot of configs to be archived in oxidized for Extreme/Avaya voss.
          Last Change: 45 day(s), 15:20:07   (1 day(s), 05:30:16 ago)
     Last Vlan Change: 45 day(s), 15:20:07   (1 day(s), 05:30:16 ago)
 Last Statistic Reset: 0 day(s), 00:00:00

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
