### PR TITLE
Systemd restart on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+* FEATURE: add automatic restart on failure for systemd (@deajan)
 * FEATURE: add ZynOS GS1900 specific model support (@deajan)
 * FEATURE: add PurityOS model support (@elliot64)
 * FEATURE: add Ubiquiti Airfiber model support (@cchance27)

--- a/extra/oxidized.service
+++ b/extra/oxidized.service
@@ -18,6 +18,8 @@ ExecStart=/usr/local/bin/oxidized
 User=oxidized
 KillSignal=SIGKILL
 #Environment="OXIDIZED_HOME=/etc/oxidized"
+Restart=on-failure
+RestartSec=300s
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [N/A] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [N/A] Tests added or adapted (try `rake test`)
- [N/A] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
oxidized service may fail when using http source and no hosts are listed.
This allows systemd to restart a failed oxidized service on failure.

This needs #1929 to work
