### PR TITLE
Cambium ePMP Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for zte c300 and c320 olt (@glaubway)
 - model for LANCOM (@systeembeheerder)
 - model for Aruba CX switches (@jmurphy5)
+- model for Cambium ePMP radios (@martydingo) 
 
 ### Changed
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -48,6 +48,7 @@
   * [AXOS](/lib/oxidized/model/axos.rb)
 * Cambium
   * [Cambium (PMP450 Series)](/lib/oxidized/model/cambium.rb)
+  * [Cambium (ePMP Series)](/lib/oxidized/model/cambiumepmp.rb)
 * Casa
   * [Casa](/lib/oxidized/model/casa.rb)
 * Centec Networks

--- a/lib/oxidized/model/cambiumepmp.rb
+++ b/lib/oxidized/model/cambiumepmp.rb
@@ -1,7 +1,6 @@
 class CambiumePMP < Oxidized::Model
-  # Cambium ePMP Radios 
+  # Cambium ePMP Radios
 
-  # prompt /\(.*\)>/
   prompt /.*>/
 
   cmd :all do |cfg|

--- a/lib/oxidized/model/cambiumepmp.rb
+++ b/lib/oxidized/model/cambiumepmp.rb
@@ -1,5 +1,5 @@
 class CambiumePMP < Oxidized::Model
-  # Cambium ePMP Radios
+  # Cambium ePMP Radios 
 
   # prompt /\(.*\)>/
   prompt /.*>/
@@ -8,7 +8,7 @@ class CambiumePMP < Oxidized::Model
     cfg.cut_both
   end
 
-  pre do 
+  pre do
     cmd 'config show json'
   end
 

--- a/lib/oxidized/model/cambiumepmp.rb
+++ b/lib/oxidized/model/cambiumepmp.rb
@@ -1,0 +1,18 @@
+class CambiumePMP < Oxidized::Model
+  # Cambium ePMP Radios
+
+  # prompt /\(.*\)>/
+  prompt /.*>/
+
+  cmd :all do |cfg|
+    cfg.cut_both
+  end
+
+  pre do 
+    cmd 'config show json'
+  end
+
+  cfg :ssh do
+    pre_logout 'exit'
+  end
+end


### PR DESCRIPTION
## Description
Pull Request for Cambium ePMP devices to add support for these devices. The model name to use is cambiumepmp

I've had this running on our Oxidized instance and it's working well and perfectly stable for the last three months. 

This will close off https://github.com/ytti/oxidized/issues/2000 with people reporting that it works great in that issue. 

This will close off this issue also. https://github.com/ytti/oxidized/issues/2081


