### PR TITLE
Zyxel GS1900 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+* FEATURE: add ZynOS GS1900 specific model support (@deajan)
 * FEATURE: add PurityOS model support (@elliot64)
 * FEATURE: add Ubiquiti Airfiber model support (@cchance27)
 * FEATURE: add Icotera support (@funzoneq)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -208,6 +208,5 @@
   * [Zhone (OLT and MX)](/lib/oxidized/model/zhoneolt.rb)
 * Zyxel
   * [ZyNOS](/lib/oxidized/model/zynos.rb)
-  * GS1900 Switch specific ZyNOS
-    * [ZyNOSGS](/lib/oxidized/model/zynosgs.rb)
+  * [ZyNOS GS-series variant](/lib/oxidized/model/zynosgs.rb)
   * [NDMS](/lib/oxidized/model/ndms.rb)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -208,4 +208,6 @@
   * [Zhone (OLT and MX)](/lib/oxidized/model/zhoneolt.rb)
 * Zyxel
   * [ZyNOS](/lib/oxidized/model/zynos.rb)
+  * GS1900 Switch specific ZyNOS
+    * [ZyNOSGS](/lib/oxidized/model/zynosgs.rb)
   * [NDMS](/lib/oxidized/model/ndms.rb)

--- a/lib/oxidized/model/zynosgs.rb
+++ b/lib/oxidized/model/zynosgs.rb
@@ -1,0 +1,41 @@
+class ZyNOSGS < Oxidized::Model
+  # Used in Zyxel GS1900 switches, tested with GS1900-8
+  prompt /^.*# $/
+  comment '! '
+  expect /^--More--$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
+  # replace all used vt100 control sequences
+  expect /\e\[\??\d+(;\d+)*[A-Za-z]/ do |data, re|
+    data.gsub re, ''
+  end
+  cmd 'show running-config' do |cfg|
+    cfg.gsub! /(System Up Time:) \S+(.*)/, '\\1 <time>'
+    # Remove garbage vt100 control sequences
+    # Backspace 0x07 char or escape char + control chars
+    cfg.gsub! /[\b]|\e\[A|\e\[2K/, ''
+    #cfg.gsub! /\e\[A\e\[2K/, ''
+
+    #cfg.gsub! /\e\[2K/, ''
+    cfg
+  end
+
+  cfg :telnet, :ssh do
+    username /^(User name|.*Username):/
+    password /^\r?Password:/
+  end
+  cfg :telnet do
+    pre_logout do
+      send "exit\r"
+    end
+  end
+  cfg :ssh do
+    pre_logout do
+      # Yes, that GS1900 switch needs two exit !
+      send "exit\n"
+      send "exit\n"
+    end
+  end
+end

--- a/lib/oxidized/model/zynosgs.rb
+++ b/lib/oxidized/model/zynosgs.rb
@@ -16,9 +16,6 @@ class ZyNOSGS < Oxidized::Model
     # Remove garbage vt100 control sequences
     # Backspace 0x07 char or escape char + control chars
     cfg.gsub! /[\b]|\e\[A|\e\[2K/, ''
-    #cfg.gsub! /\e\[A\e\[2K/, ''
-
-    #cfg.gsub! /\e\[2K/, ''
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [N/A] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Adds support for Zyxel GS1900-8 switch to ZynOS, might also work with bigger GS1900 switches.
Fixes https://github.com/ytti/oxidized/issues/1703, part of https://github.com/ytti/oxidized/issues/1404
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
