### PR TITLE
Also store the JunOS machine parsable XML

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add Telco Systems T-Marc 3306 support via telco model (@SkylerBlumer)
 - add enable support to ciscosmb (@deesel)
 - add Waystream iBOS model
+- also export JunOS configuration XML
 
 ### Changed
 

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -22,6 +22,12 @@ class JunOS < Oxidized::Model
     comment cfg
   end
 
+  cmd 'show configuration | display omit | display xml' do |out|
+    out.type = 'xml'
+    out.name = 'xml'
+    out
+  end
+
   post do
     out = ''
     case @model


### PR DESCRIPTION
JunOS configurations can also be represented as XML.  This patch also starts exporting the XML representation of the configuration, which is much more useful if you're doing any sort of parsing of configs.
