### PR TITLE
ASA: remove last change time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 * BUGFIX: updated aosw.rb prompt. addresses issue #1254
 * BUGFIX: update comware model to fix telnet login/password for HPE MSR954 and HPE5130. Issue #1886
 * BUGFIX: filter out IOS configuration/NVRAM modified/changed timestamps to keep output persistent
+* BUGFIX: filter out ASA configuration modified/changed timestamps to keep output persistent
 * BUGFIX: update screenos model to reduce the amount of lines being stripped from beginning of cfg output
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged

--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -34,6 +34,8 @@ class ASA < Oxidized::Model
     # avoid commits due to uptime / ixo-router01 up 2 mins 28 secs / ixo-router01 up 1 days 2 hours
     cfg = cfg.each_line.reject { |line| line.match /(\s+up\s+\d+\s+)|(.*days.*)/ }
     cfg = cfg.join
+    cfg.gsub! /^Configuration has not been modified since last system restart.*\n/, ''
+    cfg.gsub! /^Configuration last modified by.*\n/, ''
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
The date of the last configuration change is changed even if the user enters the configuration mode and exits. It creates additional (useless) entries in the history, which is inconvenient and slows down the work with a long history (useful for #1616).
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
