### PR TITLE
Procurve compatibility enhancement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * FEATURE: add hpmsm model (@timwsuqld)
 * FEATURE: add FastIron model (@ZacharyPuls)
 * FEATURE: add Linuxgeneric model (@davama)
+* BUGFIX: improve procurve telnet support for older switches (@deajan)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
 * BUGFIX: remove 'sh system' from ciscosmb model (@Exordian)

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -1,7 +1,6 @@
 class Procurve < Oxidized::Model
   # some models start lines with \r
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  
   # additional prompt regex \e\[24;[0-9][hH]([\w\s.-]+# ) catches prompts on telnet with preceding vt100 control chars, where prompt does not start on a new line
   # tested on J4899B HP ProCurve 2650 Switch and J4813A HP ProCurve 2524 Switch
   prompt /^\r?([\w\s.-]+# )$|\e\[24;[0-9][hH]([\w\s.-]+# )/

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -1,6 +1,7 @@
 class Procurve < Oxidized::Model
   # some models start lines with \r
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
+  # prompt regex will fail on certain older telnet switches like J4899B because of missing newline and additional vt100 chars
   prompt /^\r?([\w\s.-]+# )$/
 
   comment '! '
@@ -28,6 +29,8 @@ class Procurve < Oxidized::Model
   cmd :all do |cfg|
     cfg = cfg.cut_both
     cfg = cfg.gsub /^\r/, ''
+    # Additional filtering for elder switches sending vt100 control chars via telnet
+    cfg.gsub! /\e\[\??\d+(;\d+)*[A-Za-z]/, ''
     cfg
   end
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -1,8 +1,10 @@
 class Procurve < Oxidized::Model
   # some models start lines with \r
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  # prompt regex will fail on certain older telnet switches like J4899B because of missing newline and additional vt100 chars
-  prompt /^\r?([\w\s.-]+# )$/
+  
+  # additional prompt regex \e\[24;[0-9][hH]([\w\s.-]+# ) catches prompts on telnet with preceding vt100 control chars, where prompt does not start on a new line
+  # tested on J4899B HP ProCurve 2650 Switch and J4813A HP ProCurve 2524 Switch
+  prompt /^\r?([\w\s.-]+# )$|\e\[24;[0-9][hH]([\w\s.-]+# )/
 
   comment '! '
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [N/A] Tests added or adapted (try `rake test`)
- [N/A] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Fixes an issue with detecting prompt on older procurve switches (J4899B and J4813A tested), where VT100 control chars get send to scroll, resulting in a prompt which starts with a control character instead of a newline.

Also tested for regression against the following switches (which still work):
- J9776A, J9138A, J9775A, J9783A, J9728A, J9586A


<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Should fix https://github.com/ytti/oxidized/issues/1804 and https://github.com/ytti/oxidized/issues/1705 and maybe https://github.com/ytti/oxidized/issues/1607