### PR TITLE
Ios restore last conf change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+* MISC: restore IOS model filtering of "configuration last changed/NVRAM modified" in #1896. Issue #1921
+
 ## 0.27.0
 
 * FEATURE: add automatic restart on failure for systemd (@deajan)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * FEATURE: add FastIron model (@ZacharyPuls)
 * FEATURE: add Linuxgeneric model (@davama)
 * FEATURE: add SpeedTouch model (@raunz)
+* FEATURE: comware added device manuinfo to include serial number (@raunz)
 * BUGFIX: improve procurve telnet support for older switches (@deajan)
 * BUGFIX: voss model
 * BUGFIX: cambium model should not consider timestamp for backup as unneeded, and causes diffs (@cchance27)
@@ -29,6 +30,7 @@
 * BUGFIX: filter out IOS configuration/NVRAM modified/changed timestamps to keep output persistent
 * BUGFIX: update screenos model to reduce the amount of lines being stripped from beginning of cfg output
 * BUGFIX: include colon in aosw prompt regexp in case it is a mac address (@raunz)
+* BUGFIX: comware improvement for requesting HP 19x0 switches hidden CLI. Issues #1754 and #1447
 * MISC: add pgsql support, mechanized and net-tftp to Dockerfile
 * MISC: upgrade slop, net-telnet and rugged
 * MISC: extra secret scrubbing in comware model (@bengels00)

--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -36,12 +36,15 @@ class Comware < Oxidized::Model
     # the pager cannot be disabled before _cmdline-mode on.
     if vars :comware_cmdline
       post_login do
-        send "_cmdline-mode on\n"
-        send "y\n"
-        send vars(:comware_cmdline) + "\n"
-        send "xtd-cli-mode on\n"
-        send "y\n"
-        send vars(:comware_cmdline) + "\n"
+        # HP V1910, V1920
+        cmd '_cmdline-mode on', /(#{@node.prompt}|Continue)/
+        cmd 'y', /(#{@node.prompt}|input password)/
+        cmd vars(:comware_cmdline)
+
+        # HP V1950
+        cmd 'xtd-cli-mode on', /(#{@node.prompt}|Continue)/
+        cmd 'y', /(#{@node.prompt}|input password)/
+        cmd vars(:comware_cmdline)
       end
     end
 
@@ -56,6 +59,11 @@ class Comware < Oxidized::Model
   end
 
   cmd 'display device' do |cfg|
+    comment cfg
+  end
+
+  cmd 'display device manuinfo' do |cfg|
+    cfg = cfg.each_line.reject { |l| l.match 'FF'.hex.chr }.join
     comment cfg
   end
 

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -108,9 +108,8 @@ class IOS < Oxidized::Model
   cmd 'show running-config' do |cfg|
     cfg = cfg.each_line.to_a[3..-1]
     cfg = cfg.reject { |line| line.match /^ntp clock-period / }.join
+    cfg = cfg.each_line.reject { |line| line.match /^! (Last|No) configuration change (at|since).*/ unless line =~ /\d+\sby\s\S+$/ }.join
     cfg.gsub! /^Current configuration : [^\n]*\n/, ''
-    cfg.gsub! /^! (Last|No) configuration change (at|since).*\n/, ''
-    cfg.gsub! /^! NVRAM config last updated.*\n/, ''
     cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]*\n*(
                   (?: [^\n]*\n*)*
                   tunnel mpls traffic-eng auto-bw)/mx, '\1'


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Restore IOS model filtering of "configuration last changed/NVRAM modified" in #1896 with modifications for 802.1x where configurations change without username.
Closes issue #1921

