### PR TITLE
Add ubiquiti Airfiber model support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+* FEATURE: add Ubiquiti Airfiber model support (@cchance27)
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
 * FIX: add dependencies for net-ssh

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -187,6 +187,7 @@
   * [AirOS](/lib/oxidized/model/airos.rb)
   * [Edgeos](/lib/oxidized/model/edgeos.rb)
   * [EdgeSwitch](/lib/oxidized/model/edgeswitch.rb)
+  * [AirFiber](/lib/oxidized/model/airfiber.rb)
 * Watchguard
   * [Fireware OS](/lib/oxidized/model/firewareos.rb)
 * Westell

--- a/lib/oxidized/model/airfiber.rb
+++ b/lib/oxidized/model/airfiber.rb
@@ -8,7 +8,7 @@ class Airfiber < Oxidized::Model
   end
 
   pre do
-    cfg = cmd 'cat /tmp/system.cfg'
+    cmd 'cat /tmp/system.cfg'
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/airfiber.rb
+++ b/lib/oxidized/model/airfiber.rb
@@ -1,0 +1,22 @@
+class Airfiber < Oxidized::Model
+  # Ubiquiti Airfiber (tested with Airfiber 11FX)
+
+  prompt /^AF[\w\.]+#/
+
+  cmd :all do |cfg|
+    cfg.cut_both
+  end
+
+  pre do
+    cfg = cmd 'cat /tmp/system.cfg'
+  end
+
+  cfg :telnet do
+    username /^[\w\W]+\slogin:\s$/
+    password /^[p:P]assword:\s$/
+  end
+
+  cfg :telnet, :ssh do
+    pre_logout 'exit'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR creates and adds support for backing up the latest config from the airfiber from telnet/ssh.
