### PR TITLE
Added : to prompt regex to support Aruba Virtual-Controller prompt, w…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * BUGFIX: update comware model to fix telnet login/password for HPE MSR954 and HPE5130. Issue #1886
 * BUGFIX: filter out IOS configuration/NVRAM modified/changed timestamps to keep output persistent
 * BUGFIX: update screenos model to reduce the amount of lines being stripped from beginning of cfg output
+* BUGFIX: include colon in aosw prompt regexp in case it is a mac address (@raunz)
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
 * MISC: extra secret scrubbing in comware model (@bengels00)

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -10,7 +10,7 @@ class AOSW < Oxidized::Model
   # All IAPs connected to a Instant Controller will have the same config output. Only the controller needs to be monitored.
 
   comment  '# '
-  prompt /^([\w\(.@-]+(\)?\s?)[#>]\s?)$/
+  prompt /^([\w\(:.@-]+(\)?\s?)[#>]\s?)$/
 
   cmd :all do |cfg|
     cfg.cut_both


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added ":" to prompt regex to support Aruba Virtual-Controller prompt, which could be a mac address.

Improvement to issue #1254