### PR TITLE
Glaubway dlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support
 - change pfSense secret scrubbing to handle new format in 2.4.5+
-- support for d-link dgs-1100 series switch(@glaubway)
+- support for d-link dgs-1100 series switches(@glaubway)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support
 - change pfSense secret scrubbing to handle new format in 2.4.5+
+- support for d-link dgs-1100 series switch(@glaubway)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/dlink.rb
+++ b/lib/oxidized/model/dlink.rb
@@ -1,5 +1,6 @@
 class Dlink < Oxidized::Model
   # D-LINK Switches
+  # Add support dgs 1100 series (tested only with dgs-1100-10/me)
 
   prompt /^(\r*[\w\s.@()\/:-]+[#>]\s?)$/
   comment '# '
@@ -26,7 +27,7 @@ class Dlink < Oxidized::Model
   cmd 'show config current'
 
   cfg :telnet do
-    username /\r*[Uu]ser[Nn]ame:/
+    username /\r*([\w\s.@()\/:-]+)?([Uu]ser[Nn]ame|[Ll]ogin):/
     password /\r*[Pp]ass[Ww]ord:/
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Added support for d-link dgs-1100 series switches, tested with dgs-1100-10/me
