### PR TITLE
xmppdiff: Make more diffs interesting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Additional scrubbing for SonicOS v7 devices (@gerard780)
 - improved Telnet support for enterasys (@jplitza)
 - Include "show version" output for enterasys (@jplitza)
+- xmppdiff now also shows diffs with only removed or only added lines (@jplitza)
 
 ### Fixed
 

--- a/lib/oxidized/hook/xmppdiff.rb
+++ b/lib/oxidized/hook/xmppdiff.rb
@@ -21,8 +21,6 @@ class XMPPDiff < Oxidized::Hook
         interesting = diff[:patch].lines.to_a[4..-1].any? do |line|
           ["+", "-"].include?(line[0]) && (not ["#", "!"].include?(line[1]))
         end
-        interesting &&= diff[:patch].lines.to_a[5..-1].any? { |line| line[0] == '-' }
-        interesting &&= diff[:patch].lines.to_a[5..-1].any? { |line| line[0] == '+' }
 
         if interesting
           log "Connecting to XMPP"


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Previously, only diffs that contained added *and* deleted lines were considered "interesting".

This is a curious definition that I was unable to find in other hooks, and definitely not what we wanted/expected.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
