### PR TITLE
Ciscosmb: remove 'sh system' output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,14 +5,13 @@
 * FEATURE: add Ubiquiti Airfiber model support (@cchance27)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
-* BUGFIX: remove 'sh system' from ciscosmb model
+* BUGFIX: remove 'sh system' from ciscosmb model (@Exordian)
 * BUGFIX: dlink model didn't support prompts with spaces in the model type (Extreme EAS 200-24p) (@cchance27)
 * BUGFIX: routeros model does not collect configuration via telnet input (@hexdump0x0200)
 * BUGFIX: add dependencies for net-ssh
 * BUGFIX: crash on some recent Ruby versions in the nagios check (@Kegeruneku)
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
-
 
 ## 0.26.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * FEATURE: add Ubiquiti Airfiber model support (@cchance27)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
+* BUGFIX: remove 'sh system' from ciscosmb model
 * BUGFIX: dlink model didn't support prompts with spaces in the model type (Extreme EAS 200-24p) (@cchance27)
 * BUGFIX: routeros model does not collect configuration via telnet input (@hexdump0x0200)
 * BUGFIX: add dependencies for net-ssh

--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -29,11 +29,6 @@ class CiscoSMB < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show system' do |cfg|
-    cfg.gsub! /System Up Time.*\n/, ''
-    comment cfg
-  end
-
   cmd 'show bootvar' do |cfg|
     comment cfg
   end


### PR DESCRIPTION
## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
'show system' on a Cisco SG500 emits the following output:
```
System Description:                       SG500-52P 52-Port Gigabit PoE Stackable Managed Switch
System Up Time (days,hour:min:sec):       102,20:25:15
System Contact:                           X
System Name:                              X
System Location:                          X
System MAC Address:                       XX:XX:XX:XX:XX:XX
System Object ID:                         1.3.6.1.4.1.9.6.1.81.52.2

Fans Status:                              OK


          Unit            Temperature (Celsius)            Status          
------------------------ ------------------------ ------------------------ 
           1                        32                       OK            
```

None of these informations are relevant for a backup system IMO. The ever-changing temperature triggers unneeded 'config' changes on oxidized.