### PR TITLE
restore aosw prompt that slipped through review in #1820

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -10,7 +10,7 @@ class AOSW < Oxidized::Model
   # All IAPs connected to a Instant Controller will have the same config output. Only the controller needs to be monitored.
 
   comment  '# '
-  prompt /^([\w\(.@-]+(\)?\s?)[#>]\s?)$/
+  prompt /^\(?.+\)?\s[#>]/ 
 
   cmd :all do |cfg|
     cfg.cut_both

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -10,7 +10,7 @@ class AOSW < Oxidized::Model
   # All IAPs connected to a Instant Controller will have the same config output. Only the controller needs to be monitored.
 
   comment  '# '
-  prompt /^\(?.+\)?\s[#>]/ 
+  prompt /^\(?.+\)?\s[#>]/
 
   cmd :all do |cfg|
     cfg.cut_both


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Revert unintentional prompt change in asow model that slipped in as part of #1820

Closes #1870
