### PR TITLE
Cambium timestamp correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
 * BUGFIX: voss model
+* BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs
 * FIX: add dependencies for net-ssh
 
 ## 0.26.3

--- a/lib/oxidized/model/cambium.rb
+++ b/lib/oxidized/model/cambium.rb
@@ -7,6 +7,7 @@ class Cambium < Oxidized::Model
   end
 
   cmd cfg_cb do |cfg|
+    cfg.gsub! /"cfgUtcTimestamp":.*?,\n/, ''
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Just added a gsub to drop the timestamp from configuration as it changes every backup

Closes issue #1740