### PR TITLE
Change default routing daemon

### DIFF
--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -14,7 +14,7 @@ class Cumulus < Oxidized::Model
   # show the persistent configuration
   pre do
     # Set FRR or Quagga in config
-    routing_daemon = vars(:cumulus_routing_daemon) ? vars(:cumulus_routing_daemon).downcase : 'quagga'
+    routing_daemon = vars(:cumulus_routing_daemon) ? vars(:cumulus_routing_daemon).downcase : 'frr'
     routing_conf_file = routing_daemon == 'frr' ? 'frr.conf' : 'Quagga.conf'
     routing_daemon_shout = routing_daemon.upcase
 


### PR DESCRIPTION
The default routing stack on modern versions of Cumulus is FRR.  Use this as the default instead of Quagga
