### PR TITLE
Update airfiber prompt regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
 - fixed snmp secret handling in netgear model (@CirnoT)
 - filter next periodic save schedule time in xos model output (@sargon)
+- Update AirFiber prompt regex (@murrant)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/airfiber.rb
+++ b/lib/oxidized/model/airfiber.rb
@@ -1,7 +1,7 @@
 class Airfiber < Oxidized::Model
   # Ubiquiti Airfiber (tested with Airfiber 11FX)
 
-  prompt /^AF[\w\.]+#/
+  prompt /^AF[\w\.-]+#/
 
   cmd :all do |cfg|
     cfg.cut_both


### PR DESCRIPTION
Did not match rc versions of airfiber.

` AF09.v4.1.0-rc.2.218.200225.0850#` for example

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
