### PR TITLE
model/xos: filter perodic save schedule time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
+- filter next periodic save schedule time in xos model output (@sargon)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -23,7 +23,7 @@ class XOS < Oxidized::Model
   end
 
   cmd 'show switch' do |cfg|
-    comment cfg.each_line.reject { |line| line.match(/Time:/) || line.match(/boot/i) }.join
+    comment cfg.each_line.reject { |line| line.match(/Time:/) || line.match(/boot/i) || line.match(/Next periodic/) }.join
   end
 
   cmd 'show configuration' do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Filter the next periodic schedule time from configuration output. In our case that line triggered a change several times a day.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
