### PR TITLE
Update xos.rb prompt to work with stacked switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support
 - change pfSense secret scrubbing to handle new format in 2.4.5+
 
+### Fixed
+
+- fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
+- fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)
+
 ## [0.28.0 - 2020-05-18]
 
 ### Added
@@ -49,7 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fortios model strips uptime even without remove_secrets (@jplitza)
 - HP ProCurve now accepts ">" as apart of the prompt (@magnuslarsen)
 - fix IOS SNMP notification community hiding for informs and v3 (@moisseev)
-- fixed issue where the regex-pattern for XOS-prompts used invalid syntax (@darkcatapulter)
+- fixed issue where the regex-pattern for XOS-prompts used invalid syntax (@DarkCatapulter)
 - set terminal width in EdgeCOS model (@moisseev)
 - suppress errors for commands that are not supported on some devices in EdgeCOS model (@moisseev)
 - revert including command names in the output of the EdgeCOS model (@moisseev)

--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -1,7 +1,7 @@
 class XOS < Oxidized::Model
   # Extreme Networks XOS
 
-  prompt /^\*?\s?[-\w.~]+(:\d+)? [#>] $/
+  prompt /^\s?\*?\s?[-\w]+\s?[-\w.~]+(:\d+)? [#>] $/
   comment  '# '
 
   cmd :all do |cfg|
@@ -43,7 +43,7 @@ class XOS < Oxidized::Model
   cfg :telnet, :ssh do
     post_login do
       data = cmd 'disable clipaging session'
-      match = data.match /^disable clipaging session\n\*?[\w .-]+(:\d+)? [#>] $/m
+      match = data.match /^disable clipaging session\n\r?\*?\s?[-\w]+\s?[-\w.~]+(:\d+)? [#>] $/m
       next if match
 
       cmd 'disable clipaging'


### PR DESCRIPTION
The current xos.rb regexp for prompt does not take stacked switches into account and therefore only works for standalone devices. This is a slight update to make the prompt regexp include stacked switches.
Reference: #2107

This update also fixes an issue that wasn't entirely solved in the previous pull request for xos.rb where Oxidized can't match the prompt if the XOS-device has not saved its configuration.
Reference: #2113

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
