### PR TITLE
Update oxidized.init

### DIFF
--- a/extra/oxidized.init
+++ b/extra/oxidized.init
@@ -18,7 +18,6 @@ PATH=/sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin
 DAEMON=$(which oxidized)
 NAME="oxidized"
 DESC="Oxidized - Network Device Configuration Backup Tool"
-ARGS=""
 USER="oxidized"
 
 test -x $DAEMON || exit 0
@@ -29,20 +28,18 @@ if [ -r /etc/default/$NAME ]; then
 	. /etc/default/$NAME
 fi
 
-CONFIG="${CONFIG:-/etc/oxidized/config}"
-
 PIDFILE=/var/run/$NAME.pid
 
 do_start()
 {
         start-stop-daemon --start --quiet --background --pidfile $PIDFILE --make-pidfile  \
-        --oknodo --chuid $USER --exec $DAEMON -- -c $CONFIG $ARGS
+        --oknodo --chuid $USER --exec $DAEMON
 }
 
 do_stop()
 {
         start-stop-daemon --oknodo --stop --quiet -v --pidfile $PIDFILE \
-        --chuid $USER --retry KILL/10 -- -c $CONFIG $ARGS
+        --chuid $USER --retry KILL/10
 }
 
 case "$1" in


### PR DESCRIPTION
Option -c and args argument are not supported anymore in oxidized daemon. Script failed starting daemon.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
