### PR TITLE
Fix node path in git output.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
 - fixed snmp secret handling in netgear model (@CirnoT)
 - filter next periodic save schedule time in xos model output (@sargon)
+- fix node path in git output, when single mode repo activated (@sargon)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -135,7 +135,7 @@ module Oxidized
     def yield_repo_and_path(node, group)
       repo, path = node.repo, node.name
 
-      path = "#{group}/#{node.name}" if group && @cfg.single_repo?
+      path = "#{group}/#{node.name}" if !group.nil? && !group.empty? && @cfg.single_repo?
 
       [repo, path]
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
When single-repo is activated and a node has no group defined the prefix
should not be applied. Otherwise the api is not able to retrieve old
versions.

This may be a condition raised by the use of the web interface, when
the not given group is not nil? but empty string.
