### PR TITLE
Explicit stringio to string type conversion in nagios check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * BUGFIX: dlink model didn't support prompts with spaces in the model type (Extreme EAS 200-24p) (@cchance27)
 * BUGFIX: routeros model does not collect configuration via telnet input (@hexdump0x0200)
 * BUGFIX: add dependencies for net-ssh
+* BUGFIX: crash on some recent Ruby versions in the nagios check (@Kegeruneku)
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
 

--- a/extra/nagios_check_failing_nodes.rb
+++ b/extra/nagios_check_failing_nodes.rb
@@ -10,7 +10,7 @@ pending = false
 critical_nodes = []
 pending_nodes = []
 
-json = JSON.parse(open("http://localhost:8888/nodes.json"))
+json = JSON.parse(open("http://localhost:8888/nodes.json").read)
 json.each do |node|
   if not node['last'].nil?
     if node['last']['status'] != 'success'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
The script crashes at least on Ruby 2.3 due to a denied implicit conversion during JSON parsing:
```
/usr/lib/ruby/2.3.0/json/common.rb:156:in `initialize': no implicit conversion of StringIO into String (TypeError)
	from /usr/lib/ruby/2.3.0/json/common.rb:156:in `new'
	from /usr/lib/ruby/2.3.0/json/common.rb:156:in `parse'
	from ./check_oxidized_failing_nodes.rb:13:in `<main>'
```

I added a `.string` explicit conversion to prevent the error.