### PR TITLE
Model for ZTE olt C320

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - enterasys800 model for enterasys 800-series fe/ge switches (@javichumellamo)
+- zte olt model for c300, c320 series (@glaubway)
 
 ### Changed
 

--- a/lib/oxidized/model/zteolt.rb
+++ b/lib/oxidized/model/zteolt.rb
@@ -1,0 +1,52 @@
+class ZTEOLT < Oxidized::Model
+  prompt /^([\w.@()-]+[#>]\s?)$/
+  comment  '! '
+
+  cmd :all do |cfg|
+    cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
+    cfg.cut_both
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(tacacs-server (.+ )?key) .+/, '\\1 <secret hidden>'
+    cfg.gsub! /^username (\S+) privilege (\d+) (\S+).*/, '<secret hidden>'
+    cfg.gsub! /^(enable (password|secret)( level \d+)? \d) .+/, '\\1 <secret hidden>'
+    cfg
+  end
+
+  cmd 'show version-running' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show patch-running' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg.gsub! /^timestamp_write: .*\n/, ''
+    cfg
+  end
+
+  cfg :telnet do
+    username /^Username:/i
+    password /^Password:/i
+  end
+
+  cfg :telnet, :ssh do
+    # preferred way to handle additional passwords
+    post_login do
+      if vars(:enable) == true
+        cmd "enable"
+      elsif vars(:enable)
+        cmd "enable", /^[pP]assword:/
+        cmd vars(:enable)
+      end
+    end
+    post_login 'terminal length 0'
+    pre_logout do
+       cmd 'disable'
+       cmd 'exit'
+    end
+  end
+end

--- a/lib/oxidized/model/zteolt.rb
+++ b/lib/oxidized/model/zteolt.rb
@@ -44,9 +44,7 @@ class ZTEOLT < Oxidized::Model
       end
     end
     post_login 'terminal length 0'
-    pre_logout do
-       cmd 'disable'
-       cmd 'exit'
-    end
+    pre_logout 'disable'
+    pre_logout 'exit'
   end
 end


### PR DESCRIPTION
Model for ZTE olt C320 firmware 1.2.5 and 2.1

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add new model for ZTE olt.