### PR TITLE
datacom.rb: Fix DataCom prompt and pagination issues (#2151)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)
+- improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
+- fixed an issue where Oxidized was unable to match post login prompt RegEx in new DmOS firmware (@Zuquim)
+- fixed an issue where Oxidized was unable to properly paginate DataCom devices' terminal output (@Zuquim)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/datacom.rb
+++ b/lib/oxidized/model/datacom.rb
@@ -1,16 +1,30 @@
 class DataCom < Oxidized::Model
+  # editing model specific prompt RegEx, adding: [\n]?
+  # to workaround the new DmOS post login welcome message
+  prompt /([\n]?[\w-]+[(]*[\w-]*[)]*[#>][\s]?)$/
+  # @legacy => false: new DmOS firmware | true: old OS firmware
+  @legacy = false
   comment '! '
 
-  expect /^--More--\s+$/ do |data, re|
-    send ' '
-    data.sub re, ''
-  end
+# was not able to make expect method work for pagination
+#  expect /^\s*--More--\s*$/ do |data, re|
+#    send ' '
+#    data.sub re, ''
+#  end
 
   cmd :all do |cfg|
-    cfg.cut_head.cut_both.cut_tail
+    cfg.cut_both
   end
 
   cmd 'show firmware' do |cfg|
+    # since 'show firmware' does not paginate in neither firmware versions,
+    # chose to use it's output to distinguish between the old and new OS
+    if cfg.lines.first =~ /^Running firmware:\s*$/  # Old OS firmware
+      @legacy = true
+      cmd "config\nno terminal paging\nexit"
+    else  # New DmOS firmware
+      cmd "paginate false"
+    end
     comment cfg
   end
 
@@ -20,6 +34,10 @@ class DataCom < Oxidized::Model
 
   cmd 'show running-config' do |cfg|
     cfg.cut_head
+  end
+
+  if @legacy == true
+    cmd "config\nterminal paging\nexit"
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -31,7 +31,7 @@ class IronWare < Oxidized::Model
     cfg.encode!("UTF-8", invalid: :replace, undef: :replace) # sometimes ironware returns broken encoding
     cfg.gsub! /(^((.*)Current temp(.*))$)/, '' # remove unwanted lines current temperature
     cfg.gsub! /Speed = [A-Z-]{2,6} \(\d{2,3}%\)/, '' # remove unwanted lines Speed Fans
-    cfg.gsub! /current speed is [A-Z]{2,6} \(\d{2,3}%\)/, ''
+    cfg.gsub! /current speed is [A-Z-]{2,6} \(\d{2,3}%\)/, ''
     cfg.gsub! /Fan \d* - STATUS: OK \D*\d*./, '' # Fix for ADX Fan speed reporting
     cfg.gsub! /\d* deg C/, '' # Fix for ADX temperature reporting
     cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)(<->([\[]*)3([\]]*))*/, ''


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

### prompt issue
Since the release of the new DmOS firmware, right after a successful login, the device displayed a welcome message, such as:
>Password:
>Welcome to the DmOS CLI
><username> connected from <ip_address> using ssh on hostname
>hostname# 

For this reason, the default RegEx was not able to match the prompt.
It was fixed by adding a custom prompt for the DataCom model, with `[\n]?` in the beginning.

### pagination issue
It seams that the `expect(regex)` method that was supposed to workaround pagination was not working as it should. Several RegEx combinations were tried without success. Oxidized routine for these devices timed out every time a command that triggered pagination was executed.

In order to address this issue, considering the old and new firmware versions, the device terminal pagination setting is now being temporarily disabled during the backup routine.

----
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Closes issue #2151 

