### PR TITLE
Adding support for Accedian EtherNID devices

### DIFF
--- a/lib/oxidized/model/enid.rb
+++ b/lib/oxidized/model/enid.rb
@@ -1,0 +1,27 @@
+class ENID < Oxidized::Model
+    # Support for Accedian EtherNID family
+  
+    comment '#'
+    prompt /^(\w+-\w+):\s?$/
+  
+    cmd 'port show status' do |cfg|
+      comment cfg
+    end
+  
+    cmd 'configuration export' do |cfg|
+      cfg.gsub! /^.*FILE_ATTRIB.*/, ''
+      cfg.gsub! /^.*Export Done.*/, ''
+      cfg.cut_both
+    end
+  
+    cfg :telnet do
+      username /^(\w+-\w+\s+login:)\s?$/
+      password /[Pp]assword:\s?/
+    end
+  
+    cfg :ssh do |cfg|
+      post_login 'session writelock'
+      pre_logout 'session writeunlock'
+      pre_logout 'exit'
+    end
+  end

--- a/lib/oxidized/model/enid.rb
+++ b/lib/oxidized/model/enid.rb
@@ -25,3 +25,4 @@ class ENID < Oxidized::Model
       pre_logout 'exit'
     end
   end
+  


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Adding support for Accedian EtherNID devices. There is a model (aen.rb) that supports the newer Metro* platform, but this model supports the older EtherNID platform.
