### PR TITLE
Added 'enable' command for Arista EOS (if enable is not default op mo…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+## 0.27.1
+
+* BUGFIX: enable command for Arista EOS model in case RADIUS AVP's don't default to enable
+
 ## 0.27.0
 
 * FEATURE: add automatic restart on failure for systemd (@deajan)

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -18,7 +18,7 @@ class EOS < Oxidized::Model
     cfg
   end
 
-  cmd 'enable' do |cfg\
+  cmd 'enable' do |cfg|
     comment cfg
   end
 

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -18,6 +18,10 @@ class EOS < Oxidized::Model
     cfg
   end
 
+  cmd 'enable' do |cfg\
+    comment cfg
+  end
+
   cmd 'show inventory | no-more' do |cfg|
     comment cfg
   end


### PR DESCRIPTION
## Description
Added command to Arista EOS model to put switch in enable mode before running privileged commands (show running-config)

Closes issue #1969 
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
