### PR TITLE
fastiron.rb: added a second "exit" to pre_logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Allows "Username" as username prompt in Brocade ICX-series devices (@piterpunk) 
 - Add show-sensitive flag on export command on Mikrotik RouterOS when remove_secret is off (@kedare)
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support
 - change pfSense secret scrubbing to handle new format in 2.4.5+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,11 +46,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed snmp secret handling in netgear model (@CirnoT)
 - generalise fortiOS to support new versions and VM based products e.g. FortiManager, FortiAnalyzer and FortiMail, which requires keyboard-interactive auth method. Includes trial-and-error cmd list to retrieve most infromative config. Fixes #2227. Moved 'system ha status' to 'config global' section to support clusters with virtual domains.
 - filter next periodic save schedule time in xos model output (@sargon)
--  Fix when auto-saved is configured on xos switches  (@trappiz)
+- Fix when auto-saved is configured on xos switches  (@trappiz)
 - fixed ArubaOS-CX enviroment/system inconsistent values #2297 (@raunz)
 - Update AirFiber prompt regex (@murrant)
 - System time and running time are now stripped from tplink model output (@spike77453)
 - <?xml... line is no longer improperly stripped from OPNsense and PFsense backups (@pv2b)
+- fixed an issue where Oxidized timeouts in Brocade ICX-series devices (@piterpunk)
 
 
 ## [0.28.0 - 2020-05-18]

--- a/lib/oxidized/model/fastiron.rb
+++ b/lib/oxidized/model/fastiron.rb
@@ -62,5 +62,6 @@ class FastIron < Oxidized::Model
     end
     post_login 'skip-page-display'
     pre_logout 'exit'
+    pre_logout 'exit'
   end
 end

--- a/lib/oxidized/model/fastiron.rb
+++ b/lib/oxidized/model/fastiron.rb
@@ -46,7 +46,7 @@ class FastIron < Oxidized::Model
   cmd 'show running-config'
 
   cfg :telnet do
-    username /^.* login: /
+    username /^(.* login|Username): /
     password /^Password:/
   end
 


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added a second "exit" in fastiron.rb pre_logout.
This change fixes a timeout on ICX-series devices that keeps waiting forever after the first "exit" and didn't makes the backup, as stated in issue #2202 
Now it works fine:
```
D, [2020-10-15T19:35:59.432065 #31] DEBUG -- : lib/oxidized/input/ssh.rb: Connecting to BROCADE_ICX7250-24
D, [2020-10-15T19:36:15.401607 #31] DEBUG -- : lib/oxidized/input/ssh.rb: expecting [/^([\w.@()-]+[#>]\s?)$/] at BROCADE_ICX7250-24
D, [2020-10-15T19:36:16.205171 #31] DEBUG -- : lib/oxidized/input/cli.rb: Running post_login commands at BROCADE_ICX7250-24
D, [2020-10-15T19:36:16.205305 #31] DEBUG -- : lib/oxidized/input/cli.rb: Running post_login command: nil, block: #<Proc:0x000055999314e290@/var/lib/gems/2.5.0/gems/oxidized-0.28.0/lib/oxidized/model/fastiron.rb:55> at BROCADE_ICX7250-24
D, [2020-10-15T19:36:16.205426 #31] DEBUG -- : lib/oxidized/input/cli.rb: Running post_login command: "skip-page-display", block: nil at BROCADE_ICX7250-24
D, [2020-10-15T19:36:16.205484 #31] DEBUG -- : lib/oxidized/input/ssh.rb skip-page-display @ BROCADE_ICX7250-24 with expect: /^([\w.@()-]+[#>]\s?)$/
D, [2020-10-15T19:36:16.205717 #31] DEBUG -- : lib/oxidized/input/ssh.rb: expecting [/^([\w.@()-]+[#>]\s?)$/] at BROCADE_ICX7250-24
D, [2020-10-15T19:36:16.607373 #31] DEBUG -- : lib/oxidized/input/ssh.rb show version @ BROCADE_ICX7250-24 with expect: /^([\w.@()-]+[#>]\s?)$/
D, [2020-10-15T19:36:16.607569 #31] DEBUG -- : lib/oxidized/input/ssh.rb: expecting [/^([\w.@()-]+[#>]\s?)$/] at BROCADE_ICX7250-24
D, [2020-10-15T19:36:17.009688 #31] DEBUG -- : lib/oxidized/input/ssh.rb show module @ BROCADE_ICX7250-24 with expect: /^([\w.@()-]+[#>]\s?)$/
D, [2020-10-15T19:36:17.009895 #31] DEBUG -- : lib/oxidized/input/ssh.rb: expecting [/^([\w.@()-]+[#>]\s?)$/] at BROCADE_ICX7250-24
D, [2020-10-15T19:36:17.411739 #31] DEBUG -- : lib/oxidized/input/ssh.rb show media | exclude EMPTY @ BROCADE_ICX7250-24 with expect: /^([\w.@()-]+[#>]\s?)$/
D, [2020-10-15T19:36:17.411955 #31] DEBUG -- : lib/oxidized/input/ssh.rb: expecting [/^([\w.@()-]+[#>]\s?)$/] at BROCADE_ICX7250-24
D, [2020-10-15T19:36:18.014549 #31] DEBUG -- : lib/oxidized/input/ssh.rb show hardware-info @ BROCADE_ICX7250-24 with expect: /^([\w.@()-]+[#>]\s?)$/
D, [2020-10-15T19:36:18.014767 #31] DEBUG -- : lib/oxidized/input/ssh.rb: expecting [/^([\w.@()-]+[#>]\s?)$/] at BROCADE_ICX7250-24
D, [2020-10-15T19:36:22.824953 #31] DEBUG -- : lib/oxidized/input/ssh.rb show stack @ BROCADE_ICX7250-24 with expect: /^([\w.@()-]+[#>]\s?)$/
D, [2020-10-15T19:36:22.825129 #31] DEBUG -- : lib/oxidized/input/ssh.rb: expecting [/^([\w.@()-]+[#>]\s?)$/] at BROCADE_ICX7250-24
D, [2020-10-15T19:36:23.227231 #31] DEBUG -- : lib/oxidized/input/ssh.rb show running-config @ BROCADE_ICX7250-24 with expect: /^([\w.@()-]+[#>]\s?)$/
D, [2020-10-15T19:36:23.227424 #31] DEBUG -- : lib/oxidized/input/ssh.rb: expecting [/^([\w.@()-]+[#>]\s?)$/] at BROCADE_ICX7250-24
D, [2020-10-15T19:36:23.841060 #31] DEBUG -- : lib/oxidized/input/cli.rb Running pre_logout commands at BROCADE_ICX7250-24
D, [2020-10-15T19:36:23.841179 #31] DEBUG -- : lib/oxidized/input/ssh.rb exit @ BROCADE_ICX7250-24 with expect: nil
D, [2020-10-15T19:36:23.841339 #31] DEBUG -- : lib/oxidized/input/ssh.rb exit @ BROCADE_ICX7250-24 with expect: nil
D, [2020-10-15T19:36:28.951247 #31] DEBUG -- : lib/oxidized/node.rb: Oxidized::SSH ran for BROCADE_ICX7250-24 successfully
```

Fixes #2202 
