### PR TITLE
Create rad.db file - Add RAD support

### DIFF
--- a/lib/oxidized/model/rad.rb
+++ b/lib/oxidized/model/rad.rb
@@ -1,0 +1,56 @@
+class Rad < Oxidized::Model
+  prompt /([\w.@()*-]+[#>]\s?)$/
+  comment  '! '
+
+  # example how to handle pager
+  # expect /^\s--More--\s+.*$/ do |data, re|
+  #  send ' '
+  #  data.sub re, ''
+  # end
+
+  # non-preferred way to handle additional PW prompt
+  # expect /^[\w.]+>$/ do |data|
+  #  send "enable\n"
+  #  send vars(:enable) + "\n"
+  #  data
+  # end
+
+  cmd :all do |cfg|
+    # cfg.gsub! /\cH+\s{8}/, ''         # example how to handle pager
+    # cfg.gsub! /\cH+/, ''              # example how to handle pager
+    cfg.cut_both
+  end
+
+#  cmd :secret do |cfg|
+#    cfg.gsub! /^(snmp set-read-community ").*+?(".*)$/, '\\1<secret hidden>\\2'
+#    cfg
+#  end
+  
+  cmd "show config system system-date" do |cfg|
+    cfg
+  end
+
+  cmd "configure" do |cfg|
+    cfg
+  end
+
+  cmd "terminal length 0" do |cfg|
+    cfg
+  end
+
+  cmd "info" do |cfg|
+    cfg
+  end
+
+  cfg :telnet, :ssh do
+    post_login 'echo info'
+    # preferred way to handle additional passwords
+    if vars :enable
+      post_login do
+        send "enable"
+        cmd vars(:enable)
+     end
+    end
+    pre_logout "logout\r"
+  end
+end


### PR DESCRIPTION
I had some trouble with "not matching configured prompt" error
this cisco ios issues solved it: https://github.com/ytti/oxidized/issues/747
Initialy: prompt /^([\w.@()*-]+[#>]\s?)$/ then: prompt /([\w.@()*-]+[#>]\s?)$/

tested on RAD ETX-203AX

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
