### PR TITLE
Zynos gs compat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+* FEATURE: add zyxel GS1900 support to ZynOS model (@deajan) 
 * FEATURE: add PurityOS model support (@elliot64)
 * FEATURE: add Ubiquiti Airfiber model support (@cchance27)
 * FEATURE: add Icotera support (@funzoneq)

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -23,7 +23,7 @@ class ZyNOS < Oxidized::Model
     cfg.gsub! /[\b]|\e\[A|\e\[2K/, ''
     cfg
   end
-  
+
   cfg :ftp do
   end
 

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -1,10 +1,40 @@
 class ZyNOS < Oxidized::Model
-  # Used in Zyxel DSLAMs, such as SAM1316
+  # Used in Zyxel GS1900 switches
+  # Used in Zyxel DSLAMs, such as SAM1316, please comment out prompt line for those
 
+  prompt /^.*# $/
   comment '! '
+
+  expect /^--More--$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
 
   cmd 'config-0'
 
+  cmd 'show running-config' do |cfg|
+    cfg
+  end
+  
   cfg :ftp do
+  end
+
+  cfg :telnet, :ssh do
+    username /^(User name|.*Username):/
+    password /^\r?Password:/
+  end
+
+  cfg :telnet do
+    pre_logout do
+      send "exit\r"
+    end
+  end
+
+  cfg :ssh do
+    pre_logout do
+      # Yes, that GS1900 switch needs two exit !
+      send "exit\n"
+      send "exit\n"
+    end
   end
 end

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -10,16 +10,17 @@ class ZyNOS < Oxidized::Model
     data.sub re, ''
   end
 
+  # replace all used vt100 control sequences
+  expect /\e\[\??\d+(;\d+)*[A-Za-z]/ do |data, re|
+    data.gsub re, ''
+  end
+  
   cmd 'config-0'
 
   cmd 'show running-config' do |cfg|
     cfg.gsub! /(System Up Time:) \S+(.*)/, '\\1 <time>'
-    
-    # Remove garbage chars sent when by --More--
-    # Backspace 0x07 char
-    cfg.gsub! /[\b]/, ''
-    cfg.gsub! /\e\[A\e\[2K/, ''
-    
+    # Remove additional garbage vt100 control sequences
+    cfg.gsub! /[\b]|\e\[A|\e\[2K/, ''
     cfg
   end
   

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -14,7 +14,7 @@ class ZyNOS < Oxidized::Model
   expect /\e\[\??\d+(;\d+)*[A-Za-z]/ do |data, re|
     data.gsub re, ''
   end
-  
+
   cmd 'config-0'
 
   cmd 'show running-config' do |cfg|

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -13,6 +13,7 @@ class ZyNOS < Oxidized::Model
   cmd 'config-0'
 
   cmd 'show running-config' do |cfg|
+    cfg.gsub! /(System Up Time:) \S+(.*)/, '\\1 <time>'
     cfg
   end
   

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -14,6 +14,12 @@ class ZyNOS < Oxidized::Model
 
   cmd 'show running-config' do |cfg|
     cfg.gsub! /(System Up Time:) \S+(.*)/, '\\1 <time>'
+    
+    # Remove garbage chars sent when by --More--
+    # Backspace 0x07 char
+    cfg.gsub! /[\b]/, ''
+    cfg.gsub! /\e\[A\e\[2K/, ''
+    
     cfg
   end
   


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [N/A] Tests added or adapted (try `rake test`)
- [N/A] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Adds support for Zyxel GS1900-8 switch to ZynOS, might also work with bigger GS1900 switches.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Fixes https://github.com/ytti/oxidized/issues/1703
Fixes part of https://github.com/ytti/oxidized/issues/1404