### PR TITLE
fortios: Strip cluster uptime even without :remove_secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * BUGFIX: better virtual domain detection in fortios (@agabellini)
 * BUGFIX: allow any max length for username/password in GcomBNPS (@freddy36)
 * BUGFIX: relax prompt requirements in ciscosmb (@Atroskelis)
+* BUGFIX: fortios model strips uptime even without remove_secrets (@jplitza)
 * MISC: more secret scrubbing in sonicos (@s-fu)
 * MISC: openssh key scrubbing as secret in fortios (@agabellini)
 * MISC: scrubs macsec key from Arista EOS (@krisamundson)

--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -23,13 +23,13 @@ class FortiOS < Oxidized::Model
     cfg.gsub! /(set private-key ).*?-+END (ENCRYPTED|RSA|OPENSSH) PRIVATE KEY-+\n?"$/m, '\\1<configuration removed>'
     cfg.gsub! /(set ca ).*?-+END CERTIFICATE-+"$/m, '\\1<configuration removed>'
     cfg.gsub! /(set csr ).*?-+END CERTIFICATE REQUEST-+"$/m, '\\1<configuration removed>'
-    cfg.gsub! /(Cluster uptime:).*/, '\\1 <stripped>'
     cfg
   end
 
   cmd 'get system status' do |cfg|
     @vdom_enabled = cfg.match /Virtual domain configuration: (enable|multiple)/
-    cfg.gsub!(/(System time: )(.*)/, '\1<stripped>\3')
+    cfg.gsub! /(System time:).*/, '\\1 <stripped>'
+    cfg.gsub! /(Cluster uptime:).*/, '\\1 <stripped>'
     cfg.gsub! /(Virus-DB|Extended DB|IPS-DB|IPS-ETDB|APP-DB|INDUSTRIAL-DB|Botnet DB|IPS Malicious URL Database).*/, '\\1 <db version stripped>'
     comment cfg
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Strip cluster uptime from FortiOS dumps even without :remove_secrets
    
This is not a secert but dynamic data that *always* changes between two dumps, thus it should never be included, regardless of the :remove_secrets setting

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
