### PR TITLE
fix documentation for monkey-patching

### DIFF
--- a/docs/Creating-Models.md
+++ b/docs/Creating-Models.md
@@ -130,6 +130,12 @@ end
 ```
 
 ```ruby
+cmd 'show version', clear: true do |cfg|
+  ... "(new code for parsing 'show version', replaces the existing definition in the model)" ...
+end
+```
+
+```ruby
 cmd :ssh, prepend: true do
   ... "(code that should run first, before any code in the existing :ssh definition in the model)" ...
 end

--- a/docs/Creating-Models.md
+++ b/docs/Creating-Models.md
@@ -124,13 +124,13 @@ This functionality is supported for `cfg`, `cmd`, `pre`, `post`, and `expect` bl
 Examples:
 
 ```ruby
-cmd :secret clear: true do
+cmd :secret, clear: true do
   ... "(new code for secret removal which replaces the existing :secret definition in the model)" ...
 end
 ```
 
 ```ruby
-cmd :ssh do prepend: true do
+cmd :ssh, prepend: true do
   ... "(code that should run first, before any code in the existing :ssh definition in the model)" ...
 end
 ```


### PR DESCRIPTION
## Pre-Request Checklist
- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
I noticed that the examples for monkey-patching gave syntax errors when used.
I fixed some typos, and added an example of a string based command, instead of only having single word symbol commands.
