### PR TITLE
Moved show configuration output the end of cfg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * MISC: upgrade slop, net-telnet and rugged
 * MISC: extra secret scrubbing in comware model (@bengels00)
 * MISC: removed snmpd lines from linuxgeneric model
+* MISC: moved show configuration command to the end in junos model
 
 ## 0.26.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@
 * MISC: upgrade slop, net-telnet and rugged
 * MISC: extra secret scrubbing in comware model (@bengels00)
 * MISC: removed snmpd lines from linuxgeneric model
-* MISC: moved show configuration command to the end in junos model
+* MISC: moved show configuration command to the end in junos model (@raunz)
 
 ## 0.26.3
 

--- a/docs/Model-Notes/JunOS.md
+++ b/docs/Model-Notes/JunOS.md
@@ -20,13 +20,13 @@ The commands Oxidized executes are:
 
 1. set cli screen-length 0
 2. set cli screen-width 0
-3. show configuration
-4. show version
-5. show chassis hardware
-6. show system license
-7. show system license keys (ex22|ex33|ex4|ex8|qfx only)
-8. show virtual-chassis (MX960 only)
-9. show chassis fabric reachability
+3. show version
+4. show chassis hardware
+5. show system license
+6. show system license keys (ex22|ex33|ex4|ex8|qfx only)
+7. show virtual-chassis (MX960 only)
+8. show chassis fabric reachability
+9. show configuration
 
 Oxidized can now retrieve your configuration!
 

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -17,8 +17,6 @@ class JunOS < Oxidized::Model
     cfg
   end
 
-  cmd 'show configuration | display omit'
-
   cmd 'show version' do |cfg|
     @model = Regexp.last_match(1) if cfg =~ /^Model: (\S+)/
     comment cfg
@@ -38,6 +36,8 @@ class JunOS < Oxidized::Model
   cmd('show chassis hardware') { |cfg| comment cfg }
   cmd('show system license') { |cfg| comment cfg }
   cmd('show system license keys') { |cfg| comment cfg }
+
+  cmd 'show configuration | display omit'
 
   cfg :telnet do
     username(/^login:/)


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Moved 'show configuration' to the end of commands list, so the cfg result will start with comments and end with configuration. Most of the models execute configuration retrieval command the last one, so changing junos model to the same behaviour would be nice.