### PR TITLE
Fix to get data from node.vars

### DIFF
--- a/lib/oxidized/config/vars.rb
+++ b/lib/oxidized/config/vars.rb
@@ -2,7 +2,7 @@ module Oxidized::Config::Vars
   # convenience method for accessing node, group or global level user variables
   # nil values will be ignored
   def vars(name)
-    r = @node.vars[name] unless @node.vars.nil?
+    r = @node.vars[name.to_s] unless @node.vars.nil?
     if Oxidized.config.groups.has_key?(@node.group)
       r ||= Oxidized.config.groups[@node.group].vars[name.to_s] if Oxidized.config.groups[@node.group].vars.has_key?(name.to_s)
     end


### PR DESCRIPTION
Added code to convert param "name" tostring, else the node level "vars" data was not returned.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
