### PR TITLE
Handle pfSense 2.4.5+ passwords that are wrapped in CDATA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support
+- change pfSense secret scrubbing to handle new format in 2.4.5+
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/pfsense.rb
+++ b/lib/oxidized/model/pfsense.rb
@@ -6,9 +6,9 @@ class PfSense < Oxidized::Model
   end
 
   cmd :secret do |cfg|
-    cfg.gsub! /(\s+<bcrypt-hash>)[^<]+(<\/bcrypt-hash>)/, '\\1<secret hidden>\\2'
-    cfg.gsub! /(\s+<password>)[^<]+(<\/password>)/, '\\1<secret hidden>\\2'
-    cfg.gsub! /(\s+<lighttpd_ls_password>)[^<]+(<\/lighttpd_ls_password>)/, '\\1<secret hidden>\\2'
+    cfg.gsub! /(\s+<bcrypt-hash>).+?(<\/bcrypt-hash>)/, '\\1<secret hidden>\\2'
+    cfg.gsub! /(\s+<password>).+?(<\/password>)/, '\\1<secret hidden>\\2'
+    cfg.gsub! /(\s+<lighttpd_ls_password>).+?(<\/lighttpd_ls_password>)/, '\\1<secret hidden>\\2'
     cfg
   end
 


### PR DESCRIPTION
## Description
pfSense 2.4.5 now wraps the data inside `<password>` tags with a `<![CDATA[` `]]>` wrapper.  The current regular expression does not match the new format.  This causes pfSense password data to be exposed by Oxidized.  

My regular expression update handles both the existing data (from versions 2.4.4 and prior) and data that is wrapped in CDATA (from version 2.4.5 and beyond).

Example of old configuration data from 2.4.4:
`<password>$1$bcrypthash/</password>`

Example of new configuration data from 2.4.5:
`<password><![CDATA[$1$bcrypthash/]]></password>`