### PR TITLE
Allows DLink OS to work with OEM models with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
 * BUGFIX: voss model
-* BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs
+* BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
+* BUGFIX: dlink model didn't support prompts with spaces in the model type (Extreme EAS 200-24p) (@cchance27)
 * FIX: add dependencies for net-ssh
 
 ## 0.26.3

--- a/lib/oxidized/model/dlink.rb
+++ b/lib/oxidized/model/dlink.rb
@@ -1,7 +1,7 @@
 class Dlink < Oxidized::Model
   # D-LINK Switches
 
-  prompt /^(\r*[\w.@()\/:-]+[#>]\s?)$/
+  prompt /^(\r*[\w\s.@()\/:-]+[#>]\s?)$/
   comment '# '
 
   cmd :secret do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added space character for the prompt match of dlink.rb this allows models like EAS 200-24p to be valid prompts because the prompt appears as "EAS 200-24p:admin#" and space broke it previously.

Closes #1738 