### PR TITLE
Fix SNMP community removal for Netgear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
+- fixed snmp secret handling in netgear model (@CirnoT)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -5,7 +5,8 @@ class Netgear < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub!(/password (\S+)/, 'password <hidden>')
     cfg.gsub!(/encrypted (\S+)/, 'encrypted <hidden>')
-    cfg.gsub!(/snmp-server community (\S+)/, 'snmp-server community <hidden>') # snmp
+    cfg.gsub!(/snmp-server community (\S+)$/, 'snmp-server community <hidden>')
+    cfg.gsub!(/snmp-server community (\S+) (\S+) (\S+)/, 'snmp-server community \\1 \\2 <hidden>')
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->

Before:
```
snmp-server community <hidden>
snmp-server community <hidden> 192.168.0.100 public
snmp-server community <hidden> 255.255.255.255 public
```

After:
```
snmp-server community <hidden>
snmp-server community ipaddr 192.168.0.100 <hidden>
snmp-server community ipmask 255.255.255.255 <hidden>
```