### PR TITLE
Add QTECH model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add Telco Systems T-Marc 3306 support via telco model (@SkylerBlumer)
 - add enable support to ciscosmb (@deesel)
 - add Waystream iBOS model
+- add QTECH model (@moisseev)
 
 ### Changed
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -180,6 +180,8 @@
   * [AlteonOS](/lib/oxidized/model/alteonos.rb)
 * Raisecom
   * [Raisecom](/lib/oxidized/model/raisecom.rb)
+* QTECH
+  * [QSW-3400, QSW-3450, QSW-3500](/lib/oxidized/model/qtech.rb)
 * Quanta
   * [Quanta / VxWorks 6.6 (1.1.0.8)](/lib/oxidized/model/quantaos.rb)
 * Siklu

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -181,7 +181,7 @@
 * Raisecom
   * [Raisecom](/lib/oxidized/model/raisecom.rb)
 * QTECH
-  * [QSW-3400, QSW-3450, QSW-3500](/lib/oxidized/model/qtech.rb)
+  * [QSW-2800, QSW-3400, QSW-3450, QSW-3500](/lib/oxidized/model/qtech.rb)
 * Quanta
   * [Quanta / VxWorks 6.6 (1.1.0.8)](/lib/oxidized/model/quantaos.rb)
 * Siklu

--- a/lib/oxidized/model/qtech.rb
+++ b/lib/oxidized/model/qtech.rb
@@ -1,0 +1,38 @@
+class QTECH < Oxidized::Model
+  comment '! '
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community(?: r[ow])?(?: \d)?) .+/, '\\1 <secret hidden>'
+    cfg.gsub! /^(snmp-server user .+ auth \S+) .+/, '\\1 <secret hidden>'
+    cfg.gsub! /^(username .+ password \d) .+/, '\\1 <secret hidden>'
+    cfg.gsub! /^(enable password(?: level \d+)? \d) .+/, '\\1 <secret hidden>'
+    cfg
+  end
+
+  cmd 'show version' do |cfg|
+    cfg = cfg.each_line.to_a[1..-2]
+    comment cfg.reject { |line| line.match /^  (Copyright |All rights reserved$|Uptime is |Last reboot is )/ }.join
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg.lines.to_a[1..-2].join
+  end
+
+  cfg :telnet do
+    username /^login:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    post_login do
+      if vars(:enable) == true
+        cmd "enable"
+      elsif vars(:enable)
+        cmd "enable", /^[pP]assword:/
+        cmd vars(:enable)
+      end
+      cmd 'terminal length 0'
+    end
+    pre_logout 'exit'
+  end
+end

--- a/lib/oxidized/model/qtech.rb
+++ b/lib/oxidized/model/qtech.rb
@@ -1,6 +1,10 @@
 class QTECH < Oxidized::Model
   comment '! '
 
+  cmd :all do |cfg|
+    cfg.cut_both
+  end
+
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community(?: r[ow])?(?: \d)?) .+/, '\\1 <secret hidden>'
     cfg.gsub! /^(snmp-server user .+ auth \S+) .+/, '\\1 <secret hidden>'
@@ -10,12 +14,11 @@ class QTECH < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    cfg = cfg.each_line.to_a[1..-2]
-    comment cfg.reject { |line| line.match /^  (Copyright |All rights reserved$|Uptime is |Last reboot is )/ }.join
+    comment cfg.each_line.reject { |line| line.match /^  (Copyright |All rights reserved$|Uptime is |Last reboot is )/ }.join
   end
 
   cmd 'show running-config' do |cfg|
-    cfg.lines.to_a[1..-2].join
+    cfg
   end
 
   cfg :telnet do


### PR DESCRIPTION
QTECH company offers several lines of Ethernet switches
designed specifically for Internet providers, data centers,
industrial enterprises and the energy sector.

https://www.qtech.ru/en/catalog/

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
