### PR TITLE
Cumulus model - Don't store transient data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - scrubs macsec key from Arista EOS (@krisamundson)
 - rubocop dependency now ~> 0.80.0
 - rugged dependency now ~> 0.28.0
+- cumulus model no longer records transient data (@plett)
 
 ### Fixed
 

--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -33,9 +33,6 @@ class Cumulus < Oxidized::Model
     cfg += add_comment 'NTP.CONF'
     cfg += cmd 'cat /etc/ntp.conf'
 
-    cfg += add_comment 'IP Routes'
-    cfg += cmd 'netstat -rn'
-
     cfg += add_comment 'SNMP settings'
     cfg += cmd 'cat /etc/snmp/snmpd.conf'
 
@@ -73,7 +70,7 @@ class Cumulus < Oxidized::Model
     cfg += cmd 'cat /etc/cumulus/datapath/traffic.conf'
 
     cfg += add_comment 'ACL'
-    cfg += cmd 'iptables -L -n'
+    cfg += cmd 'cat /etc/cumulus/acl/policy.conf'
 
     cfg += add_comment 'VERSION'
     cfg += cmd 'cat /etc/cumulus/etc.replace/os-release'


### PR DESCRIPTION
## Description
This is a trivial change to remove the logging of kernel routes by the Cumulus model, as they are transient data and not configuration which needs backing up.

Closes issue #2080
