### PR TITLE
Support Aruba IAP unencrypted keys

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -57,6 +57,11 @@ class AOSW < Oxidized::Model
     cfg = "" if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/ # Don't show for unsupported devices (IAP and MAS)
     rstrip_cfg comment cfg
   end
+  
+  cmd 'show license passphrase' do |cfg|
+    cfg = "" if cfg.match /(Invalid input detected at '\^' marker|Parse error)/ # Don't show for unsupported devices (IAP and MAS)
+    rstrip_cfg comment cfg
+  end
 
   cmd 'show switchinfo' do |cfg| # this command will run only on wireless switches
     @is_IAP = true  if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/ # add this suffix only for IAPs


### PR DESCRIPTION
When the script is run against a wireless switch, the command 'encrypt disable' is issued before retrieving the configuration. In IAPs, this command is not implemented but you can run 'show running-config ' with the suffix 'no-encrypt' and the result is similar. Unfortunately if you add this suffix in a wireless switch you will get an error message. So before sending the show run.. command we check wether is a wireless switch or an IAP by executing a 'show switchinfo' and then deciding which is the right command to retrieve the config. 
I've also added a blank to the prompt  because the prompt detection fails if there is a blank in the hostname

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
