### PR TITLE
hook/exec: preserve some environment variables

### DIFF
--- a/lib/oxidized/hook/exec.rb
+++ b/lib/oxidized/hook/exec.rb
@@ -59,7 +59,12 @@ class Exec < Oxidized::Hook
 
   def make_env(ctx)
     env = {
-      "OX_EVENT" => ctx.event.to_s
+      'OX_EVENT'                => ctx.event.to_s,
+      'PATH'                    => ENV['PATH'],
+      'HOME'                    => ENV['HOME'],
+      'OXIDIZED_HOME'           => ENV['OXIDIZED_HOME'],
+      'OXIDIZED_LOGS'           => ENV['OXIDIZED_LOGS'],
+      'OXIDIZED_SSH_PASSPHRASE' => ENV['OXIDIZED_SSH_PASSPHRASE']
     }
     if ctx.node
       env.merge!(


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
When executing a hook, the exec plugin removes all environment
variables. However, some variables can be useful to have: many software
crash if HOME is unset (including oxidized when we want to use `oxs`)
and PATH is useful to have for software not trying to populate a PATH
before invoking `exec*()` (unlike a shell).