### PR TITLE
FortiOS: strip disk usage and current time

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -30,6 +30,8 @@ class FortiOS < Oxidized::Model
     @vdom_enabled = cfg.match /Virtual domain configuration: (enable|multiple)/
     cfg.gsub! /(System time:).*/, '\\1 <stripped>'
     cfg.gsub! /(Cluster uptime:).*/, '\\1 <stripped>'
+    cfg.gsub! /(Disk Usage)\s*:\s*(.*)/, '\1 <stripped>'
+    cfg.gsub! /(Current Time)\s*:\s*(.*)/, '\1 <stripped>'
     cfg.gsub! /(Virus-DB|Extended DB|IPS-DB|IPS-ETDB|APP-DB|INDUSTRIAL-DB|Botnet DB|IPS Malicious URL Database).*/, '\\1 <db version stripped>'
     comment cfg
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

This removes the Disk Usage and Current Time from the `get system status` command output for FortiOS devices.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
