### PR TITLE
Updated xos.rb regex-code to better match XOS-prompts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - relax prompt requirements in ciscosmb (@Atroskelis)
 - fortios model strips uptime even without remove_secrets (@jplitza)
 - HP ProCurve now accepts ">" as apart of the prompt (@magnuslarsen)
-- updated regex-pattern to better match XOS-prompts (@darkcatapulter)
+- fixed issue where the regex-pattern for XOS-prompts used invalid syntax (@darkcatapulter)
 
 ## [0.27.0] - 2019-10-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - allow any max length for username/password in GcomBNPS (@freddy36)
 - relax prompt requirements in ciscosmb (@Atroskelis)
 - fortios model strips uptime even without remove_secrets (@jplitza)
+- updated regex-pattern to better match XOS-prompts (@darkcatapulter)
 
 ## [0.27.0] - 2019-10-27
 

--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -1,7 +1,7 @@
 class XOS < Oxidized::Model
   # Extreme Networks XOS
 
-  prompt /^[*]?\s?([-\w.~]+(\s[(\w\-.)]+)?~?\s?[#>$]\s?)$/
+  prompt /^\*?\s?[-\w.~]+(:\d+)? [#>] $/
   comment  '# '
 
   cmd :all do |cfg|
@@ -43,7 +43,7 @@ class XOS < Oxidized::Model
   cfg :telnet, :ssh do
     post_login do
       data = cmd 'disable clipaging session'
-      match = data.match /^disable clipaging session\n\*?[\w .-]+(:\d+)? # $/m
+      match = data.match /^disable clipaging session\n\*?[\w .-]+(:\d+)? [#>] $/m
       next if match
 
       cmd 'disable clipaging'

--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -1,7 +1,7 @@
 class XOS < Oxidized::Model
   # Extreme Networks XOS
 
-  prompt /^*?[\w .-]+# $/
+  prompt /^[*]?\s?([-\w.~]+(\s[(\w\-.)]+)?~?\s?[#>$]\s?)$/
   comment  '# '
 
   cmd :all do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
This regular expression is invalid on some XOS-prompts, example X620-series, where the OS adds a '\*' symbol in front of the hostname. For example, hostname **mydevice-eu-sw02** would give a prompt looking like this: ```* mydevice-eu-sw02 >```

I manually tested the current regex on xos.rb using [regex101.com](https://regex101.com) and also noticed that it generally does a poor job in matching valid hostnames. In this change, I basically copied the regex that existed on ```fortios.rb```, manually tested it and then slightly tweaked it to work for XOS-prompts as well.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
