### PR TITLE
Procurve exclude power consumption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * FEATURE: add FastIron model (@ZacharyPuls)
 * FEATURE: add Linuxgeneric model (@davama)
 * FEATURE: add SpeedTouch model (@raunz)
+* BUGFIX: prevent versionning on procurve switches by removing power usage output (@deajan)
 * BUGFIX: improve procurve telnet support for older switches (@deajan)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -32,7 +32,8 @@ class Procurve < Oxidized::Model
     cfg = cfg.gsub /^\r/, ''
     # Additional filtering for elder switches sending vt100 control chars via telnet
     cfg.gsub! /\e\[\??\d+(;\d+)*[A-Za-z]/, ''
-    cfg.gsub! /(.*(AC .*[0-9]*V).*([0-9]*).*([0-9]*)$/, '\\1 <removed> \\2'
+    # Additional filtering for power usage reporting which obviously changes over time
+    cfg.gsub! /^(.*AC [0-9]{3}V\/?([0-9]{3}V)?) *([0-9]{1,3}) (.*)/, '\\1 <removed> \\4'
     cfg
   end
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -32,6 +32,7 @@ class Procurve < Oxidized::Model
     cfg = cfg.gsub /^\r/, ''
     # Additional filtering for elder switches sending vt100 control chars via telnet
     cfg.gsub! /\e\[\??\d+(;\d+)*[A-Za-z]/, ''
+    cfg.gsub! /(.*(AC .*[0-9]*V).*([0-9]*).*([0-9]*)$/, '\\1 <removed> \\2'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [N/A] Tests added or adapted (try `rake test`)
- [N/A] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
I recently worked on HPe 5400 series switches which work great with current oxidized, but create new versions of the configuration because of power consumption output in the configuration.

This fix replaces the actual wattage with `<removed>` so the config doesn't change.
