### PR TITLE
Add OpenRC init script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - enterasys800 model for enterasys 800-series fe/ge switches (@javichumellamo)
+- add OpenRC startup script /for Alpine and Gentoo/ (@baznikin)
 
 ### Changed
 

--- a/extra/oxidized.openrc
+++ b/extra/oxidized.openrc
@@ -1,0 +1,35 @@
+#!/sbin/openrc-run
+
+description="Oxidized - network device configuration backup tool"
+command="/usr/bin/${SVCNAME}"
+command_user="${RC_SVCNAME}"
+command_background=true
+pidfile="/var/run/${RC_SVCNAME}.pid"
+output_log="/var/log/${RC_SVCNAME}.log"
+error_log="/var/log/${RC_SVCNAME}.err.log"
+
+extra_commands="reload"
+reload() {
+  ebegin "Reloading ${RC_SVCNAME}"
+  wget -q http://127.0.0.1:8888/reload?format=json -O /dev/null 2>/dev/null
+}
+
+checkconfig() {
+  su -c "${command} --show-exhaustive-config" ${command_user} >/dev/null || return 1
+}
+
+start_pre() {
+  # Make logs writtable
+  touch ${output_log} ${error_log}
+  chown ${command_user} ${output_log} ${error_log}
+
+  if [ "${RC_CMD}" != "restart" ] ; then
+    checkconfig || return $?
+  fi
+}
+
+stop_pre() {
+  if [ "${RC_CMD}" = "restart" ] ; then
+      checkconfig || return $?
+  fi
+}


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [v] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Added `extra/oxidixed.openrc`, tested on Alpine Linux. Writen with OpenRC scripting guide considerations, should run on any compartible system.