### PR TITLE
Create linuxgeneric.rb model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * FEATURE: add sonicos model (@rgnv)
 * FEATURE: add hpmsm model (@timwsuqld)
 * FEATURE: add FastIron model (@ZacharyPuls)
+* FEATURE: add Linuxgeneric model (@davama)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
 * BUGFIX: remove 'sh system' from ciscosmb model (@Exordian)

--- a/docs/Model-Notes/LinuxGeneric.md
+++ b/docs/Model-Notes/LinuxGeneric.md
@@ -1,0 +1,23 @@
+# LinuxGeneric model notes
+
+To expand the usage of this model for more specific needs you can create a file in `~/.config/oxidized/model/linuxgeneric.rb`
+
+```
+require 'oxidized/model/linuxgeneric.rb'
+
+class LinuxGeneric
+  
+  cmd :secret, clear: true do |cfg|
+    cfg.gsub! /^(default (\S+).* (expires) ).*/, '\\1 <redacted>' 
+    cfg
+  end
+   
+  post do
+    cfg = add_comment 'THE MONKEY PATCH'
+    cfg += cmd 'firewall-cmd --list-all --zone=public'
+  end
+end
+```
+See [Extending-Model](https://github.com/ytti/oxidized/blob/master/docs/Creating-Models.md#creating-and-extending-models)
+
+Back to [Model-Notes](README.md)

--- a/docs/Model-Notes/README.md
+++ b/docs/Model-Notes/README.md
@@ -19,5 +19,6 @@ Netgear|[Netgear](Netgear.md)|11 Apr 2018
 Nokia|[Nokia ISAM](Nokia.md)|22 Aug 2018
 Viptela|[Viptela](Viptela.md)|1 Jul 2018
 Zyxel|[XGS4600 Series](XGS4600-Zyxel.md)|1 Feb 2018
+Linux|[LinuxGeneric](LinuxGeneric.md)|10 Jun 2019
 
 If you discover additional caveats or problems please make sure to consult the [GitHub issues for oxidized](https://github.com/ytti/oxidized/issues) known issues.

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -138,6 +138,8 @@
 * Juniper
   * [JunOS](/lib/oxidized/model/junos.rb)
   * [ScreenOS (Netscreen)](/lib/oxidized/model/screenos.rb)
+* Linuxgeneric
+  * [CentOS](/lib/oxidized/model/linuxgeneric.rb)
 * Mellanox
   * [MLNX-OS](/lib/oxidized/model/mlnxos.rb)
   * [Voltaire](/lib/oxidized/model/voltaire.rb)

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -10,7 +10,7 @@ class AOSW < Oxidized::Model
   # All IAPs connected to a Instant Controller will have the same config output. Only the controller needs to be monitored.
 
   comment  '# '
-  prompt /^\(?.+\)?\s[#>]/
+  prompt /^([\w\(.@-]+(\)?\s?)[#>]\s?)$/
 
   cmd :all do |cfg|
     cfg.cut_both

--- a/lib/oxidized/model/linuxgeneric.rb
+++ b/lib/oxidized/model/linuxgeneric.rb
@@ -1,0 +1,85 @@
+class LinuxGeneric < Oxidized::Model
+  prompt /^(\w.*|\W.*)(:|#) /
+  comment '# '
+
+  # add a comment in the final conf
+  def add_comment(comment)
+    "\n###### #{comment} ######\n"
+  end
+
+  cmd :all do |cfg|
+    cfg.cut_both
+  end
+
+  # show the persistent configuration
+  pre do
+    cfg = add_comment 'THE HOSTNAME'
+    cfg += cmd 'cat /etc/hostname'
+
+    cfg += add_comment 'THE HOSTS'
+    cfg += cmd 'cat /etc/hosts'
+
+    cfg += add_comment 'THE INTERFACES'
+    cfg += cmd 'ip link'
+
+    cfg += add_comment 'RESOLV.CONF'
+    cfg += cmd 'cat /etc/resolv.conf'
+
+    cfg += add_comment 'NTP.CONF'
+    cfg += cmd 'cat /etc/ntp.conf'
+
+    cfg += add_comment 'IP Routes'
+    cfg += cmd 'ip route'
+
+    cfg += add_comment 'IPv6 Routes'
+    cfg += cmd 'ip -6 route'
+
+    cfg += add_comment 'SNMP settings'
+    cfg += cmd 'cat /etc/snmp/snmpd.conf'
+
+    cfg += add_comment 'NTP settings'
+    cfg += cmd 'cat /etc/ntp.conf'
+
+    cfg += add_comment 'MOTD'
+    cfg += cmd 'cat /etc/motd'
+
+    cfg += add_comment 'PASSWD'
+    cfg += cmd 'cat /etc/passwd'
+
+    cfg += add_comment 'GROUP'
+    cfg += cmd 'cat /etc/group'
+
+    cfg += add_comment 'nsswitch.conf'
+    cfg += cmd 'cat /etc/nsswitch.conf'
+
+    cfg += add_comment 'ACL'
+    cfg += cmd 'iptables -L -n'
+
+    cfg += add_comment 'VERSION'
+    cfg += cmd 'cat /etc/issue'
+
+    cfg
+  end
+
+  cfg :telnet do
+    username /^Username:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    post_login do
+      if vars(:enable) == true
+        cmd "sudo su -", /^\[sudo\] password/
+        cmd @node.auth[:password]
+      elsif vars(:enable)
+        cmd "su -", /^Password:/
+        cmd vars(:enable)
+      end
+    end
+
+    pre_logout do
+      cmd "exit" if vars(:enable)
+    end
+    pre_logout 'exit'
+  end
+end

--- a/lib/oxidized/model/linuxgeneric.rb
+++ b/lib/oxidized/model/linuxgeneric.rb
@@ -26,9 +26,6 @@ class LinuxGeneric < Oxidized::Model
     cfg += add_comment 'RESOLV.CONF'
     cfg += cmd 'cat /etc/resolv.conf'
 
-    cfg += add_comment 'NTP.CONF'
-    cfg += cmd 'cat /etc/ntp.conf'
-
     cfg += add_comment 'IP Routes'
     cfg += cmd 'ip route'
 
@@ -37,9 +34,6 @@ class LinuxGeneric < Oxidized::Model
 
     cfg += add_comment 'SNMP settings'
     cfg += cmd 'cat /etc/snmp/snmpd.conf'
-
-    cfg += add_comment 'NTP settings'
-    cfg += cmd 'cat /etc/ntp.conf'
 
     cfg += add_comment 'MOTD'
     cfg += cmd 'cat /etc/motd'
@@ -52,9 +46,6 @@ class LinuxGeneric < Oxidized::Model
 
     cfg += add_comment 'nsswitch.conf'
     cfg += cmd 'cat /etc/nsswitch.conf'
-
-    cfg += add_comment 'ACL'
-    cfg += cmd 'iptables -L -n'
 
     cfg += add_comment 'VERSION'
     cfg += cmd 'cat /etc/issue'

--- a/lib/oxidized/model/linuxgeneric.rb
+++ b/lib/oxidized/model/linuxgeneric.rb
@@ -8,6 +8,7 @@ class LinuxGeneric < Oxidized::Model
   end
 
   cmd :all do |cfg|
+    cfg.gsub! /^(default (\S+).* (expires) ).*/, '\\1 <redacted>'
     cfg.cut_both
   end
 


### PR DESCRIPTION
See: https://github.com/ytti/oxidized/issues/1818

View [culumus.rb](https://github.com/ytti/oxidized/blob/master/lib/oxidized/model/cumulus.rb) for differences

I have tested it with CentOS 7. It worked fine. :smile: 

I am not too sure how to feel about the `prompt`. 

To to reiterate here, for more specific needs, users could extend the model like so:

```
require 'oxidized/model/linuxgeneric.rb'

class LinuxGeneric
  
  cmd :secret, clear: true do |cfg|
    cfg.gsub! /^(username (\S+) privilege (\d+) (\S+) (\d+)).*/, '\\1 <redacted>'
    cfg
  end
   
  post do
    cfg = add_comment 'THE MONKEY PATCH'
    cfg += cmd 'firewall-cmd --list-all --zone=public'
  end
end

```

Any input is much appreciated!


Thank you,
Dave