### PR TITLE
rebased to phusion/baseimage-docker bionic-1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support
 - change pfSense secret scrubbing to handle new format in 2.4.5+
+- Dockerfile rebased to phusion/baseimage-docker bionic-1.0.0
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Single-stage build of an oxidized container from phusion/baseimage-docker v0.11, derived from Ubuntu 18.04 (Bionic Beaver)
-FROM phusion/baseimage:0.11
+# Single-stage build of an oxidized container from phusion/baseimage-docker bionic-1.0.0, derived from Ubuntu 18.04 (Bionic Beaver)
+FROM phusion/baseimage:bionic-1.0.0
 
 # set up dependencies for the build process
 RUN apt-get -yq update \


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Rebase the Dockerfile (on which the official container is based) to bionic-1.0.0 release of phusion/baseimage-docker

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
