### PR TITLE
Fix when auto-saved is configured on xos switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)
 - fixed snmp secret handling in netgear model (@CirnoT)
 - filter next periodic save schedule time in xos model output (@sargon)
+-  Fix when auto-saved is configured on xos switches  (@trappiz)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -23,6 +23,7 @@ class XOS < Oxidized::Model
   end
 
   cmd 'show switch' do |cfg|
+    cfg.gsub! /Next periodic save on.*/, ''
     comment cfg.each_line.reject { |line| line.match(/Time:/) || line.match(/boot/i) || line.match(/Next periodic/) }.join
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Had issues that new backups where pushed every hour to git when "Next periodic save on" was updated with the next time to run.
Instead set the row to "empty".

```` 
 #  primary.cfg       Created by ExtremeXOS version 30.7.1.1
 #                    542681 bytes saved on Fri May 28 09:09:10 2021
 #                   Auto-saved every 60 minutes, if configuration is changed.
- #                   Next periodic save on Mon Jun 14 11:57:27 2021
+ #                   
````   


<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
