### PR TITLE
Retrieve unencrypted keys from Instant APs

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -64,11 +64,11 @@ class AOSW < Oxidized::Model
   end
 
   cmd 'show switchinfo' do |cfg| # this command will run only on wireless switches
-    @is_IAP = true  if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/ # add this suffix only for IAPs
+    @is_iap = true  if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/ # add this suffix only for IAPs
   end
 
   post do
-    if @is_IAP
+    if @is_iap
       config_IAP
     else
       config_Switch
@@ -122,7 +122,9 @@ class AOSW < Oxidized::Model
       out = []
       cfg.each_line do |line|
         next if line =~ /^controller config \d+$/
+        
         next if line =~ /^Building Configuration/
+        
         out << line.strip
       end
       out = out.join "\n"
@@ -135,7 +137,9 @@ class AOSW < Oxidized::Model
       out = []
       cfg.each_line do |line|
         next if line =~ /^controller config \d+$/
+        
         next if line =~ /^Building Configuration/
+        
         out << line.strip
       end
       out = out.join "\n"

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -116,8 +116,7 @@ class AOSW < Oxidized::Model
     out = comment out.join "\n"
     out << "\n"
   end
-
-def config_iap
+  def config_iap
     cmd 'show running-config no-encrypt' do |cfg|
       out = []
       cfg.each_line do |line|
@@ -131,8 +130,7 @@ def config_iap
       out << "\n"
     end
   end
-
-def config_switch
+  def config_switch
     cmd 'show running-config' do |cfg|
       out = []
       cfg.each_line do |line|

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -64,14 +64,14 @@ class AOSW < Oxidized::Model
   end
 
   cmd 'show switchinfo' do |cfg| # this command will run only on wireless switches
-    @is_iap = true  if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/ # add this suffix only for IAPs
+    @is_iap = true if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/ # add this suffix only for IAPs
   end
 
   post do
     if @is_iap
-      config_IAP
+      config_iap
     else
-      config_Switch
+      config_switch
     end
   end
 
@@ -117,7 +117,7 @@ class AOSW < Oxidized::Model
     out << "\n"
   end
 
-  def config_IAP
+def config_iap
     cmd 'show running-config no-encrypt' do |cfg|
       out = []
       cfg.each_line do |line|
@@ -132,7 +132,7 @@ class AOSW < Oxidized::Model
     end
   end
 
-  def config_Switch
+def config_switch
     cmd 'show running-config' do |cfg|
       out = []
       cfg.each_line do |line|

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -121,8 +121,9 @@ class AOSW < Oxidized::Model
     cmd 'show running-config no-encrypt' do |cfg|
       out = []
       cfg.each_line do |line|
-        next if line =~ /^controller config \d+$/        
-        next if line =~ /^Building Configuration/        
+        next if line =~ /^controller config \d+$/
+        next if line =~ /^Building Configuration/
+
         out << line.strip
       end
       out = out.join "\n"
@@ -134,8 +135,9 @@ class AOSW < Oxidized::Model
     cmd 'show running-config' do |cfg|
       out = []
       cfg.each_line do |line|
-        next if line =~ /^controller config \d+$/        
-        next if line =~ /^Building Configuration/        
+        next if line =~ /^controller config \d+$/
+        next if line =~ /^Building Configuration/
+
         out << line.strip
       end
       out = out.join "\n"

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -116,28 +116,26 @@ class AOSW < Oxidized::Model
     out = comment out.join "\n"
     out << "\n"
   end
+
   def config_iap
     cmd 'show running-config no-encrypt' do |cfg|
       out = []
       cfg.each_line do |line|
-        next if line =~ /^controller config \d+$/
-        
-        next if line =~ /^Building Configuration/
-        
+        next if line =~ /^controller config \d+$/        
+        next if line =~ /^Building Configuration/        
         out << line.strip
       end
       out = out.join "\n"
       out << "\n"
     end
   end
+
   def config_switch
     cmd 'show running-config' do |cfg|
       out = []
       cfg.each_line do |line|
-        next if line =~ /^controller config \d+$/
-        
-        next if line =~ /^Building Configuration/
-        
+        next if line =~ /^controller config \d+$/        
+        next if line =~ /^Building Configuration/        
         out << line.strip
       end
       out = out.join "\n"

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -10,7 +10,7 @@ class AOSW < Oxidized::Model
   # All IAPs connected to a Instant Controller will have the same config output. Only the controller needs to be monitored.
 
   comment  '# '
-  prompt /^([\w\(:.@-]+(\)?\s?)[#>]\s?)$/
+  prompt /^([\w \(:.@-]+(\)?\s?)[#>]\s?)$/
 
   cmd :all do |cfg|
     cfg.cut_both
@@ -63,16 +63,16 @@ class AOSW < Oxidized::Model
     rstrip_cfg comment cfg
   end
 
-  cmd 'show running-config' do |cfg|
-    out = []
-    cfg.each_line do |line|
-      next if line =~ /^controller config \d+$/
-      next if line =~ /^Building Configuration/
+  cmd 'show switchinfo' do |cfg| # this command will run only on wireless switches
+    @is_IAP = true  if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/ # add this suffix only for IAPs
+  end
 
-      out << line.strip
+  post do
+    if @is_IAP
+      config_IAP
+    else
+      config_Switch
     end
-    out = out.join "\n"
-    out << "\n"
   end
 
   cfg :telnet do
@@ -115,5 +115,31 @@ class AOSW < Oxidized::Model
     end
     out = comment out.join "\n"
     out << "\n"
+  end
+
+  def config_IAP
+    cmd 'show running-config no-encrypt' do |cfg|
+      out = []
+      cfg.each_line do |line|
+        next if line =~ /^controller config \d+$/
+        next if line =~ /^Building Configuration/
+        out << line.strip
+      end
+      out = out.join "\n"
+      out << "\n"
+    end
+  end
+
+  def config_Switch
+    cmd 'show running-config' do |cfg|
+      out = []
+      cfg.each_line do |line|
+        next if line =~ /^controller config \d+$/
+        next if line =~ /^Building Configuration/
+        out << line.strip
+      end
+      out = out.join "\n"
+      out << "\n"
+    end
   end
 end


### PR DESCRIPTION
When the script is run against a wireless switch, the command 'encrypt disable' is issued before retrieving the configuration. In IAPs, this command is not implemented but you can run 'show running-config ' with the suffix 'no-encrypt' and the result is similar. Unfortunately if you add this suffix in a wireless switch you will get an error message. So before sending the show run.. command we check wether is a wireless switch or an IAP by executing a 'show switchinfo' and then deciding which is the right command to retrieve the config.
I've also added a blank to the prompt because the prompt detection fails if there is a blank in the hostname

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
