### PR TITLE
Avoids running proxy commands if ssh_proxy config is empty/blank

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - scrub PoE related messages from routeros config output (@pioto)
 - support for d-link dgs-1100 series switches in dlink model (@glaubway)
 - enterasys model now works with both ro and rw access (@sargon)
+- only runs SSH proxy commands if the ssh_proxy configuration item has been defined (@jameskirsop)
 
 ### Fixed
 

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -134,7 +134,8 @@ module Oxidized
       ssh_opts[:auth_methods] = auth_methods
       Oxidized.logger.debug "AUTH METHODS::#{auth_methods}"
 
-      if (proxy_host = vars(:ssh_proxy))
+      proxy_host = vars(:ssh_proxy)
+      if ( defined?(proxy_host) && !proxy_host.nil? && !proxy_host.empty? )
         proxy_command =  "ssh "
         proxy_command += "-o StrictHostKeyChecking=no " unless secure
         if (proxy_port = vars(:ssh_proxy_port))


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This prevents the [ssh_proxy code block](https://github.com/ytti/oxidized/blob/c0dae48928ec391c01070a32c2eedb034d983c10/lib/oxidized/input/ssh.rb#L137) being executed when the value is empty in an SQL source, and otherwise has no effect.

It brings Oxidized in line with the _expected_ behaviour and closes #2267 
