### PR TITLE
Bugfixes for config loading, signal handling and worker deadlock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
 - fixed snmp secret handling in netgear model (@CirnoT)
 - filter next periodic save schedule time in xos model output (@sargon)
+- Oxidized will now exit on SIGTERM and SIGINT; SIGHUP will trigger a node list reload and reopen logs (@gs-kamnas)
+- fixed an issue where OXIDIZED\_HOME did not appropriately set the main user config file location (@gs-kamnas)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/bin/oxidized
+++ b/bin/oxidized
@@ -1,8 +1,5 @@
 #!/usr/bin/env ruby
 
-# FIX ME, killing oxidized needs -9
-trap("INT") { exit } # sinatra will otherwise steal this from us
-
 begin
   require_relative '../lib/oxidized/cli'
   Oxidized::CLI.new.run

--- a/lib/oxidized.rb
+++ b/lib/oxidized.rb
@@ -13,6 +13,7 @@ module Oxidized
   require 'oxidized/nodes'
   require 'oxidized/manager'
   require 'oxidized/hook'
+  require 'oxidized/signals'
   require 'oxidized/core'
 
   def self.asetus

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -14,7 +14,7 @@ module Oxidized
     Sleep     = 1
 
     def self.load(cmd_opts = {})
-      asetus = Asetus.new(name: 'oxidized', load: false, key_to_s: true)
+      asetus = Asetus.new(name: 'oxidized', load: false, key_to_s: true, usrdir: Oxidized::Config::Root)
       Oxidized.asetus = asetus
 
       asetus.default.username      = 'username'
@@ -59,7 +59,7 @@ module Oxidized
         raise InvalidConfig, "Error loading config: #{error.message}"
       end
 
-      raise NoConfig, 'edit ~/.config/oxidized/config' if asetus.create
+      raise NoConfig, "edit #{File.join(Oxidized::Config::Root, 'config')}" if asetus.create
 
       # override if comand line flag given
       asetus.cfg.debug = cmd_opts[:debug] if cmd_opts[:debug]

--- a/lib/oxidized/core.rb
+++ b/lib/oxidized/core.rb
@@ -15,7 +15,15 @@ module Oxidized
       raise NoNodesFound, 'source returns no usable nodes' if nodes.size.zero?
 
       @worker = Worker.new nodes
-      trap('HUP') { nodes.load }
+      @need_reload = false
+
+      # If we receive a SIGHUP, queue a reload of the state
+      reload_proc = Proc.new do
+        @need_reload = true
+      end
+      Signals.register_signal('HUP', reload_proc)
+
+      # Initialize REST API and webUI if requested
       if Oxidized.config.rest?
         begin
           require 'oxidized/web'
@@ -31,9 +39,20 @@ module Oxidized
 
     private
 
+    def reload
+      Oxidized.logger.info("Reloading node list and log files")
+      @worker.reload
+      Oxidized.logger.reopen
+      @need_reload = false
+    end
+
     def run
       Oxidized.logger.debug "lib/oxidized/core.rb: Starting the worker..."
-      @worker.work while sleep Config::Sleep
+      while true
+        reload if @need_reload
+        @worker.work
+        sleep Config::Sleep
+      end
     end
   end
 end

--- a/lib/oxidized/core.rb
+++ b/lib/oxidized/core.rb
@@ -18,7 +18,7 @@ module Oxidized
       @need_reload = false
 
       # If we receive a SIGHUP, queue a reload of the state
-      reload_proc = Proc.new do
+      reload_proc = proc do
         @need_reload = true
       end
       Signals.register_signal('HUP', reload_proc)
@@ -48,7 +48,7 @@ module Oxidized
 
     def run
       Oxidized.logger.debug "lib/oxidized/core.rb: Starting the worker..."
-      while true
+      loop do
         reload if @need_reload
         @worker.work
         sleep Config::Sleep

