### PR TITLE
refactor sonicos model from PR #950

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * FEATURE: add Ubiquiti Airfiber model support (@cchance27)
 * FEATURE: include licensing information in aos model (@pozar)
+* FEATURE: add sonicos model (@rgnv)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
 * BUGFIX: dlink model didn't support prompts with spaces in the model type (Extreme EAS 200-24p) (@cchance27)
@@ -12,7 +13,6 @@
 * BUGFIX: crash on some recent Ruby versions in the nagios check (@Kegeruneku)
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
-
 
 ## 0.26.3
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -169,6 +169,8 @@
   * [Quanta / VxWorks 6.6 (1.1.0.8)](/lib/oxidized/model/quantaos.rb)
 * Siklu
   * [EtherHaul](/lib/oxidized/model/siklu.rb)
+* SonicWALL
+   * [SonicOS](lib/oxidized/model/sonicos.rb)
 * SNR
   * [SNR-S300G, S2xxx, S3xxx, S4xxx](/lib/oxidized/model/dcnos.rb)
 * Supermicro

--- a/lib/oxidized/model/sonicos.rb
+++ b/lib/oxidized/model/sonicos.rb
@@ -1,0 +1,46 @@
+class SonicOS < Oxidized::Model
+  # Applies to Sonicwall NSA series firewalls
+
+  prompt /^\w+@\w+[>]\(?.+\)?\s?/
+  comment  '! '
+
+  cmd :all do |cfg|
+    cfg.each_line.to_a[1..-2].join
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /cli ftp password default \d\,(\S+)/, 'cli ftp password default <secret hidden> \2'
+    cfg.gsub! /secret \d\,(\S+)/, 'secret <secret hidden> \2'
+    cfg.gsub! /shared-secret \d\,(\S+)/, 'shared-secret <secret hidden> \2'
+    cfg
+  end
+
+  cmd 'show version' do |cfg|
+    cfg = comment clean cfg
+    cfg << "\n"
+  end
+
+  cmd 'show current-config' do |cfg|
+    cfg.gsub! /^: [^\n]*\n/, ''
+    clean cfg
+  end
+
+  cfg :telnet, :ssh do
+    post_login 'no cli pager session'
+    pre_logout 'exit'
+  end
+
+  def clean(cfg)
+    out = []
+    cfg.each_line do |line|
+      next if line =~ /system-time \"\d{2}\/\d{2}\/\d{4} \d{2}\:\d{2}:\d{2}.\d+\"/
+      next if line =~ /system-uptime "(\s+up\s+\d+\s+)|(.*Days.*)"/
+      next if line =~ /checksum \d+/
+
+      line = line[1..-1] if line[0] == "\r"
+      out << line.strip
+    end
+    out = out.join "\n"
+    out << "\n"
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Introduces support for SonicOS, refactor of #950 by @rgnv to clean it up and separate the models into separate PRs.

Potentially addresses #1236 #938
