### PR TITLE
Update fortios.rb to strip AV Model DB version

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -30,7 +30,7 @@ class FortiOS < Oxidized::Model
     @vdom_enabled = cfg.match /Virtual domain configuration: (enable|multiple)/
     cfg.gsub! /(System time:).*/, '\\1 <stripped>'
     cfg.gsub! /(Cluster uptime:).*/, '\\1 <stripped>'
-    cfg.gsub! /(Virus-DB|Extended DB|IPS-DB|IPS-ETDB|APP-DB|INDUSTRIAL-DB|Botnet DB|IPS Malicious URL Database).*/, '\\1 <db version stripped>'
+    cfg.gsub! /(Virus-DB|Extended DB|IPS-DB|IPS-ETDB|APP-DB|INDUSTRIAL-DB|Botnet DB|IPS Malicious URL Database|AV AI/ML Model).*/, '\\1 <db version stripped>'
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
The new version of FortiOS adds an AV AI/ML Model database version that changes frequently, like the Virus DB and IPS DB. This small change prevents the AV DB version from being backed up, and showing config changes on every backup

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
