### PR TITLE
Added "password cipher" to comware secret removal pattern.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 * BUGFIX: crash on some recent Ruby versions in the nagios check (@Kegeruneku)
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
+* MISC: extra secret scrubbing in comverse model (@bengels00)
 
 ## 0.26.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 * BUGFIX: crash on some recent Ruby versions in the nagios check (@Kegeruneku)
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
-* MISC: extra secret scrubbing in comverse model (@bengels00)
+* MISC: extra secret scrubbing in comware model (@bengels00)
 
 ## 0.26.3
 

--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -21,6 +21,7 @@ class Comware < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub! /^( snmp-agent community).*/, '\\1 <configuration removed>'
     cfg.gsub! /^( password hash).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^( password cipher).*/, '\\1 <configuration removed>'
     cfg
   end
 


### PR DESCRIPTION
## Description
Comware let's you store passwords with the "password cipher" command that was not recognized as secret pattern, so the cipher string was stored in git without removing it.

Added "password cipher" to secret detection patterns.