### PR TITLE
HP ProCurve now accepts ">" as apart of the prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - allow any max length for username/password in GcomBNPS (@freddy36)
 - relax prompt requirements in ciscosmb (@Atroskelis)
 - fortios model strips uptime even without remove_secrets (@jplitza)
+- HP ProCurve now accepts ">" as apart of the prompt (@magnuslarsen)
 
 ## [0.27.0] - 2019-10-27
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -3,7 +3,7 @@ class Procurve < Oxidized::Model
   # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+# ), which ends the line
   # telnet switchs may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), follwed by the prompt, followed
   # by at least 3 other vt100 characters
-  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+# )($|(\e\[24;[0-9][0-9]?[hH]){3})/
+  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
 
   comment '! '
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -1,6 +1,6 @@
 class Procurve < Oxidized::Model
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+# ), which ends the line
+  # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+[#>] ), which ends the line
   # telnet switchs may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), follwed by the prompt, followed
   # by at least 3 other vt100 characters
   prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
On my HP ProCurve devices, the prompt contains `device-name> `  and not `device-name# `  as expected by the prompt setter.
This PR also allows `>` to be in-place of the current `#` requirement.

This PR does not break any compatibility with previous versions.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
