### PR TITLE
remove telnet config as no prompts are defined

### DIFF
--- a/lib/oxidized/model/sonicos.rb
+++ b/lib/oxidized/model/sonicos.rb
@@ -25,7 +25,7 @@ class SonicOS < Oxidized::Model
     clean cfg
   end
 
-  cfg :telnet, :ssh do
+  cfg :ssh do
     post_login 'no cli pager session'
     pre_logout 'exit'
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Remove telnet from config block in sonicos model as no telnet prompts are defined.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
