### PR TITLE
Fix eos error on no-more

### DIFF
--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -20,11 +20,21 @@ class EOS < Oxidized::Model
   end
 
   cmd 'show inventory | no-more' do |cfg|
+    if cfg =~ /\/bin\/sh: no-more: command not found/
+      cfg = cmd 'show inventory'
+    end
     comment cfg
   end
 
   cmd 'show running-config | no-more | exclude ! Time:' do |cfg|
+    if cfg =~ /\/bin\/sh: no-more: command not found/
+      cfg = cmd 'show running-config | exclude ! Time:'
+    end
     cfg
+  end
+
+  cmd 'write memory' do |cfg|
+    comment cfg
   end
 
   cfg :telnet, :ssh do


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Not all EOS switches have no-more. (HW DCS-7048T-A)

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
