### PR TITLE
GcomBNPS: allow any max length for username/password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * FEATURE: add Waystream iBOS model
 * BUGFIX: better login modalities for telnet in aos7 (@optimuscream)
 * BUGFIX: better virtual domain detection in fortios (@agabellini)
+* BUGFIX: allow any max length for username/password in GcomBNPS (@freddy36)
 * MISC: more secret scrubbing in sonicos (@s-fu)
 * MISC: openssh key scrubbing as secret in fortios (@agabellini)
 * MISC: scrubs macsec key from Arista EOS (@krisamundson)

--- a/lib/oxidized/model/gcombnps.rb
+++ b/lib/oxidized/model/gcombnps.rb
@@ -5,11 +5,11 @@ class GcomBNPS < Oxidized::Model
   # tested with:
   #  - S5330 (aka Fiberstore S3800)
 
-  prompt /^\r?([\w.@()-]+?(\(1-16 chars\))?[#>:]\s?)$/ # also match SSH password promt (post_login commands are sent after the first prompt)
+  prompt /^\r?([\w.@()-]+?(\(1-\d+ chars\))?[#>:]\s?)$/ # also match SSH password promt (post_login commands are sent after the first prompt)
   comment '! '
 
   # alternative to handle the SSH login, but this breaks telnet
-  #  expect /^Password\(1-16 chars\):/ do |data|
+  #  expect /^Password\(1-\d+ chars\):/ do |data|
   #      send @node.auth[:password] + "\n"
   #      ''
   #  end
@@ -66,8 +66,8 @@ class GcomBNPS < Oxidized::Model
   end
 
   cfg :telnet do
-    username /^Username\(1-32 chars\):/
-    password /^Password\(1-16 chars\):/
+    username /^Username\(1-\d+ chars\):/
+    password /^Password\(1-\d+ chars\):/
   end
 
   cfg :ssh do


### PR DESCRIPTION
## Pre-Request Checklist

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Allow any max length for username/password in GcomBNPS model (max length varies between software versions)