### PR TITLE
Clean up procurve prompt regexp

### DIFF
--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -3,7 +3,7 @@ class Procurve < Oxidized::Model
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
   # additional prompt regex \e\[24;[0-9][hH]([\w\s.-]+# ) catches prompts on telnet with preceding vt100 control chars, where prompt does not start on a new line
   # tested on J4899B HP ProCurve 2650 Switch and J4813A HP ProCurve 2524 Switch
-  prompt  /^(\r|\e\[24;[0-9][hH])?([\w\s.-]+# )$/ 
+  prompt  /^(\r|\e\[24;[0-9][hH])?([\w\s.-]+# )$/
 
   comment '! '
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -3,7 +3,7 @@ class Procurve < Oxidized::Model
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
   # additional prompt regex \e\[24;[0-9][hH]([\w\s.-]+# ) catches prompts on telnet with preceding vt100 control chars, where prompt does not start on a new line
   # tested on J4899B HP ProCurve 2650 Switch and J4813A HP ProCurve 2524 Switch
-  prompt /^\r?([\w\s.-]+# )$|\e\[24;[0-9][hH]([\w\s.-]+# )/
+  prompt  /^(\r|\e\[24;[0-9][hH])?([\w\s.-]+# )$/ 
 
   comment '! '
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Clean up procurve prompt to be more concise.

Follow-up from #1866
