### PR TITLE
Update aos7.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+* BUGFIX: better login modalities for telnet in aos7 (@optimuscream)
+
 ## 0.27.0
 
 * FEATURE: add automatic restart on failure for systemd (@deajan)

--- a/lib/oxidized/model/aos7.rb
+++ b/lib/oxidized/model/aos7.rb
@@ -47,7 +47,7 @@ class AOS7 < Oxidized::Model
   end
 
   cfg :telnet do
-    username /^login : /
+    username /^([\w -])*login: /
     password /^Password : /
   end
 

--- a/lib/oxidized/model/aos7.rb
+++ b/lib/oxidized/model/aos7.rb
@@ -48,7 +48,7 @@ class AOS7 < Oxidized::Model
 
   cfg :telnet do
     username /^([\w -])*login: /
-    password /^Password: /
+    password /^Password\s?: /
   end
 
   cfg :telnet, :ssh do

--- a/lib/oxidized/model/aos7.rb
+++ b/lib/oxidized/model/aos7.rb
@@ -48,7 +48,7 @@ class AOS7 < Oxidized::Model
 
   cfg :telnet do
     username /^([\w -])*login: /
-    password /^Password : /
+    password /^Password: /
   end
 
   cfg :telnet, :ssh do


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here.-->
Login prompt for device type :
Alcatel-Lucent Enterprise OS6900-X72 8.5.196.R04 GA, February 25, 2019

is like this (example machine OS6900-X72-MACHINE)

`OS6900-X72-MACHINE login:`

So I have to edit the login code in aos7.rb to permit oxidized to get through.
Closes issue #1959

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
