### PR TITLE
Add cambium as a supported model to docs (pmp450 series)

### DIFF
--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -44,6 +44,8 @@
   * [SLX-OS](/lib/oxidized/model/slxos.rb)
 * Calix
   * [AXOS](/lib/oxidized/model/axos.rb)
+* Cambium
+  * [Cambium (PMP450 Series)](/lib/oxidized/model/cambium.rb)
 * Casa
   * [Casa](/lib/oxidized/model/casa.rb)
 * Check Point


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Just a quick modification to documentation as oxidized supports cambium pmp450's but it's not listed as supported in documentation