### PR TITLE
Collect config from HRP enabled devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - avoid /humidity hardware field in tmos (F5) to be reported (@albsga)
 - version information or OPNsense and PFsense models is now included as XML comments (@pv2b)
 - only runs SSH proxy commands if the ssh_proxy configuration item has been defined (@jameskirsop)
+- updated vrp.rb to correctly parse huawei devices
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - scrub PoE related messages from routeros config output (@pioto)
 - support for d-link dgs-1100 series switches in dlink model (@glaubway)
 - enterasys model now works with both ro and rw access (@sargon)
+- updated vrp.rb to correctly parse huawei devices
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - scrub PoE related messages from routeros config output (@pioto)
 - support for d-link dgs-1100 series switches in dlink model (@glaubway)
 - enterasys model now works with both ro and rw access (@sargon)
-- updated vrp.rb to correctly parse huawei devices
 
 ### Fixed
 

--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -1,7 +1,7 @@
 class VRP < Oxidized::Model
   # Huawei VRP
 
-  prompt /(<[\w.-]+>)$/
+  prompt /*(<[\w.-]+>)$/
   comment '# '
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -1,7 +1,7 @@
 class VRP < Oxidized::Model
   # Huawei VRP
 
-  prompt /*(<[\w.-]+>)$/
+  prompt /(<[\w.-]+>)$/
   comment '# '
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -1,7 +1,7 @@
 class VRP < Oxidized::Model
   # Huawei VRP
 
-  prompt /^(<[\w.-]+>)$/
+  prompt /(<[\w.-]+>)$/
   comment '# '
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -1,7 +1,7 @@
 class VRP < Oxidized::Model
   # Huawei VRP
 
-  prompt /(<[\w.-]+>)$/
+  prompt /^.*(<[\w.-]+>)$/
   comment '# '
 
   cmd :secret do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- ~~[ ] Tests added or adapted (try `rake test`)~~ N/A
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
The change makes it so that devices that are in HRP mode can correctly be collected and parsed by oxidized. If not the * is removed is will not process devices in HRP mode. Even with this change other Huawei devices can be correctly collected as before. 
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
