### PR TITLE
EdgeCOS: add ES3526XA-V2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - enterasys800 model for enterasys 800-series fe/ge switches (@javichumellamo)
+- add ES3526XA-V2 support in EdgeCOS model (@moisseev)
 
 ### Changed
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -96,7 +96,7 @@
 * ECI Telecom
   * [ECIapollo](/lib/oxidized/model/eciapollo.rb)
 * EdgeCore
-  * [ECS3510, ES3528M](/lib/oxidized/model/edgecos.rb)
+  * [ECS3510, ES3526XA-V2, ES3528M](/lib/oxidized/model/edgecos.rb)
 * Ericsson/Redback
   * [IPOS (former SEOS)](/lib/oxidized/model/ipos.rb)
 * Extreme Networks

--- a/lib/oxidized/model/edgecos.rb
+++ b/lib/oxidized/model/edgecos.rb
@@ -1,6 +1,12 @@
 class EdgeCOS < Oxidized::Model
   comment '! '
 
+  # Handle pager for ES3526XA-V2
+  expect /^---More---.*$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
   cmd :secret do |cfg|
     cfg.gsub!(/password \d+ (\S+).*/, '<secret removed>')
     cfg.gsub!(/community (\S+)/, 'community <hidden>')
@@ -10,6 +16,8 @@ class EdgeCOS < Oxidized::Model
   cmd :all do |cfg|
     # Do not show errors for commands that are not supported on some devices
     cfg.gsub! /^(% Invalid input detected at '\^' marker\.|^\s+\^)$/, ''
+    # Handle pager for ES3526XA-V2
+    cfg.gsub! /^([\b]{10}\s{10}[\b]{10})/, ''
     cfg.cut_both
   end
 


### PR DESCRIPTION
that doesn't support `terminal` command

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
