### PR TITLE
Fix location of systemd service file on Debian systems

### DIFF
--- a/extra/oxidized.service
+++ b/extra/oxidized.service
@@ -1,12 +1,9 @@
-#For debian 8 put it in /lib/systemd/system/
-#To set OXIDIZED_HOME instead of the default:
-# ~${oxidized_user}/.config/oxidized in debian 8, then uncomment
-#(and modify as required) the "Environment" variable below so
-#systemd sets the correct environment. Tested only on Debian 8.8.
-#YMMV otherwise.
+# Put this file in /etc/systemd/system.
 #
-#For RHEL / CentOS 7 put it in /etc/systemd/system/
-#and call it with systemctl start oxidized.service
+# To set OXIDIZED_HOME instead of the default,
+# ~oxidized/.config/oxidized, uncomment (and modify as required) the
+# "Environment" variable below so systemd sets the correct
+# environment.
 
 [Unit]
 Description=Oxidized - Network Device Configuration Backup Tool


### PR DESCRIPTION
Administrators are not expected to put files in `/lib`. The correct
location for the systemd service file is in
`/etc/systemd/system` (like for RHEL).

This is only a change in documentation. Also, I think we should not use `SIGKILL` as the kill. Is the issue still present in recent versions of oxidized? Just using `SIGTERM` works for me. Cc @mattie47 