### PR TITLE
added support for huawei OLT MA5800

### DIFF
--- a/lib/oxidized/model/vrp58.rb
+++ b/lib/oxidized/model/vrp58.rb
@@ -1,0 +1,53 @@
+class VRP58 < Oxidized::Model
+  # Huawei VRP MA5800
+
+  prompt /^([\w.-]+(>|#))$/
+  comment '# '
+
+  cmd :secret do |cfg|
+    cfg.gsub! /(pin verify (?:auto|)).*/, '\\1 <PIN hidden>'
+    cfg.gsub! /(%\^%#.*%\^%#)/, '<secret hidden>'
+    cfg
+  end
+
+  cmd :all do |cfg|
+    cfg.each_line.to_a[1..-2].join
+  end
+
+  cfg :telnet do
+    username /^(>>User name:)$/
+    password /^(>>User password:)$/
+  end
+
+  cfg :telnet, :ssh do
+    post_login 'enable'
+    post_login 'undo echo'
+    post_login "scroll \n"
+    post_login 'undo interactive'
+    post_login 'infoswitch cli off'
+    pre_logout "quit"
+  end
+
+  cmd "display board serial-number 0 \n" do |cfg|
+    comment cfg
+  end
+
+  cmd "display board desc 0 \n" do |cfg|
+    comment cfg
+  end
+
+  cmd "display io-packetfile information \n" do |cfg|
+    comment cfg
+  end
+
+  cmd "display version \n" do |cfg|
+    cfg = cfg.each_line.select {|l| not l.match /Uptime/ }.join
+    comment cfg
+  end
+
+  cmd "display current-configuration \n" do |cfg|
+    cfg
+  end
+
+end
+


### PR DESCRIPTION
Hi,

We've added support for huawei OLT MA5800. The provided vrp.rb didn't work for us. 

tested on VERSION : MA5800V100R018C10

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
