### PR TITLE
fortios added command 'get system ha status'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * FEATURE: add hpmsm model (@timwsuqld)
 * FEATURE: add FastIron model (@ZacharyPuls)
 * FEATURE: add Linuxgeneric model (@davama)
+* FEATURE: include HA status info in fortios model (@raunz)
 * FEATURE: add SpeedTouch model (@raunz)
 * BUGFIX: improve procurve telnet support for older switches (@deajan)
 * BUGFIX: voss model

--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -34,6 +34,11 @@ class FortiOS < Oxidized::Model
     comment cfg
   end
 
+  cmd 'get system ha status' do |cfg|
+    cfg = cfg.each_line.select { |line| line.match /^(HA Health Status|Mode|Model|Master|Slave\s+):/ }.join
+    comment cfg
+  end
+
   post do
     cfg = []
     cfg << cmd('config global') if @vdom_enabled


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added 'get system ha status' command to fortios. Comments now include hardware information about FortiGate cluster nodes.

### output of HA cluster:
```
# HA Health Status: OK
# Model: FortiGate-100D
# Mode: HA A-P
# Master: my-node-slave-fw, FG100D3G14830001, cluster index = 1
# Slave : my-node-master-fw, FG100D3G15800008, cluster index = 0
# Master: FG100D3G14830001, operating cluster index = 0
# Slave : FG100D3G15800008, operating cluster index = 1
```
### output of non HA single device:
```
# Model: FortiGate-30D
# Mode: standalone
```