### PR TITLE
Improve scrubbing for eos, netscaler, fortios and asa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - scrub PoE related messages from routeros config output (@pioto)
 - support for d-link dgs-1100 series switches in dlink model (@glaubway)
 - enterasys model now works with both ro and rw access (@sargon)
+- snmp secret scrubbing for netscaler model (@piethugen)
+- ospf secret scrubbing for eos model (@piethugen)
 
 ### Fixed
 
@@ -31,6 +33,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
 - fixed snmp secret handling in netgear model (@CirnoT)
 - filter next periodic save schedule time in xos model output (@sargon)
+- improved snmp secret scrubbing for models: asa, fortios and eos (@piethugen)
+- improved enable password scrubbing for model eos (@piethugen)
+   
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -17,7 +17,7 @@ class ASA < Oxidized::Model
     cfg.gsub! /^(aaa-server TACACS\+? \(\S+\) host[^\n]*\n(\s+[^\n]+\n)*\skey) \S+$/mi, '\1 <secret hidden>'
     cfg.gsub! /^(aaa-server \S+ \(\S+\) host[^\n]*\n(\s+[^\n]+\n)*\s+key) \S+$/mi, '\1 <secret hidden>'
     cfg.gsub! /ldap-login-password (\S+)/, 'ldap-login-password <secret hidden>'
-    cfg.gsub! /^snmp-server host (.*) community (\S+)/, 'snmp-server host \1 community <secret hidden>'
+    cfg.gsub! /^snmp-server (.*) community (\S+)/, 'snmp-server \1 community <secret hidden>'
     cfg.gsub! /^(failover key) .+/, '\1 <secret hidden>'
     cfg.gsub! /^(\s+ospf message-digest-key \d+ md5) .+/, '\1 <secret hidden>'
     cfg.gsub! /^(\s+ospf authentication-key) .+/, '\1 <secret hidden>'

--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -17,7 +17,7 @@ class ASA < Oxidized::Model
     cfg.gsub! /^(aaa-server TACACS\+? \(\S+\) host[^\n]*\n(\s+[^\n]+\n)*\skey) \S+$/mi, '\1 <secret hidden>'
     cfg.gsub! /^(aaa-server \S+ \(\S+\) host[^\n]*\n(\s+[^\n]+\n)*\s+key) \S+$/mi, '\1 <secret hidden>'
     cfg.gsub! /ldap-login-password (\S+)/, 'ldap-login-password <secret hidden>'
-    cfg.gsub! /^snmp-server (.*) community (\S+)/, 'snmp-server \1 community <secret hidden>'
+    cfg.gsub! /^snmp-server(.*)community (\S+)/, 'snmp-server\1community <secret hidden>'
     cfg.gsub! /^(failover key) .+/, '\1 <secret hidden>'
     cfg.gsub! /^(\s+ospf message-digest-key \d+ md5) .+/, '\1 <secret hidden>'
     cfg.gsub! /^(\s+ospf authentication-key) .+/, '\1 <secret hidden>'

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -11,11 +11,13 @@ class EOS < Oxidized::Model
 
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(snmp-server host .*) (\S+\Z)/, '\\1 <configuration removed>'
     cfg.gsub! /(secret \w+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /^(enable secret).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(tacacs-server key \d+).*/, '\\1 <configuration removed>'
     cfg.gsub! /( {6}key) (\h+ 7) (\h+).*/, '\\1 <secret hidden>'
+    cfg.gsub! /(key \d) (\S+)/, '\\1 <secret hidden>'
     cfg
   end
 

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -11,7 +11,7 @@ class EOS < Oxidized::Model
 
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
-    cfg.gsub! /^(snmp-server host .*) (\S+\Z)/, '\\1 <configuration removed>'
+    cfg.gsub! /^(snmp-server host .*) (\S+)$/, '\\1 <configuration removed>'
     cfg.gsub! /(secret \w+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(password \w+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -13,6 +13,7 @@ class EOS < Oxidized::Model
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(snmp-server host .*) (\S+\Z)/, '\\1 <configuration removed>'
     cfg.gsub! /(secret \w+) (\S+).*/, '\\1 <secret hidden>'
+    cfg.gsub! /(password \w+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /^(enable secret).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(tacacs-server key \d+).*/, '\\1 <configuration removed>'

--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -23,6 +23,7 @@ class FortiOS < Oxidized::Model
     cfg.gsub! /(set private-key ).*?-+END (ENCRYPTED|RSA|OPENSSH) PRIVATE KEY-+\n?"$/m, '\\1<configuration removed>'
     cfg.gsub! /(set ca ).*?-+END CERTIFICATE-+"$/m, '\\1<configuration removed>'
     cfg.gsub! /(set csr ).*?-+END CERTIFICATE REQUEST-+"$/m, '\\1<configuration removed>'
+    cfg.gsub! /(config system snmp community\s.*\s*set name )(\S+$)/, '\1 <configuration removed>'
     cfg
   end
 

--- a/lib/oxidized/model/netscaler.rb
+++ b/lib/oxidized/model/netscaler.rb
@@ -16,6 +16,7 @@ class NetScaler < Oxidized::Model
 
   cmd :secret do |cfg|
     cfg.gsub! /\w+\s(-encrypted)/, '<secret hidden> \\1'
+    cfg.gsub! /(snmp community) \S+ (\S*)/, '\1 <secret hidden> \2'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Improved or added SNMP community scrubbing for eos, netscaler, asa and fortios models.
Also added scrubbing of ospf secrets and enable passwords for eos the model
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
