### PR TITLE
Changing telnet cmd endings from \n to \r\n

### DIFF
--- a/lib/oxidized/input/telnet.rb
+++ b/lib/oxidized/input/telnet.rb
@@ -35,7 +35,7 @@ module Oxidized
     end
 
     def cmd(cmd_str, expect = @node.prompt)
-      return send(cmd_str + "\n") unless expect
+      return send(cmd_str + "\r\n") unless expect
 
       Oxidized.logger.debug "Telnet: #{cmd_str} @#{@node.name}"
       args = { 'String'  => cmd_str,


### PR DESCRIPTION

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Changed telnet cmd because it was getting stuck at login prompts for some devices.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
fixes #1614
fixes #1650
fixes #1784
fixes #1493
fixes #1786