### PR TITLE
Watchguard FirewareOS name fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * FEATURE: add hpmsm model (@timwsuqld)
 * FEATURE: add FastIron model (@ZacharyPuls)
 * FEATURE: add Linuxgeneric model (@davama)
+* BUGFIX: fireware model made oxidized crash (@deajan)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
 * BUGFIX: remove 'sh system' from ciscosmb model (@Exordian)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -201,7 +201,7 @@
   * [EdgeSwitch](/lib/oxidized/model/edgeswitch.rb)
   * [AirFiber](/lib/oxidized/model/airfiber.rb)
 * Watchguard
-  * [Fireware OS](/lib/oxidized/model/firewareos.rb)
+  * [Fireware OS](/lib/oxidized/model/fireware.rb)
 * Westell
   * [Westell 8178G, Westell 8266G](/lib/oxidized/model/weos.rb)
 * Zhone

--- a/lib/oxidized/model/fireware.rb
+++ b/lib/oxidized/model/fireware.rb
@@ -1,4 +1,4 @@
-class FirewareOS < Oxidized::Model
+class Fireware < Oxidized::Model
   prompt /^\[?\w*\]?\w*?(<\w*>)?(#|>)\s*$/
   comment  '-- '
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [N/A] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
LibreNMS returns "fireware" instead of "firewareos".
Checked with snmpwalk over a Watchguard, it's not the firewall itself that gives that name, but librenms.
I'm not sure whether the name should be changed in oxidized or LibreNMS, but but well here we are.
Open to any suggestiongs.

This PR also fixes `undefined method `new' for nil:NilClass` because of the class naming.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
No issue open I think.