### PR TITLE
Strip uptime from 'show version' command in SG220 switches

### DIFF
--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -26,6 +26,7 @@ class CiscoSMB < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
+    cfg.gsub! /uptime is\ .+/, '<uptime removed>'
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
PR #1473 has solved the login issues for SG220 switches that ciscosmb model has.
In order to completely assimilate SG220 switches there also has to be a solution for the uptime string that causes meaningless diffs. Note that the complete removal of show system command from the ciscosmb model (as per PR #1799) hasn't solved the problem since in SG220 switches the uptime is printed by the show version command.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
This should be the last required change to close issue #1148 
