### PR TITLE
Replace Junos vMX bandwidth license output with placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+* BUGFIX: Junos model should not consider bandwidth licenses in use for vMX devices
+
 ## 0.27.0
 
 * FEATURE: add automatic restart on failure for systemd (@deajan)

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -8,6 +8,7 @@ class JunOS < Oxidized::Model
   cmd :all do |cfg|
     cfg = cfg.cut_both if screenscrape
     cfg.gsub!(/  scale-subscriber (\s+)(\d+)/, '  scale-subscriber                <count>')
+    cfg.gsub!(/  VMX-BANDWIDTH (\s+)(\d+)/,'  VMX-BANDWIDTH                <count>')
     cfg.lines.map { |line| line.rstrip }.join("\n") + "\n"
   end
 


### PR DESCRIPTION
## Pre-Request 

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Juniper vMX devices provide the current bandwidth in use when viewing the licenses. As an example:

```
License usage:
                                 Licenses     Licenses    Licenses    Expiry
  Feature name                       used    installed      needed
  VMX-BANDWIDTH                      1193        10000           0    permanent
  VMX-SCALE-PREMIUM                     1            1           0    permanent
```

It is unusual for the bandwidth used to be the same each polling run which results in a change every time.
