### PR TITLE
fix paging output (disable press Q paging message)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * FEATURE: add Telco Systems T-Marc 3306 support via telco model (@SkylerBlumer)
 * FEATURE: add enable support to ciscosmb (@deesel)
 * FEATURE: add Waystream iBOS model
+* BUGFIX: use without-paging variant of print statement in routeros (@vkushnir)
 * BUGFIX: include the commands in the output in EdgeCOS model (@freddy36)
 * BUGFIX: update patterns for minor software version dependent differences in EdgeCOS model (@freddy36)
 * BUGFIX: better login modalities for telnet in aos7 (@optimuscream)

--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -12,15 +12,15 @@ class RouterOS < Oxidized::Model
     cfg
   end
 
-  cmd '/system routerboard print' do |cfg|
+  cmd '/system routerboard print without-paging' do |cfg|
     comment cfg
   end
 
-  cmd '/system package update print' do |cfg|
+  cmd '/system package update print without-paging' do |cfg|
     comment cfg
   end
 
-  cmd '/system history print' do |cfg|
+  cmd '/system history print without-paging' do |cfg|
     comment cfg
   end
 


### PR DESCRIPTION
## Description
`/system history print` some times more than screen. And it waits for a key press.
```
U nat rule changed                         user    write
U address list entry added                 user    write
U address list entry added                 user    write
-- [Q quit|down]
```
**without-paging** after **print** solve all problems.