### PR TITLE
ironware.rb: Fix "current speed" regex to enclude MED-HI speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)
+- improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -31,7 +31,7 @@ class IronWare < Oxidized::Model
     cfg.encode!("UTF-8", invalid: :replace, undef: :replace) # sometimes ironware returns broken encoding
     cfg.gsub! /(^((.*)Current temp(.*))$)/, '' # remove unwanted lines current temperature
     cfg.gsub! /Speed = [A-Z-]{2,6} \(\d{2,3}%\)/, '' # remove unwanted lines Speed Fans
-    cfg.gsub! /current speed is [A-Z]{2,6} \(\d{2,3}%\)/, ''
+    cfg.gsub! /current speed is [A-Z-]{2,6} \(\d{2,3}%\)/, ''
     cfg.gsub! /Fan \d* - STATUS: OK \D*\d*./, '' # Fix for ADX Fan speed reporting
     cfg.gsub! /\d* deg C/, '' # Fix for ADX temperature reporting
     cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)(<->([\[]*)3([\]]*))*/, ''


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

The following line output by show chassis was not accounting for all cases, which meant configuration would be updated based on fan speed.

```-! --- TEMPERATURE are in auto mode (current speed is MED-HI (90%)). Temperature monitoring poll period is 60 seconds.```

Added '-' character to regex to resolve issue.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
