### PR TITLE
add Centec Networks CNOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Master
 
+* FEATURE: add Fiberstore S5800/S5850 series support via fsos_s5800 model (@freddy36)
 * FEATURE: include transceiver information in EdgeCOS model (@freddy36)
 * FEATURE: add Telco Systems T-Marc 3306 support via telco model (@SkylerBlumer)
 * FEATURE: add enable support to ciscosmb (@deesel)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Master
 
-* FEATURE: add Fiberstore S5800/S5850 series support via fsos_s5800 model (@freddy36)
+* FEATURE: add Centec Networks CNOS (Fiberstore S5800/S5850) support via cnos model (@freddy36)
 * FEATURE: include transceiver information in EdgeCOS model (@freddy36)
 * FEATURE: add Telco Systems T-Marc 3306 support via telco model (@SkylerBlumer)
 * FEATURE: add enable support to ciscosmb (@deesel)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -106,6 +106,8 @@
 * Fiberstore
   * [S3800](/lib/oxidized/model/gcombnps.rb)
   * [S3900](/lib/oxidized/model/edgecos.rb)
+  * [S5800](/lib/oxidized/model/fsos_s5800.rb)
+  * [S5850](/lib/oxidized/model/fsos_s5800.rb)
 * Firebrick
   * [FBxxxx](/lib/oxidized/model/firebrick.rb)
 * Force10

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -49,6 +49,8 @@
   * [Cambium (PMP450 Series)](/lib/oxidized/model/cambium.rb)
 * Casa
   * [Casa](/lib/oxidized/model/casa.rb)
+* Centec Networks
+  * [CNOS](/lib/oxidized/model/cnos.rb)
 * Check Point
   * [GaiaOS](/lib/oxidized/model/gaiaos.rb)
 * Ciena
@@ -106,8 +108,8 @@
 * Fiberstore
   * [S3800](/lib/oxidized/model/gcombnps.rb)
   * [S3900](/lib/oxidized/model/edgecos.rb)
-  * [S5800](/lib/oxidized/model/fsos_s5800.rb)
-  * [S5850](/lib/oxidized/model/fsos_s5800.rb)
+  * [S5800](/lib/oxidized/model/cnos.rb)
+  * [S5850](/lib/oxidized/model/cnos.rb)
 * Firebrick
   * [FBxxxx](/lib/oxidized/model/firebrick.rb)
 * Force10

--- a/lib/oxidized/model/cnos.rb
+++ b/lib/oxidized/model/cnos.rb
@@ -1,4 +1,5 @@
-class FSOS_S5800 < Oxidized::Model
+# model for Centec Networks CNOS based switches
+class CNOS < Oxidized::Model
   comment '! '
 
   cmd :all do |cfg|

--- a/lib/oxidized/model/fsos_s5800.rb
+++ b/lib/oxidized/model/fsos_s5800.rb
@@ -1,0 +1,32 @@
+class FSOS_S5800 < Oxidized::Model
+  comment '! '
+
+  cmd :all do |cfg|
+    cfg.each_line.to_a[0..-2].join
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg.gsub!(/(snmp-server community )(\S+)/, '\1<hidden>')
+    cfg.gsub!(/key type private.+key string end/m, '<private key hidden>')
+    cfg
+  end
+
+  cmd 'show version' do |cfg|
+    cfg.gsub! /^(.* uptime is ).*\n/, '\1'
+    comment cfg
+  end
+
+  cmd 'show transceiver' do |cfg|
+    comment cfg
+  end
+
+  cfg :telnet do
+    username /^Username:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    post_login 'terminal length 0'
+    pre_logout 'exit'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Add Fiberstore S5800/S5850 series support

A better solution than #1855