### PR TITLE
Add hidden info for SonicWall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * FEATURE: add Waystream iBOS model
 * BUGFIX: better login modalities for telnet in aos7 (@optimuscream)
 * BUGFIX: better virtual domain detection in fortios (@agabellini)
+* MISC: more secret scrubbing in sonicos (@s-fu)
 * MISC: openssh key scrubbing as secret in fortios (@agabellini)
 
 ## 0.27.0

--- a/lib/oxidized/model/sonicos.rb
+++ b/lib/oxidized/model/sonicos.rb
@@ -12,6 +12,11 @@ class SonicOS < Oxidized::Model
     cfg.gsub! /cli ftp password default \d\,(\S+)/, 'cli ftp password default <secret hidden> \2'
     cfg.gsub! /secret \d\,(\S+)/, 'secret <secret hidden> \2'
     cfg.gsub! /shared-secret \d\,(\S+)/, 'shared-secret <secret hidden> \2'
+    cfg.gsub! /password \d\,(\S+)/, 'password <secret hidden> \2'
+    cfg.gsub! /passphrase password \d\,(\S+)/, 'passphrase password <secret hidden> \2'
+    cfg.gsub! /bind-password \d\,(\S+)/, 'bind-password <secret hidden> \2'
+    cfg.gsub! /authentication sha1 \d\,(\S+)/, 'authentication sha1 <secret hidden> \2'
+    cfg.gsub! /encryption aes \d\,(\S+)/, 'encryption aes <secret hidden> \2'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Sensitive information also exists in the following lines. Mark then in hidden secret module.

- password xxx
- passphrase password xxx
- bind-password xxx
- authenticate sha1 xxx
- encryption aes xxx