### PR TITLE
[syslog] Fix typos in varaible names

### DIFF
--- a/extra/syslog.rb
+++ b/extra/syslog.rb
@@ -129,9 +129,9 @@ module Oxidized
 
     def getname(ipaddr)
       if Oxidized::CFG.syslogd.resolve == false
-        ipddr
+        ipaddr
       else
-        name = (Resolv.getname ipaddr.to_s rescue ipadr)
+        name = (Resolv.getname ipaddr.to_s rescue ipaddr)
         NAME_MAP.each { |re, sub| name.sub! re, sub }
         name
       end


### PR DESCRIPTION
Fixes errors reported:

```
syslog.rb:134:in `rescue in getname': undefined local variable or method `ipadr' for #<Oxidized::SyslogMonitor:0x0055b9858ad448 @mode=:udp> (NameError)
Did you mean?  ipaddr
	from syslog.rb:134:in `getname'
	from syslog.rb:99:in `jnpr'
	from syslog.rb:107:in `handle_log'
	from syslog.rb:126:in `block in run'
	from syslog.rb:112:in `loop'
	from syslog.rb:112:in `run'
	from syslog.rb:78:in `initialize'
	from syslog.rb:64:in `new'
	from syslog.rb:64:in `udp'
	from syslog.rb:142:in `<main>'
```