--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -44,7 +44,8 @@ module Oxidized
       # a) less threads running than the total amount of nodes
       # b) we want less than the max specified number of threads
 
-      return unless @want < @nodes.size and @want < @max
+      return unless (@want < @nodes.size) && (@want < @max)
+
       @want += 1
     end
 
@@ -54,6 +55,7 @@ module Oxidized
       # then we want one more thread (rationale is to fix hanging thread causing HOLB)
 
       return unless @want <= size
+
       increment if (Time.now.utc - @last) > MAX_INTER_JOB_GAP
     end
   end

--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -39,14 +39,22 @@ module Oxidized
       @want = @max if @want > @max
     end
 
-    def work
-      # if   a) we want less or same amount of threads as we now running
-      # and  b) we want less threads running than the total amount of nodes
-      # and  c) there is more than MAX_INTER_JOB_GAP since last one was started
-      # then we want one more thread (rationale is to fix hanging thread causing HOLB)
-      return unless @want <= size && @want < @nodes.size
+    def increment
+      # Increments the job count if safe to do so, which means:
+      # a) less threads running than the total amount of nodes
+      # b) we want less than the max specified number of threads
 
-      @want += 1 if (Time.now.utc - @last) > MAX_INTER_JOB_GAP
+      return unless @want < @nodes.size and @want < @max
+      @want += 1
+    end
+
+    def work
+      # if   a) we want less or same amount of threads as we now have running
+      # and  b) there is more than MAX_INTER_JOB_GAP since last one was started
+      # then we want one more thread (rationale is to fix hanging thread causing HOLB)
+
+      return unless @want <= size
+      increment if (Time.now.utc - @last) > MAX_INTER_JOB_GAP
     end
   end
 end

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -27,7 +27,7 @@ module Oxidized
           end
         end
         size.zero? ? replace(new) : update_nodes(new)
-        @jobs.new_count unless @jobs.nil?
+        @jobs&.new_count
         Oxidized.logger.info "lib/oxidized/nodes.rb: Loaded #{size} nodes"
       end
     end

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -27,6 +27,7 @@ module Oxidized
           end
         end
         size.zero? ? replace(new) : update_nodes(new)
+        @jobs.new_count unless @jobs.nil?
         Oxidized.logger.info "lib/oxidized/nodes.rb: Loaded #{size} nodes"
       end
     end
@@ -77,7 +78,9 @@ module Oxidized
         # set last job to nil so that the node is picked for immediate update
         n.last = nil
         put n
-        jobs.want += 1 if Oxidized.config.next_adds_job?
+        # Caution: Infinite worker loop will occur if jobs.want > # of nodes,
+        # therefore dont directly increment @want
+        jobs.increment if Oxidized.config.next_adds_job?
       end
     end
     alias top next

--- a/lib/oxidized/signals.rb
+++ b/lib/oxidized/signals.rb
@@ -3,8 +3,8 @@
 module Puma
   class Signal
     class << self
-      alias_method :os_trap, :trap
-      def Signal.trap sig, &block
+      alias os_trap trap
+      def Signal.trap(sig, &block)
         sigshortname = sig.gsub /SIG/, ''
         Oxidized::Signals.register_signal(sig, block) unless sigshortname.eql? 'HUP'
       end
@@ -14,11 +14,11 @@ end
 
 module Oxidized
   class Signals
-    @handlers = Hash.new { |h, k| h[k] = Array.new }
+    @handlers = Hash.new { |h, k| h[k] = [] }
     class << self
       attr_accessor :handlers
 
-      def register_signal sig, procobj
+      def register_signal(sig, procobj)
         # Compute short name of the signal (without SIG prefix)
         sigshortname = sig.gsub /SIG/, ''
         signum = Signal.list[sigshortname]
@@ -32,13 +32,13 @@ module Oxidized
         @handlers[signum].push(procobj)
       end
 
