### PR TITLE
sros show chassis and model cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * FEATURE: add Ubiquiti Airfiber model support (@cchance27)
 * FEATURE: add Icotera support (@funzoneq)
 * FEATURE: include licensing information in aos model (@pozar)
+* FEATURE: include chassis information in sros model (@raunz)
 * FEATURE: add firelinuxos (FirePOWER) model (@rgnv)
 * FEATURE: add sonicos model (@rgnv)
 * FEATURE: add hpmsm model (@timwsuqld)

--- a/lib/oxidized/model/sros.rb
+++ b/lib/oxidized/model/sros.rb
@@ -45,7 +45,7 @@ class SROS < Oxidized::Model
   # Show the chassis information.
   #
   cmd 'show chassis' do |cfg|
-    comment cfg.lines.to_a[1..25].reject { |line| line.match /state|Time|Temperature|Status/ }.join
+    comment cfg.lines.to_a[0..25].reject { |line| line.match /state|Time|Temperature|Status/ }.join
   end
 
   #

--- a/lib/oxidized/model/sros.rb
+++ b/lib/oxidized/model/sros.rb
@@ -10,6 +10,9 @@ class SROS < Oxidized::Model
 
   cmd :all do |cfg, cmdstring|
     new_cfg = comment "COMMAND: #{cmdstring}\n"
+    cfg.gsub! /# Finished .*/, ''
+    cfg.gsub! /# Generated .*/, ''
+    cfg.delete! "\r"
     new_cfg << cfg.cut_both
   end
 
@@ -17,8 +20,6 @@ class SROS < Oxidized::Model
   # Show the boot options file.
   #
   cmd 'show bof' do |cfg|
-    cfg.gsub! /# Finished .*/, ''
-    cfg.gsub! /# Generated .*/, ''
     comment cfg
   end
 
@@ -30,8 +31,6 @@ class SROS < Oxidized::Model
     # Strip uptime.
     #
     cfg.sub! /^System Up Time.*\n/, ''
-    cfg.gsub! /# Finished .*/, ''
-    cfg.gsub! /# Generated .*/, ''
     comment cfg
   end
 
@@ -39,22 +38,21 @@ class SROS < Oxidized::Model
   # Show the card state.
   #
   cmd 'show card state' do |cfg|
-    cfg.gsub! /# Finished .*/, ''
-    cfg.gsub! /# Generated .*/, ''
     comment cfg
+  end
+
+  #
+  # Show the chassis information.
+  #
+  cmd 'show chassis' do |cfg|
+    comment cfg.lines.to_a[1..25].reject { |line| line.match /state|Time|Temperature|Status/ }.join
   end
 
   #
   # Show the boot log.
   #
   cmd 'file type bootlog.txt' do |cfg|
-    #
-    # Strip carriage returns and backspaces.
-    #
-    cfg.delete! "\r"
     cfg.gsub! /[\b][\b][\b]/, "\n"
-    cfg.gsub! /# Finished .*/, ''
-    cfg.gsub! /# Generated .*/, ''
     comment cfg
   end
 
@@ -62,8 +60,6 @@ class SROS < Oxidized::Model
   # Show the running debug configuration.
   #
   cmd 'show debug' do |cfg|
-    cfg.gsub! /# Finished .*/, ''
-    cfg.gsub! /# Generated .*/, ''
     comment cfg
   end
 
@@ -71,12 +67,6 @@ class SROS < Oxidized::Model
   # Show the saved debug configuration (admin debug-save).
   #
   cmd 'file type config.dbg' do |cfg|
-    #
-    # Strip carriage returns.
-    #
-    cfg.delete! "\r"
-    cfg.gsub! /# Finished .*/, ''
-    cfg.gsub! /# Generated .*/, ''
     comment cfg
   end
 
@@ -84,12 +74,6 @@ class SROS < Oxidized::Model
   # Show the running persistent indices.
   #
   cmd 'admin display-config index' do |cfg|
-    #
-    # Strip carriage returns.
-    #
-    cfg.delete! "\r"
-    cfg.gsub! /# Finished .*/, ''
-    cfg.gsub! /# Generated .*/, ''
     comment cfg
   end
 
@@ -97,12 +81,7 @@ class SROS < Oxidized::Model
   # Show the running configuration.
   #
   cmd 'admin display-config' do |cfg|
-    #
-    # Strip carriage returns.
-    #
-    cfg.delete! "\r"
-    cfg.gsub! /# Finished .*/, ''
-    cfg.gsub! /# Generated .*/, ''
+    cfg
   end
 
   cfg :telnet do


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Cleaned up copy-paste gsub's from each cmd.
Added 25 lines of "show chassis" command from where additional non-persistent lines are rejected.

Sample section appended to comments:
```
# # COMMAND: show chassis
#
# ===============================================================================
# Chassis Information
# ===============================================================================
#     Name                          : sros-sar-m
#     Type                          : 7705 SAR-M
#     Location                      :
#     Coordinates                   :
#     CLLI code                     :
#     Number of slots               : 2
#     Number of ports               : 23
#     Base MAC address              : d4:e3:3f:d8:1f:17
#
# Hardware Data
#     Part number                   : 3HE05051ABAE0105
#     CLEI code                     : IPMSY10BRA
#     Serial number                 : NS1218F0000
#     Manufacture date              : 04302012
#     Manufacturing string          : C06641
#     Manufacturing deviations      :
```