### PR TITLE
Model impovements for ios/comware/ironware/screenos and new model speedtouch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FEATURE: add hpmsm model (@timwsuqld)
 * FEATURE: add FastIron model (@ZacharyPuls)
 * FEATURE: add Linuxgeneric model (@davama)
+* FEATURE: add SpeedTouch model (@raunz)
 * BUGFIX: improve procurve telnet support for older switches (@deajan)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
@@ -24,6 +25,9 @@
 * BUGFIX: remove stray whitespace in adtran model (@nickhilliard)
 * BUGFIX: if input model returns subclassed string we may overwrite the string with an empty string
 * BUGFIX: updated aosw.rb prompt. addresses issue #1254
+* BUGFIX: update comware model to fix telnet login/password for HPE MSR954 and HPE5130. Issue #1886
+* BUGFIX: filter out IOS configuration/NVRAM modified/changed timestamps to keep output persistent
+* BUGFIX: update screenos model to reduce the amount of lines being stripped from beginning of cfg output
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
 * MISC: extra secret scrubbing in comware model (@bengels00)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -182,6 +182,8 @@
    * [SonicOS](lib/oxidized/model/sonicos.rb)
 * SNR
   * [SNR-S300G, S2xxx, S3xxx, S4xxx](/lib/oxidized/model/dcnos.rb)
+* Speedtouch
+  * [Thomson Speedtouch](/lib/oxidized/model/speedtouch.rb)
 * Supermicro
   * [SSE-G2252, G2252P](/lib/oxidized/model/edgecos.rb)
   * [SSE-G48-TG4, G24-TG4](/lib/oxidized/model/aricentiss.rb)

--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -26,8 +26,8 @@ class Comware < Oxidized::Model
   end
 
   cfg :telnet do
-    username /^Username:$/
-    password /^Password:$/
+    username /^(Username|login):/
+    password /^Password:/
   end
 
   cfg :telnet, :ssh do

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -95,6 +95,7 @@ class IOS < Oxidized::Model
 
   cmd 'show vtp status' do |cfg|
     cfg.gsub! /^$\n/, ''
+    cfg.gsub! /Configuration last modified by.*\n/, ''
     cfg.gsub! /^/, 'VTP: ' unless cfg.empty?
     comment "#{cfg}\n"
   end
@@ -107,6 +108,8 @@ class IOS < Oxidized::Model
     cfg = cfg.each_line.to_a[3..-1]
     cfg = cfg.reject { |line| line.match /^ntp clock-period / }.join
     cfg.gsub! /^Current configuration : [^\n]*\n/, ''
+    cfg.gsub! /^! (Last|No) configuration change (at|since).*\n/, ''
+    cfg.gsub! /^! NVRAM config last updated.*\n/, ''
     cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]*\n*(
                   (?: [^\n]*\n*)*
                   tunnel mpls traffic-eng auto-bw)/mx, '\1'

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -51,6 +51,7 @@ class IronWare < Oxidized::Model
 
   cmd 'show flash' do |cfg|
     cfg.gsub! /(\d+) bytes/, '' # Fix for ADX flash size
+    cfg.gsub! /(^((.*)Code Flash Free Space(.*))$)/, '' # Brocade
     comment cfg
   end
 

--- a/lib/oxidized/model/screenos.rb
+++ b/lib/oxidized/model/screenos.rb
@@ -6,7 +6,7 @@ class ScreenOS < Oxidized::Model
   prompt /^[\w.:()-]+->\s?$/
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[2..-2].join
+    cfg.each_line.to_a[1..-2].join
   end
 
   cmd :secret do |cfg|
@@ -24,8 +24,7 @@ class ScreenOS < Oxidized::Model
   end
 
   cmd 'get config' do |cfg|
-    cfg = cfg.each_line.to_a[3..-1].join
-    cfg
+    cfg.each_line.to_a[1..-1].join
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/speedtouch.rb
+++ b/lib/oxidized/model/speedtouch.rb
@@ -1,7 +1,6 @@
 class SpeedTouch < Oxidized::Model
-
   prompt /([\w{}=]+[>])$/
-  comment  '! '
+  comment '! '
 
   expect /login$/ do
     send "\n"
@@ -10,16 +9,16 @@ class SpeedTouch < Oxidized::Model
 
   cmd ':env list' do |cfg|
     cfg.each_line.select do |line|
-      not line.match /:env list$/ and
-      not line.match /{\w+}=>$/
+      (not line.match /:env list$/) &&
+        (not line.match /{\w+}=>$/)
     end.join
     comment cfg
   end
 
   cmd ':config dump' do |cfg|
     cfg.each_line.select do |line|
-      not line.match /:config dump$/ and
-      not line.match /{\w+}=>$/
+      (not line.match /:config dump$/) &&
+        (not line.match /{\w+}=>$/)
     end.join
     cfg
   end
@@ -29,8 +28,7 @@ class SpeedTouch < Oxidized::Model
     password /^Password : /
   end
 
- cfg :telnet do
-   pre_logout 'exit'
- end
-
+  cfg :telnet do
+    pre_logout 'exit'
+  end
 end

--- a/lib/oxidized/model/speedtouch.rb
+++ b/lib/oxidized/model/speedtouch.rb
@@ -1,0 +1,36 @@
+class SpeedTouch < Oxidized::Model
+
+  prompt /([\w{}=]+[>])$/
+  comment  '! '
+
+  expect /login$/ do
+    send "\n"
+    ""
+  end
+
+  cmd ':env list' do |cfg|
+    cfg.each_line.select do |line|
+      not line.match /:env list$/ and
+      not line.match /{\w+}=>$/
+    end.join
+    comment cfg
+  end
+
+  cmd ':config dump' do |cfg|
+    cfg.each_line.select do |line|
+      not line.match /:config dump$/ and
+      not line.match /{\w+}=>$/
+    end.join
+    cfg
+  end
+
+  cfg :telnet do
+    username /^Username : /
+    password /^Password : /
+  end
+
+ cfg :telnet do
+   pre_logout 'exit'
+ end
+
+end


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)

## Description
Comware model login prompt has changed in newer HPE devices. Fix for #1886
Wipe out 'flash free space' from some Brocade devices which use ironware model.
Added Thomson Speedtouch model.
Added gsub's to ios model, to ignore "configuration last changed", "NVRAM modified" lines from config and VTP status. 
