### PR TITLE
Added support for reloading just a single node

### DIFF
--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -20,10 +20,10 @@ module Oxidized
           begin
             node_obj = Node.new node
             new.push node_obj
-          rescue ModelNotFound => err
-            Oxidized.logger.error "node %s raised %s with message '%s'" % [node, err.class, err.message]
-          rescue Resolv::ResolvError => err
-            Oxidized.logger.error "node %s is not resolvable, raised %s with message '%s'" % [node, err.class, err.message]
+          rescue ModelNotFound => e
+            Oxidized.logger.error "node %s raised %s with message '%s'" % [node, e.class, e.message]
+          rescue Resolv::ResolvError => e
+            Oxidized.logger.error "node %s is not resolvable, raised %s with message '%s'" % [node, e.class, e.message]
           end
         end
         size.zero? ? replace(new) : update_nodes(new)
@@ -31,7 +31,7 @@ module Oxidized
       end
     end
 
-    def load_node node_want
+    def load_node(node_want)
       with_lock do
         new = []
         @source = Oxidized.config.source.default
@@ -48,8 +48,8 @@ module Oxidized
           end
         end
         begin
-          _node = Node.new upd_node
-          new.push _node
+          new_node = Node.new upd_node
+          new.push new_node
         rescue ModelNotFound => err
           Oxidized.logger.error "node %s raised %s with message '%s'" % [node.name, err.class, err.message]
         rescue Resolv::ResolvError => err

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -204,7 +204,6 @@ module Oxidized
         node = find { |n| n.name == node_name }
         output = node.output.new
         raise Oxidized::NotSupported unless output.respond_to? :fetch
-
         yield node, output
       end
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This will accept a single node and then reload just the source for that single node where the source backend supports it (http and sql will).

We have been using this code for 6 months now to allow us to add / update a single node without reloading the entire source. This cuts reload times down from minutes to seconds when you have 1,000's of nodes in your source list.

My Ruby is very limited so please feel free to judge me, please make some recommendations though and I'll try and work through them :)

Requires: https://github.com/ytti/oxidized-web/pull/189
