### PR TITLE
Update linuxgeneric.rb

### DIFF
--- a/lib/oxidized/model/linuxgeneric.rb
+++ b/lib/oxidized/model/linuxgeneric.rb
@@ -1,5 +1,5 @@
 class LinuxGeneric < Oxidized::Model
-  prompt /^(\w.*|\W.*)(:|#) /
+  prompt /^(\w.*|\W.*)(:|#) */
   comment '# '
 
   # add a comment in the final conf


### PR DESCRIPTION
edited regex for prompt to work on SLES 12-SP4

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
wanted to use system:

```
NAME="SLES"
VERSION="12-SP4"
VERSION_ID="12.4"
PRETTY_NAME="SUSE Linux Enterprise Server 12 SP4"
ID="sles"
ANSI_COLOR="0;32"
CPE_NAME="cpe:/o:suse:sles:12:sp4"
```

with `linuxgeneric.rb`

had to edit line2 
`prompt /^(\w.*|\W.*)(:|#) /`
 to:  
`prompt /^(\w.*|\W.*)(:|#) */`
to work