### PR TITLE
Strip line "# received packet from x.x.x.x bad format" from RouterOS

### DIFF
--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -29,6 +29,7 @@ class RouterOS < Oxidized::Model
     cmd run_cmd do |cfg|
       cfg.gsub! /\\\r?\n\s+/, '' # strip new line
       cfg.gsub! /# inactive time\r\n/, '' # Remove time based system comment
+      cfg.gsub! /# received packet from \S+ bad format\r\n/, '' # Remove intermittent VRRP/CARP collision comment
       cfg = cfg.split("\n").reject { |line| line[/^#\s\w{3}\/\d{2}\/\d{4}.*$/] }
       cfg.join("\n") + "\n"
     end


### PR DESCRIPTION
## Pre-Request Checklist

Minimal change

## Description
Strip line `# received packet from x.x.x.x bad format` from RouterOS config.

This message intermittently appears and disappears when RouterOS is running VRRP and there is also CARP traffic on the same network.

The two protocols work side-by-side without problem if using different group IDs, but share the [same IP protocol number](https://en.wikipedia.org/wiki/Common_Address_Redundancy_Protocol#Incompatibility_with_IANA_standards) and this causes Mikrotik to (sometimes) include this warning in configs.