### PR TITLE
Supported OS types: add Fiberstore S3900 series

### DIFF
--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -105,6 +105,7 @@
   * [TMOS](/lib/oxidized/model/tmos.rb)
 * Fiberstore
   * [S3800](/lib/oxidized/model/gcombnps.rb)
+  * [S3900](/lib/oxidized/model/edgecos.rb)
 * Firebrick
   * [FBxxxx](/lib/oxidized/model/firebrick.rb)
 * Force10


### PR DESCRIPTION
## Description
The software of the S3900 switches is very simmilar to the EdgeCOS software.

This should help users to easily find the correct module without duplicating code.