### PR TITLE
Update acos.rb

### DIFF
--- a/lib/oxidized/model/acos.rb
+++ b/lib/oxidized/model/acos.rb
@@ -37,7 +37,7 @@ class ACOS < Oxidized::Model
     cfg
   end
 
-  #FOR ACOS 4.x
+  # change for ACOS 4.x
   cmd 'show running-config partition-config all' do |cfg|
     cfg.gsub! /(Current configuration).*/, '\\1 <removed>'
     cfg.gsub! /(Configuration last updated at).*/, '\\1 <removed>'

--- a/lib/oxidized/model/acos.rb
+++ b/lib/oxidized/model/acos.rb
@@ -37,7 +37,8 @@ class ACOS < Oxidized::Model
     cfg
   end
 
-  cmd 'show running-config all-partitions' do |cfg|
+  #FOR ACOS 4.x
+  cmd 'show running-config partition-config all' do |cfg|
     cfg.gsub! /(Current configuration).*/, '\\1 <removed>'
     cfg.gsub! /(Configuration last updated at).*/, '\\1 <removed>'
     cfg.gsub! /(Configuration last saved at).*/, '\\1 <removed>'


### PR DESCRIPTION
modified for error on ACOS 4.x
! COMMAND: show running-config all-partitions
                                    ^
% Unrecognized command.Invalid input detected at '^' marker.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
