### PR TITLE
Create fastiron.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * FEATURE: include licensing information in aos model (@pozar)
 * FEATURE: add firelinuxos (FirePOWER) model (@rgnv)
 * FEATURE: add sonicos model (@rgnv)
+* FEATURE: add FastIron model (@ZacharyPuls)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
 * BUGFIX: dlink model didn't support prompts with spaces in the model type (Extreme EAS 200-24p) (@cchance27)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -38,7 +38,7 @@
 * Brocade
   * [FabricOS](/lib/oxidized/model/fabricos.rb)
   * [FastIron] (/lib/oxidized/model/fastiron.rb)
-  * [Ironware](/lib/oxidized/model/ironware.rb)
+  * [IronWare](/lib/oxidized/model/ironware.rb)
   * [NOS (Network Operating System)](/lib/oxidized/model/nos.rb)
   * [Vyatta](/lib/oxidized/model/vyatta.rb)
   * [6910](/lib/oxidized/model/br6910.rb)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -37,6 +37,7 @@
   * [BOSS (Baystack Operating System Software)](/lib/oxidized/model/boss.rb)
 * Brocade
   * [FabricOS](/lib/oxidized/model/fabricos.rb)
+  * [FastIron] (/lib/oxidized/model/fastiron.rb)
   * [Ironware](/lib/oxidized/model/ironware.rb)
   * [NOS (Network Operating System)](/lib/oxidized/model/nos.rb)
   * [Vyatta](/lib/oxidized/model/vyatta.rb)

--- a/lib/oxidized/model/fastiron.rb
+++ b/lib/oxidized/model/fastiron.rb
@@ -1,0 +1,67 @@
+class FastIron < Oxidized::Model
+  prompt /^([\w.@()-]+[#>]\s?)$/
+  comment  '! '
+
+  cmd :all do |cfg|
+    # cfg.gsub! /\cH+\s{8}/, ''         # example how to handle pager
+    # cfg.gsub! /\cH+/, ''              # example how to handle pager
+    # get rid of errors for commands that don't work on some devices
+    cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
+    cfg.cut_both
+  end
+
+  cmd 'show version' do |cfg|
+    comments = []
+    comments << cfg.lines.first
+    lines = cfg.lines
+    lines.each_with_index do |line, i|
+
+      comments << "Version: #{Regexp.last_match(1)}" if line =~ /^\s+SW: Version (.*)$/
+
+      comments << "Boot-Monitor Version: #{Regexp.last_match(1)}" if line =~ /^\s+Compressed Boot-Monitor Image size = \d+, Version:(.*)$/
+
+      comments << "Serial: #{Regexp.last_match(1)}" if line =~ /^\s+Serial  #:(.*)$/
+    end
+    comments << "\n"
+    comment comments.join "\n"
+  end
+
+  cmd 'show module' do |cfg|
+    cfg.gsub! /^$\n/, ''
+    cfg.gsub! /^/, 'Modules: ' unless cfg.empty?
+    comment "#{cfg}\n"
+  end
+
+  cmd 'show media | exclude EMPTY' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show hardware-info' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show stack' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show running-config'
+
+  cfg :telnet do
+    username /^.* login: /
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    # preferred way to handle additional passwords
+    post_login do
+      if vars(:enable) == true
+        cmd "enable"
+      elsif vars(:enable)
+        cmd "enable", /^[pP]assword:/
+        cmd vars(:enable)
+      end
+    end
+    post_login 'skip-page-display'
+    pre_logout 'exit'
+  end
+end

--- a/lib/oxidized/model/fastiron.rb
+++ b/lib/oxidized/model/fastiron.rb
@@ -14,8 +14,7 @@ class FastIron < Oxidized::Model
     comments = []
     comments << cfg.lines.first
     lines = cfg.lines
-    lines.each_with_index do |line, i|
-
+    lines.each_with_index do |line, _i|
       comments << "Version: #{Regexp.last_match(1)}" if line =~ /^\s+SW: Version (.*)$/
 
       comments << "Boot-Monitor Version: #{Regexp.last_match(1)}" if line =~ /^\s+Compressed Boot-Monitor Image size = \d+, Version:(.*)$/


### PR DESCRIPTION
Add support for Ruckus (Brocade) ICX-series switches.

Tested on an ICX7750-48F running FastIron 08.0.30mT203

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
