### PR TITLE
add support for Dell N-Series switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for zte c300 and c320 olt (@glaubway)
 - model for LANCOM (@systeembeheerder)
 - model for Aruba CX switches (@jmurphy5)
+- model for Dell EMC Networking N-Series switches
 
 ### Changed
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -91,6 +91,7 @@
   * [PowerConnect](/lib/oxidized/model/powerconnect.rb)
   * [AOSW](/lib/oxidized/model/aosw.rb)
   * [DellX](/lib/oxidized/model/dellx.rb)
+  * [DellN](/lib/oxidized/model/delln.rb)
   * [Dell EMC Networking OS10](/lib/oxidized/model/os10.rb)
 * D-Link
   * [D-Link](/lib/oxidized/model/dlink.rb)

--- a/lib/oxidized/model/delln.rb
+++ b/lib/oxidized/model/delln.rb
@@ -1,0 +1,74 @@
+class DellN < Oxidized::Model
+  # Used in Dell N-Series Switches
+
+  prompt /[#>]$/
+
+  comment '! '
+
+  cmd :all do |cfg|
+    cfg.each_line.to_a[1..-3].join
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^(username \S+ password (?:encrypted )?)\S+(.*)/, '\1<hidden>\2'
+    cfg
+  end
+
+  cmd 'show version' do |cfg|
+    if @stackable.nil?
+      @stackable = true if cfg =~ /(U|u)nit\s/
+    end
+    cfg = cfg.split("\n").reject { |line| line[/Up\sTime/] }
+    comment cfg.join("\n") + "\n"
+  end
+
+  cmd 'show system' do |cfg|
+    clean cfg
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg.sub(/^(sflow \S+ destination owner \S+ timeout )\d+$/, '! \1<timeout>')
+  end
+
+  cfg :telnet, :ssh do
+    username /[uU]ser\s?[nN]ame:$/
+    password /[pP]assword:$/
+  end
+
+  cfg :telnet, :ssh do
+    post_login do
+      if vars(:enable) == true
+        cmd "enable"
+      elsif vars(:enable)
+        cmd "enable", /^[pP]assword:/
+        cmd vars(:enable)
+      end
+    end
+    post_login 'terminal length 0'
+
+    pre_logout "logout"
+    pre_logout "exit"
+  end
+
+  def clean(cfg)
+    out = []
+    skip_blocks = 0
+    cfg.each_line do |line|
+      # If this is a stackable switch we should skip this block of information
+      if line.match(/Up\sTime|Temperature|Power Suppl(ies|y)|Fans/i) && (@stackable == true)
+        skip_blocks = 1
+        # Some switches have another empty line. This is identified by this line having a colon
+        skip_blocks = 2 if line =~ /:/
+      end
+      # If we have lines to skip do this until we reach and empty line
+      if skip_blocks.positive?
+        skip_blocks -= 1 if /\S/ !~ line
+        next
+      end
+      out << line.strip
+    end
+    out = out.reject { |line| line[/Up\sTime/] }
+    out = comment out.join "\n"
+    out << "\n"
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add file for N-Series switches.
Based on the DellX, with more section replaced by 'terminal length 0' on post_login ("More:" not match on DellN), and add possibility to enable without password.
