### PR TITLE
More restrictive prompt regex

### DIFF
--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -1,9 +1,9 @@
 class Procurve < Oxidized::Model
-  # some models start lines with \r
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  # additional prompt regex \e\[24;[0-9][hH]([\w\s.-]+# ) catches prompts on telnet with preceding vt100 control chars, where prompt does not start on a new line
-  # tested on J4899B HP ProCurve 2650 Switch and J4813A HP ProCurve 2524 Switch
-  prompt /^\r?([\w\s.-]+# )$|\e\[24;[0-9][hH]([\w\s.-]+# )/
+  # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+# ), which ends the line
+  # telnet switchs may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), follwed by the prompt, followed
+  # by at least 3 other vt100 characters
+  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+# )($|(\e\[24;[0-9][0-9]?[hH]){3})/
 
   comment '! '
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [N/A] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
As discussed in https://github.com/ytti/oxidized/pull/1866, this is a less open version of the prompt working for ssh and telnet switches

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
