### PR TITLE
input/ssh.rb: Proxy over cisco to cisco

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -142,6 +142,32 @@ vars_map:
 ...
 ```
 
+## Proxy over Cisco Device to Cisco Device
+
+When using the ssh proxy you will run into some problems if you use a cisco device as a jumphost/proxy. 
+
+This can be provided by defining the following variables in oxidized/config; 'cisco_jumphost', 'cisco_proxy_user' and 'cisco_proxy_pass'.
+
+optionally you can add 'vrf_name' if your proxy is via VRF, but this variable doesn't need to be defined.
+
+Below is an example with the VRF variable added with it.
+
+```yaml
+...
+map:
+  name: 0
+  model: 1
+  ip: 2
+  username: 3
+  password: 4
+vars_map:
+  enable: 5
+  cisco_jumphost: 6
+  vrf_name: 7
+  cisco_proxy_user: 8
+  cisco_proxy_pass: 9
+  
+
 ## SSH enabling legacy algorithms
 
 When connecting to older firmware over SSH, it is sometimes necessary to enable legacy/disabled settings like KexAlgorithms, HostKeyAlgorithms, MAC or the Encryption.

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -106,7 +106,7 @@ module Oxidized
     def vrf_ssh_shell_open(ssh)
       @ses = ssh.open_channel do |ch|
 	    # Execute the command that will initialize the proxy ssh over vrf
-        ch.exec "ssh -vrf #{node.vars[:vrfname]} -l #{node.vars[:vrfuser]} #{node.ip}" do |ch, success|
+        ch.exec "ssh -vrf #{node.vars[:vrfname]} -l #{node.vars[:cisco_proxy_user]} #{node.ip}" do |ch, success|
           raise "could not execute command" unless success
           do_loop = true;
           ch.on_data do |_ch, data|
@@ -118,7 +118,7 @@ module Oxidized
             @output = @node.model.expects @output
             # Check for password prompt. If the router asks for a password then the password will be send
             if data =~ /Password: / && do_loop
-              _ch.send_data("#{node.vars[:vrfpass]}\n")
+              _ch.send_data("#{node.vars[:cisco_proxy_pass]}\n")
               do_loop = false
             end
 
@@ -144,12 +144,12 @@ module Oxidized
 
             # Check for username prompt. If the router asks for a username then the username will be send
             if data =~ /Username: / && do_loop0
-              _ch.send_data("#{node.vars[:vrfuser]}\n")
+              _ch.send_data("#{node.vars[:cisco_proxy_user]}\n")
               do_loop0 = false
             end
 			# Check for password prompt. If the router asks for a password then the password will be send
             if data =~ /Password: / && do_loop1
-              _ch.send_data("#{node.vars[:vrfpass]}\n")
+              _ch.send_data("#{node.vars[:cisco_proxy_pass]}\n")
               do_loop1 = false
             end
 
@@ -161,7 +161,7 @@ module Oxidized
     # Execute the command that will initialize the proxy ssh over a normal connection
     def proxy_ssh_shell_open(ssh)
       @ses = ssh.open_channel do |ch|
-        ch.exec "ssh -l #{node.vars[:vrfuser]} #{node.ip}" do |ch, success|
+        ch.exec "ssh -l #{node.vars[:cisco_proxy_user]} #{node.ip}" do |ch, success|
           raise "could not execute command" unless success
           do_loop0 = true;
           ch.on_data do |_ch, data|
@@ -174,7 +174,7 @@ module Oxidized
 
             # Check for password prompt. If the router asks for a password then the password will be send
             if data =~ /Password: / && do_loop1
-              _ch.send_data("#{node.vars[:vrfpass]}\n")
+              _ch.send_data("#{node.vars[:cisco_proxy_pass]}\n")
               do_loop1 = false
             end
 
@@ -200,12 +200,12 @@ module Oxidized
 
             # Check for username prompt. If the router asks for a username then the username will be send
             if data =~ /Username: / && do_loop0
