### PR TITLE
Fix rugged dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * MISC: openssh key scrubbing as secret in fortios (@agabellini)
 * MISC: scrubs macsec key from Arista EOS (@krisamundson)
 * MISC: rubocop dependency now ~> 0.80.0
+* MISC: rugged dependency now ~> 0.28.0
 
 ## 0.27.0
 

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ed25519', '~> 1.2'
   s.add_runtime_dependency 'net-ssh', '~> 5'
   s.add_runtime_dependency 'net-telnet', '~> 0.2'
-  s.add_runtime_dependency 'rugged',  '~> 0.28'
+  s.add_runtime_dependency 'rugged',  '~> 0.28.0'
   s.add_runtime_dependency 'slop',    '~> 4.6'
 
   s.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
The rugged gem now has 0.99.0 that requires a much newer cmake than is available on RHEL7:

```
[root@centos-7 /]# scl enable rh-ruby23 -- gem install --no-document oxidized
Building native extensions.  This could take a while...
ERROR:  Error installing oxidized:
	ERROR: Failed to build gem native extension.

    current directory: /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/rugged-0.99.0/ext/rugged
/opt/rh/rh-ruby23/root/usr/bin/ruby -r ./siteconf20200312-1719-1x0mvem.rb extconf.rb
checking for gmake... yes
checking for cmake... yes
checking for pkg-config... yes
-- The C compiler identification is GNU 4.8.5
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc -- works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
CMake Error at CMakeLists.txt:15 (CMAKE_MINIMUM_REQUIRED):
  CMake 3.5.1 or higher is required.  You are running version 2.8.12.2


-- Configuring incomplete, errors occurred!
See also "/opt/rh/rh-ruby23/root/usr/local/share/gems/gems/rugged-0.99.0/vendor/libgit2/build/CMakeFiles/CMakeOutput.log".
 -- /usr/bin/gmake
*** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib64
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/opt/rh/rh-ruby23/root/usr/bin/$(RUBY_BASE_NAME)
	--with-sha1dc
	--without-sha1dc
	--use-system-libraries
extconf.rb:23:in `sys': ERROR: '/usr/bin/gmake' failed (RuntimeError)
	from extconf.rb:107:in `block (2 levels) in <main>'
	from extconf.rb:103:in `chdir'
	from extconf.rb:103:in `block in <main>'
	from extconf.rb:100:in `chdir'
	from extconf.rb:100:in `<main>'

To see why this extension failed to compile, please check the mkmf.log which can be found here:

  /opt/rh/rh-ruby23/root/usr/local/lib64/gems/ruby/rugged-0.99.0/mkmf.log

extconf failed, exit code 1

Gem files will remain installed in /opt/rh/rh-ruby23/root/usr/local/share/gems/gems/rugged-0.99.0 for inspection.
Results logged to /opt/rh/rh-ruby23/root/usr/local/lib64/gems/ruby/rugged-0.99.0/gem_make.out

```

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
