### PR TITLE
added nxos_vdc model

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -10,7 +10,10 @@ class AOSW < Oxidized::Model
   # All IAPs connected to a Instant Controller will have the same config output. Only the controller needs to be monitored.
 
   comment  '# '
-  prompt /^([\w\(:.@-]+(\)?\s?)[#>]\s?)$/
+  # after entering a command, ArubaOS returns \n\r (but \r\n when first
+  # connecting) - SSH splits the line on \n (and will convert \r\n to \n), so
+  # we will possibly get a stray \r at the start of the line
+  prompt /^(\r?[\w\(:.@-]+(\)?\s?)\*?[#>]\s?)$/
 
   cmd :all do |cfg|
     cfg.cut_both

--- a/lib/oxidized/model/nxos_vdc.rb
+++ b/lib/oxidized/model/nxos_vdc.rb
@@ -1,0 +1,46 @@
+class NXOS_VDC < Oxidized::Model
+  prompt /^(\r?[\w.@_()-]+[#]\s?)$/
+  comment '! '
+
+  def filter(cfg)
+    cfg.gsub! /\r\n?/, "\n"
+    cfg.gsub! prompt, ''
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(snmp-server user (\S+) (\S+) auth (\S+)) (\S+) (priv) (\S+)/, '\\1 <configuration removed> '
+    cfg.gsub! /^(username \S+ password \d) (\S+)/, '\\1 <secret hidden>'
+    cfg.gsub! /^(radius-server key).*/, '\\1 <secret hidden>'
+    cfg
+  end
+
+  cmd 'show version' do |cfg|
+    cfg = filter cfg
+    cfg = cfg.each_line.take_while { |line| not line.match(/uptime/i) }
+    comment cfg.join ""
+  end
+
+  cmd 'show inventory' do |cfg|
+    cfg = filter cfg
+    comment cfg
+  end
+
+  cmd 'show running-config vdc-all' do |cfg|
+    cfg = filter cfg
+    cfg.gsub! /^(show run.*)$/, '! \1'
+    cfg.gsub! /^!Time:[^\n]*\n/, ''
+    cfg.gsub! /^[\w.@_()-]+[#].*$/, ''
+    cfg
+  end
+
+  cfg :ssh, :telnet do
+    post_login 'terminal length 0'
+    pre_logout 'exit'
+  end
+
+  cfg :telnet do
+    username /^login:/
+    password /^Password:/
+  end
+end


### PR DESCRIPTION
this is for a multi-VDC Cisco NX-OS device - it connects to the admin
VDC and does a 'show running-config vdc-all' to get the configurations
for all VDCs in a single file

it would probably be better if this could somehow subclass nxos, but
I'm not skilled enough in Ruby to do this at the moment!

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
