### PR TITLE
TP-Link: working telnet, include enable-admin and other fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- allow normal users to use enable-admin to access administrative mode on tplink model (@piterpunk)
+- changes tplink's "enable" handling to support an environment with and without enable passwords (@piterpunk)
 - Add show-sensitive flag on export command on Mikrotik RouterOS when remove_secret is off (@kedare)
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support
 - change pfSense secret scrubbing to handle new format in 2.4.5+
@@ -40,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fixed the telnet support for TP-Link (@piterpunk)
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)

--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -7,13 +7,14 @@ class TPLink < Oxidized::Model
     @input.class.to_s.match(/SSH/)
   end
 
-  # With disable paging this is not needed
-  # # handle paging
-  # # workaround for sometimes missing whitespaces with "\s?"
-  # expect /Press\s?any\s?key\s?to\s?continue\s?\(Q\s?to\s?quit\)/ do |data, re|
-  #   send ' '
-  #   data.sub re, ''
-  # end
+  # handle paging
+  # workaround for sometimes missing whitespaces with "\s?"
+  # With the disable paging feature this is not needed, but let's keep it if
+  # some older firmware doesn't accept the 'terminal length 0'
+  expect /Press\s?any\s?key\s?to\s?continue\s?\(Q\s?to\s?quit\)/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
 
   # send carriage return because \n with the command is not enough
   # checks if line ends with prompt >,#,: or \r,\n otherwise send \r
@@ -23,8 +24,8 @@ class TPLink < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    # # remove unwanted paging line
-    # cfg.gsub! /^Press any key to contin.*/, ''
+    # remove unwanted paging line
+    cfg.gsub! /^Press any key to contin.*/, ''
     # normalize linefeeds
     cfg.gsub! /(\r|\r\n|\n\r)/, "\n"
     # remove empty lines


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Many fixes mainly to allow Oxidized to use a normal user to do the backup and the connection through Telnet:
#### Telnet mode
- Change the username regular expression to accept both `User Name:` and `User:` as valid prompts.
- Prevent an additional '\r' to be sent in login when using `telnet` as input. The old behaviour always send the user name as an empty string.
#### Allow non privileged user to be used
- Allow `enable` to be used with and without enable password. Previously it always send the contents of `enable` variable, even without the `Password:` prompt. To allow `enable` without password, set the `enable` variable to `true`. If you want to use a password, set `enable` variable to the password itself.
- Added 'enable-admin' to be sent. This allows a normal user to execute administrative commands. 
#### Miscelanea
- Added the command to disable paging: `terminal length 0`.
- Changed the regular expression to determine if a carriage return needs or not to be sent. Previously it always send a `\r` in the `Password:` prompt before send the defined password.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Closes #2205 
Closes #1906 