### PR TITLE
Procurve: remove infos about power modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * BUGFIX: dlink model didn't support prompts with spaces in the model type (Extreme EAS 200-24p) (@cchance27)
 * BUGFIX: routeros model does not collect configuration via telnet input (@hexdump0x0200)
 * BUGFIX: add dependencies for net-ssh
+* BUGFIX: don't log power module info on procurve model anymore
 * BUGFIX: crash on some recent Ruby versions in the nagios check (@Kegeruneku)
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -49,10 +49,6 @@ class Procurve < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show system power-supply' do |cfg|
-    comment cfg
-  end
-
   cmd 'show interfaces transceiver' do |cfg|
     comment cfg
   end


### PR DESCRIPTION
## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
power consumption may differ per run/check and trigger an unneeded backup/change
it can be re-added by monkey patching the model, i don't think dumping
infos about the power module should be the default

Closes #1453 , relates https://github.com/ytti/oxidized/pull/1176 & https://github.com/ytti/oxidized/pull/1553
