### PR TITLE
Add support for IOS RBAC to close #667

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * FEATURE: add sonicos model (@rgnv)
 * FEATURE: add hpmsm model (@timwsuqld)
 * FEATURE: add FastIron model (@ZacharyPuls)
+* FEATURE: Add support for RBAC in IOS model (@jameskirsop)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
 * BUGFIX: remove 'sh system' from ciscosmb model (@Exordian)

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -103,14 +103,18 @@ class IOS < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show running-config' do |cfg|
-    cfg = cfg.each_line.to_a[3..-1]
-    cfg = cfg.reject { |line| line.match /^ntp clock-period / }.join
-    cfg.gsub! /^Current configuration : [^\n]*\n/, ''
-    cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]*\n*(
-                  (?: [^\n]*\n*)*
-                  tunnel mpls traffic-eng auto-bw)/mx, '\1'
-    cfg
+  post do
+    cmd_line = 'show running-config'
+    cmd_line += ' view full' if vars(:ios_rbac)
+    cmd cmd_line do |cfg|
+      cfg = cfg.each_line.to_a[3..-1]
+      cfg = cfg.reject { |line| line.match /^ntp clock-period / }.join
+      cfg.gsub! /^Current configuration : [^\n]*\n/, ''
+      cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]*\n*(
+                    (?: [^\n]*\n*)*
+                    tunnel mpls traffic-eng auto-bw)/mx, '\1'
+      cfg
+    end
   end
 
   cfg :telnet do


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR allows issue https://github.com/ytti/oxidized/issues/677 to be closed. It provides backwards compatibility with non altered configuration, and only takes affect if the ios_rbac variable is specified.

If ios_rbac variable is specified, the IOS model will append 'view full' to the 'show running-config' command to allow non level 15 users read access (if configuration on the device allows).

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->