-              _ch.send_data("#{node.vars[:vrfuser]}\n")
+              _ch.send_data("#{node.vars[:cisco_proxy_user]}\n")
               do_loop0 = false
             end
 			# Check for password prompt. If the router asks for a password then the password will be send
             if data =~ /Password: / && do_loop1
-              _ch.send_data("#{node.vars[:vrfpass]}\n")
+              _ch.send_data("#{node.vars[:cisco_proxy_pass]}\n")
               do_loop1 = false
             end
 

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -24,13 +24,45 @@ module Oxidized
       @log = File.open(Oxidized::Config::Log + "/#{@node.ip}-ssh", 'w') if Oxidized.config.input.debug?
 
       Oxidized.logger.debug "lib/oxidized/input/ssh.rb: Connecting to #{@node.name}"
-      @ssh = Net::SSH.start(@node.ip, @node.auth[:username], make_ssh_opts)
+	  # Check if cisco_jumphost has been defined in the oxidized/config file. If it isn't defined then the normal net::SSH.start method will be called
+      if (@node.vars[:cisco_jumphost])
+        @ssh = Net::SSH.start(@node.vars[:cisco_jumphost], @node.auth[:username], :append_all_supported_algorithms => true)
+      else
+        @ssh = Net::SSH.start(@node.ip, @node.auth[:username], make_ssh_opts)
+      end
       unless @exec
-        shell_open @ssh
-        begin
-          login
-        rescue Timeout::Error
-          raise PromptUndetect, [@output, 'not matching configured prompt', @node.prompt].join(' ')
+	    # Check if a vrfname is defined in oxidized/config. If it is defined then the proxy will use vrf-vpn. if it isn't defined then it will proxy over a normal connection
+        if (@node.vars[:vrfname] != '')
+		  # Check which protocol is used. This variable must be defined in oxidized/config if cisco_jumphost is defined.
+          if (@node.vars[:protocol] == 'ssh')
+            vrf_ssh_shell_open @ssh
+          elsif (@node.vars[:protocol] == 'telnet')
+            vrf_telnet_shell_open @ssh
+          end
+          begin
+            login
+          rescue Timeout::Error
+            raise PromptUndetect, [@output, 'not matching configured prompt', @node.prompt].join(' ')
+          end
+        elsif (@node.vars[:vrfname] == '' and @node.vars[:cisco_jumphost] != '')
+		  # Check which protocol is used. This variable must be defined in oxidized/config if cisco_jumphost is defined.
+          if (@node.vars[:protocol] == 'ssh')
+            proxy_ssh_shell_open @ssh
+          elsif (@node.vars[:protocol] == 'telnet')
+            proxy_telnet_shell_open @ssh
+          end
+          begin
+            login
+          rescue Timeout::Error
+            raise PromptUndetect, [@output, 'not matching configured prompt', @node.prompt].join(' ')
+          end
+        else
+          shell_open @ssh
+          begin
+            login
+          rescue Timeout::Error
+            raise PromptUndetect, [@output, 'not matching configured prompt', @node.prompt].join(' ')
+          end
         end
       end
       connected?
@@ -70,6 +102,118 @@ module Oxidized
       @log.close if Oxidized.config.input.debug?
       (@ssh.close rescue true) unless @ssh.closed?
     end
