### PR TITLE
EOS: Hides MACsec Key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master
 
-* MISC: scrubs macsec key from Arista EOS
+* MISC: scrubs macsec key from Arista EOS (@krisamundson)
 
 ## 0.27.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Master
 
-## 0.27.1
-
 * MISC: scrubs macsec key from Arista EOS
 
 ## 0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@
 ## Master
 
 * FEATURE: add Waystream iBOS model
-* BUGFIX: better login modalities for telnet in aos7 (@optimuscream)	
-* BUGFIX: better virtual domain detection in fortios (@agabellini)	
-* MISC: more secret scrubbing in sonicos (@s-fu)	
+* BUGFIX: better login modalities for telnet in aos7 (@optimuscream)
+* BUGFIX: better virtual domain detection in fortios (@agabellini)
+* MISC: more secret scrubbing in sonicos (@s-fu)
 * MISC: openssh key scrubbing as secret in fortios (@agabellini)
 * MISC: scrubs macsec key from Arista EOS (@krisamundson)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Master
 
+* FEATURE: add Waystream iBOS model
+* BUGFIX: better login modalities for telnet in aos7 (@optimuscream)	
+* BUGFIX: better virtual domain detection in fortios (@agabellini)	
+* MISC: more secret scrubbing in sonicos (@s-fu)	
+* MISC: openssh key scrubbing as secret in fortios (@agabellini)
 * MISC: scrubs macsec key from Arista EOS (@krisamundson)
 
 ## 0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Master
 
+## 0.27.1
+
+* MISC: scrubs macsec key from Arista EOS
+
 ## 0.27.0
 
 * FEATURE: add automatic restart on failure for systemd (@deajan)

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -15,6 +15,7 @@ class EOS < Oxidized::Model
     cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /^(enable secret).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(tacacs-server key \d+).*/, '\\1 <configuration removed>'
+    cfg.gsub! /( {6}key) (\S+ 7) (\S+).*/, '\\1 <secret hidden>'
     cfg
   end
 

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -15,7 +15,7 @@ class EOS < Oxidized::Model
     cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /^(enable secret).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(tacacs-server key \d+).*/, '\\1 <configuration removed>'
-    cfg.gsub! /( {6}key) (\S+ 7) (\S+).*/, '\\1 <secret hidden>'
+    cfg.gsub! /( {6}key) (\h+ 7) (\h+).*/, '\\1 <secret hidden>'
     cfg
   end
 

--- a/lib/oxidized/version.rb
+++ b/lib/oxidized/version.rb
@@ -1,6 +1,6 @@
 module Oxidized
-  VERSION = '0.27.0'.freeze
-  VERSION_FULL = '0.27.0'.freeze
+  VERSION = '0.27.1'.freeze
+  VERSION_FULL = '0.27.1'.freeze
   def self.version_set
     version_full = %x(git describe --tags).chop rescue ""
     version      = %x(git describe --tags --abbrev=0).chop rescue ""

--- a/lib/oxidized/version.rb
+++ b/lib/oxidized/version.rb
@@ -1,6 +1,6 @@
 module Oxidized
-  VERSION = '0.27.1'.freeze
-  VERSION_FULL = '0.27.1'.freeze
+  VERSION = '0.27.0'.freeze
+  VERSION_FULL = '0.27.0'.freeze
   def self.version_set
     version_full = %x(git describe --tags).chop rescue ""
     version      = %x(git describe --tags --abbrev=0).chop rescue ""


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Hides macsec secret key: the CKN and CAK.

* Original Syntax Example

```
    mac security
       fips restrictions
       !
       profile default
          cipher aes256-gcm-xpn
          key 1ffab311 7 00C655A8E47F0E4756B32767F7C9A34854716C7F33F2E948A39CA9C00D0D0A0330
          mka session rekey-period 3600
          l2-protocol lldp bypass
```

* Replacement Syntax Example

```
    mac security
       fips restrictions
       !
       profile default
          cipher aes256-gcm-xpn
          key <secret hidden>
          mka session rekey-period 3600
          l2-protocol lldp bypass
```