-      def handle_signal signum
-        return unless handlers.key?(signum)
-        @handlers[signum].each do | handler |
-          handler.call()
+      def handle_signal(signum)
+        return unless handlers.has_key?(signum)
+
+        @handlers[signum].each do |handler|
+          handler.call
         end
       end
-
     end
   end
 end

--- a/lib/oxidized/signals.rb
+++ b/lib/oxidized/signals.rb
@@ -1,0 +1,44 @@
+# Monkey patch Signal.trap for Puma to keep it from overriding our handlers
+# Also prevent Puma from registering its own SIGHUP handler
+module Puma
+  class Signal
+    class << self
+      alias_method :os_trap, :trap
+      def Signal.trap sig, &block
+        sigshortname = sig.gsub /SIG/, ''
+        Oxidized::Signals.register_signal(sig, block) unless sigshortname.eql? 'HUP'
+      end
+    end
+  end
+end
+
+module Oxidized
+  class Signals
+    @handlers = Hash.new { |h, k| h[k] = Array.new }
+    class << self
+      attr_accessor :handlers
+
+      def register_signal sig, procobj
+        # Compute short name of the signal (without SIG prefix)
+        sigshortname = sig.gsub /SIG/, ''
+        signum = Signal.list[sigshortname]
+
+        # Register the handler with OS
+        Signal.trap signum do
+          Oxidized::Signals.handle_signal(signum)
+        end
+
+        # Add the proc to the handler list for the requested signal
+        @handlers[signum].push(procobj)
+      end
+
+      def handle_signal signum
+        return unless handlers.key?(signum)
+        @handlers[signum].each do | handler |
+          handler.call()
+        end
+      end
+
+    end
+  end
+end

--- a/lib/oxidized/source/csv.rb
+++ b/lib/oxidized/source/csv.rb
@@ -13,7 +13,7 @@ module Oxidized
         Oxidized.asetus.user.source.csv.map.model = 1
         Oxidized.asetus.user.source.csv.gpg       = false
         Oxidized.asetus.save :user
-        raise NoConfig, 'no source csv config, edit ~/.config/oxidized/config'
+        raise NoConfig, "no source csv config, edit #{File.join(Oxidized::Config::Root, 'config')}"
       end
       require 'gpgme' if @cfg.gpg?
     end

--- a/lib/oxidized/source/http.rb
+++ b/lib/oxidized/source/http.rb
@@ -8,7 +8,7 @@ module Oxidized
     def setup
       return unless @cfg.url.empty?
 
-      raise NoConfig, 'no source http url config, edit ~/.config/oxidized/config'
+      raise NoConfig, "no source http url config, edit #{File.join(Oxidized::Config::Root, 'config')}"
     end
 
     require "net/http"

--- a/lib/oxidized/source/sql.rb
+++ b/lib/oxidized/source/sql.rb
@@ -15,7 +15,7 @@ module Oxidized
       Oxidized.asetus.user.source.sql.map.name  = 'name'
       Oxidized.asetus.user.source.sql.map.model = 'rancid'
       Oxidized.asetus.save :user
-      raise NoConfig, 'no source sql config, edit ~/.config/oxidized/config'
+      raise NoConfig, "no source sql config, edit #{File.join(Oxidized::Config::Root, 'config')}"
     end
 
     def load(node_want = nil)

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -52,6 +52,10 @@ module Oxidized
       Oxidized.logger.warn "#{node.group}/#{node.name} not found, removed while collecting?"
     end
 
+    def reload
+      @nodes.load
+    end
+
     private
 
     def process_success(node, job)


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This change aims to address a series of bugs encountered in our usage of Oxidized, namely:
- Oxidized would not exit on SIGTERM nor reload its node list on SIGHUP if the rest API was enabled.
- Oxidized's worker would enter an aggressive loop if the /node/next API was called such that the worker pool became larger than the node list.
- OXIDIZED_HOME environment variable was not affecting the location that the main user configuration was loaded from.