+
+    def vrf_ssh_shell_open(ssh)
+      @ses = ssh.open_channel do |ch|
+	    # Execute the command that will initialize the proxy ssh over vrf
+        ch.exec "ssh -vrf #{node.vars[:vrfname]} -l #{node.vars[:vrfuser]} #{node.ip}" do |ch, success|
+          raise "could not execute command" unless success
+          do_loop = true;
+          ch.on_data do |_ch, data|
+            if Oxidized.config.input.debug?
+              @log.print data
+              @log.flush
+            end
+            @output << data
+            @output = @node.model.expects @output
+            # Check for password prompt. If the router asks for a password then the password will be send
+            if data =~ /Password: / && do_loop
+              _ch.send_data("#{node.vars[:vrfpass]}\n")
+              do_loop = false
+            end
+
+          end
+        end
+      end
+    end
+
+    # Execute the command that will initialize the proxy telnet over vrf
+    def vrf_telnet_shell_open(ssh)
+      @ses = ssh.open_channel do |ch|
+        ch.exec "telnet #{node.ip} /vrf #{node.vars[:vrfname]}" do |ch, success|
+          raise "could not execute command" unless success
+          do_loop0 = true;
+          do_loop1 = true;
+          ch.on_data do |_ch, data|
+            if Oxidized.config.input.debug?
+              @log.print data
+              @log.flush
+            end
+            @output << data
+            @output = @node.model.expects @output
+
+            # Check for username prompt. If the router asks for a username then the username will be send
+            if data =~ /Username: / && do_loop0
+              _ch.send_data("#{node.vars[:vrfuser]}\n")
+              do_loop0 = false
+            end
+			# Check for password prompt. If the router asks for a password then the password will be send
+            if data =~ /Password: / && do_loop1
+              _ch.send_data("#{node.vars[:vrfpass]}\n")
+              do_loop1 = false
+            end
+
+          end
+        end
+      end
+    end
+
+    # Execute the command that will initialize the proxy ssh over a normal connection
+    def proxy_ssh_shell_open(ssh)
+      @ses = ssh.open_channel do |ch|
+        ch.exec "ssh -l #{node.vars[:vrfuser]} #{node.ip}" do |ch, success|
+          raise "could not execute command" unless success
+          do_loop0 = true;
+          ch.on_data do |_ch, data|
+            if Oxidized.config.input.debug?
+              @log.print data
+              @log.flush
+            end
+            @output << data
+            @output = @node.model.expects @output
+
+            # Check for password prompt. If the router asks for a password then the password will be send
+            if data =~ /Password: / && do_loop1
+              _ch.send_data("#{node.vars[:vrfpass]}\n")
+              do_loop1 = false
+            end
+
+          end
+        end
+      end
+    end
+
+    # Execute the command that will initialize the proxy telnet over a normal connection
+    def proxy_telnet_shell_open(ssh)
+      @ses = ssh.open_channel do |ch|
+        ch.exec "telnet #{node.ip}" do |ch, success|
+          raise "could not execute command" unless success
+          do_loop0 = true;
+          do_loop1 = true;
+          ch.on_data do |_ch, data|
+            if Oxidized.config.input.debug?
+              @log.print data
+              @log.flush
+            end
+            @output << data
+            @output = @node.model.expects @output
+
+            # Check for username prompt. If the router asks for a username then the username will be send
+            if data =~ /Username: / && do_loop0
+              _ch.send_data("#{node.vars[:vrfuser]}\n")
+              do_loop0 = false
+            end
+			# Check for password prompt. If the router asks for a password then the password will be send
+            if data =~ /Password: / && do_loop1
+              _ch.send_data("#{node.vars[:vrfpass]}\n")
+              do_loop1 = false
+            end
+
+          end
+        end
+      end
+    end
+
 
     def shell_open(ssh)
       @ses = ssh.open_channel do |ch|
@@ -141,6 +285,7 @@ module Oxidized
           proxy_command += "-p #{proxy_port} "
         end
         proxy_command += "#{proxy_host} -W %h:%p"
+
         proxy = Net::SSH::Proxy::Command.new(proxy_command)
         ssh_opts[:proxy] = proxy
       end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
As already noted in issue #639, there isn't a functionality that let's you use a proxy over another IOS device to an IOS device. So I have added proxy functionalities which also let's you specify the protocol (ssh or telnet). In the issue #639 he talks about proxy over vrf. This functionality was also added.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->


