### PR TITLE
Create PfSenseHttps model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for Zyxel 1308 OLTs (@baldoarturo)
 - model for Linksys SRW switches (@glance-)
 - model for Cambium ePMP radios (@martydingo)
+- model for accessing pfSense over https (@glance-)
 
 ### Changed
 

--- a/docs/Model-Notes/PfSenseHttps.md
+++ b/docs/Model-Notes/PfSenseHttps.md
@@ -1,0 +1,9 @@
+# PfSenseHttps model notes
+
+This model is used to backup config.xml from PfSense via it's https web-ui.
+
+This is usefull when not having ssh access to PfSense.
+
+This needs a user with the permission: "WebCfg - Diagnostics: Backup & Restore".
+
+Back to [Model-Notes](README.md)

--- a/lib/oxidized/model/pfsensehttps.rb
+++ b/lib/oxidized/model/pfsensehttps.rb
@@ -1,0 +1,44 @@
+require 'mechanize'
+
+class PfSenseHttps < Oxidized::Model
+  cfg_cb = lambda do
+    main_page = "/index.php"
+    m = Mechanize.new
+
+    m.agent.http.verify_mode = Oxidized.config.input.http.ssl_verify? ? OpenSSL::SSL::VERIFY_PEER : OpenSSL::SSL::VERIFY_NONE
+    # https port might be something else than 443, so allow that to be configured.
+    port = vars(:https_port) || 443
+    url = URI::HTTPS.build host: @node.ip, path: main_page, port: port
+
+    m_page = m.get(url.to_s)
+    form = m_page.forms.first
+    form.usernamefld = @username
+    form.passwordfld = @password
+    form.click_button
+
+    b_page = m.get('/diag_backup.php')
+    form = b_page.form_with(action: '/diag_backup.php')
+    form.backuparea = ''
+    cfg = form.click_button(form.button_with(name: 'download'))
+    cfg.body
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /(\s+<bcrypt-hash>).+?(<\/bcrypt-hash>)/, '\\1<secret hidden>\\2'
+    cfg.gsub! /(\s+<password>).+?(<\/password>)/, '\\1<secret hidden>\\2'
+    cfg.gsub! /(\s+<lighttpd_ls_password>).+?(<\/lighttpd_ls_password>)/, '\\1<secret hidden>\\2'
+    cfg
+  end
+
+  cmd cfg_cb do |cfg|
+    cfg.gsub! /\s<revision>\s*<time>\d*<\/time>\s*.*\s*.*\s*<\/revision>/, ''
+    cfg.gsub! /\s<last_rule_upd_time>\d*<\/last_rule_upd_time>/, ''
+    cfg
+  end
+
+  cfg :http do
+    @username = @node.auth[:username]
+    @password = @node.auth[:password]
+    @secure = true
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This adds a simple model to use the web ui on PfSense machines to download the configuration. I use this in situations where I use oxidized to backup config from remote PfSense machines where I only have access to the web UI.

This is a RFC. I'm probably abusing a lot of code here, and I should write both documentation and some explaining about the model but I'm throwing this out there for some early feedback.