### PR TITLE
Fix /node/show returning the wrong node when several share the same IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
 - fixed snmp secret handling in netgear model (@CirnoT)
 - filter next periodic save schedule time in xos model output (@sargon)
+- fixed /node/show returning the wrong node when several nodes share the same IP address (@sbraz)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -131,7 +131,7 @@ module Oxidized
     end
 
     def find_index(node)
-      index { |e| [e.name, e.ip].include? node }
+      index { |e| e.name == node }
     end
 
     # @param node node which is removed from nodes list


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`) → I get `34 runs, 119 assertions, 2 failures, 0 errors, 0 skips` on my branch and master so I assume the breakage isn't related to this change
- [ ] Changes are reflected in the documentation → I don't think this is documented anywhere
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Hi,
Before this change, calling `/node/show/<node_name>` would return the first node whose name *or* IP address was `node_name`.
This could cause problems when two nodes had the same IP address but a different name. In that case, the URL would not always return the correct node.

After this change, only the node name is taken into account.

As far as I'm aware, the name is the unique identifier of a node so this shouldn't break anything but please let me know if I'm wrong.
