### PR TITLE
remove random trailing whitespace from adtran output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * BUGFIX: add dependencies for net-ssh
 * BUGFIX: don't log power module info on procurve model anymore
 * BUGFIX: crash on some recent Ruby versions in the nagios check (@Kegeruneku)
+* BUGFIX: remove stray whitespace in adtran model (@nickhilliard)
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
 * MISC: extra secret scrubbing in comware model (@bengels00)

--- a/lib/oxidized/model/adtran.rb
+++ b/lib/oxidized/model/adtran.rb
@@ -3,6 +3,10 @@ class Adtran < Oxidized::Model
 
   prompt /([\w.@-]+[#>]\s?)$/
 
+  cmd :all do |cfg|
+    cfg.each_line.to_a[2..-2].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+  end
+
   cmd :secret do |cfg|
     cfg.gsub!(/password (\S+)/, 'password <hidden>')
     cfg


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Adtran OS inserts random and variable quantities of trailing whitespace.  Occasionally it will insert a random \r into the config output for no particular reason.  This patch removes that whitespace.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
