### PR TITLE
[RFC] Create a model for Linksys SRW switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for zte c300 and c320 olt (@glaubway)
 - model for LANCOM (@systeembeheerder)
 - model for Aruba CX switches (@jmurphy5)
+- model for Linksys SRW switches (@glance-)
 
 ### Changed
 

--- a/docs/Model-Notes/LinksysSRW.md
+++ b/docs/Model-Notes/LinksysSRW.md
@@ -1,0 +1,15 @@
+# LinksysSRW model notes
+
+This is a switch model with a horible IE5 only web interface that is unusable in any modern browser due to broken and buggy html and javascript.
+
+On a first glance the serial or telnet interface isn't any more usable, but there is a way to break out of the menu driven interface and start a more usable cli.
+
+This is what this model does and dumps the config in there.
+
+As far as I know, the Linksys SRW 2008, SRW2016 , SRW2024 and SRW2048 are the only switches running this os/ui, but there might be others out there.
+
+Over snmp they identifes them self as Operating System: Cisco Small Business Software, so that might be a clue to look for if you're trying to figure out if your switch could have this hidden cli.
+
+The author of this model isn't the one who found this "hidden" cli but only someone who integrated it with oxidized. The real credits goes out to some unknown hero out there on the internet who figured this out a long time ago.
+
+Back to [Model-Notes](README.md)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -151,6 +151,8 @@
   * [ScreenOS (Netscreen)](/lib/oxidized/model/screenos.rb)
 * LANCOM Systems GmbH
   * [LCOS](/lib/oxidized/model/lancom.rb)
+* Linkys
+  * [SRW](/lib/oxidized/model/linksyssrw.rb)
 * Linuxgeneric
   * [CentOS](/lib/oxidized/model/linuxgeneric.rb)
 * Mellanox

--- a/lib/oxidized/model/linksyssrw.rb
+++ b/lib/oxidized/model/linksyssrw.rb
@@ -1,0 +1,69 @@
+class LinksysSRW < Oxidized::Model
+  comment '! '
+
+  prompt /^([\r\w.@-]+[#>]\s?)$/
+
+  # Graphical login screen
+  # Just login to get to Main Menu
+  expect /Login Screen/ do
+    Oxidized.logger.send(:debug, "#{self.class.name}: Login Screen")
+    # This is to ensure the whole thing have rendered before we send stuff
+    sleep 0.2
+    send 0x18.chr # CAN Cancel
+    send @node.auth[:username]
+    send "\t"
+    send @node.auth[:password]
+    send "\r"
+    ''
+  end
+
+  # Main menu, escape into Pre-cli-shell
+  expect /Switch Main Menu/ do
+    Oxidized.logger.send(:debug, "#{self.class.name}: Switch menu")
+    send 0x1a.chr # SUB Substitite ^z
+    ''
+  end
+
+  # Pre-cli-shell, start lcli which is ios-ish
+  expect />/ do
+    Oxidized.logger.send(:debug, "#{self.class.name}: >")
+    send "lcli\r"
+    ''
+  end
+
+  cmd :all do |cfg|
+    # Remove \r from first response row
+    cfg.gsub! /^\r/, ''
+    cfg.cut_tail + "\n"
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(enable (password|secret)( level \d+)? \d) .+/, '\\1 <secret hidden>'
+  end
+
+  cmd 'show startup-config' do |cfg|
+    # Repair some linewraps which terminal datadump doesn't take care of
+    # and there's no terminal width either.
+    cfg.gsub! /(lldpPortConfigT)\n(LVsTxEnable)/, '\\1\\2'
+    # And comment out the echo of the command
+    "#{comment cfg.lines.first}#{cfg.cut_head}"
+  end
+
+  cmd 'show version' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show system' do |cfg|
+    cfg.gsub! /(System Up Time \(days,hour:min:sec\):\s+).*/, '\\1 <uptime removed>'
+    comment cfg
+  end
+
+  cfg :telnet, :ssh do
+    # Pre-cli-shell just expects a username, who its going to log in.
+    username /^User Name:/
+    post_login 'terminal datadump'
+    pre_logout 'exit'
+    pre_logout 'logout'
+  end
+end

--- a/lib/oxidized/model/linksyssrw.rb
+++ b/lib/oxidized/model/linksyssrw.rb
@@ -60,8 +60,9 @@ class LinksysSRW < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
-    # Pre-cli-shell just expects a username, who its going to log in.
+    # Some pre-cli-shell just expects a username, who its going to log in.
     username /^User Name:/
+    password /Password:/
     post_login 'terminal datadump'
     pre_logout 'exit'
     pre_logout 'logout'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This creates a model for Linksys SRW switches by sneaking out form the
menu mode and starting the lcli tool to be able to dump the config.

Due to the fact that we're navigating and escaping from a curses mode
not using the regular username/password entry procedures,
but rather chaining a bunch of expect to do the login and start the
lcli terminal mode.

This resolves #875

This is a RFC for Linksys SWR support. I'm probably abusing a lot of code here, and I should write both documentation and some explaining about the model but I'm throwing this out there for some early feedback.