### PR TITLE
add git option to not append type.name to filename

### DIFF
--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -44,7 +44,11 @@ module Oxidized
         type_repo = File.join(File.dirname(repo), type + '.git')
         outputs.type(type).each do |output|
           (type_cfg << output; next) unless output.name # rubocop:disable Style/Semicolon
-          type_file = file + '--' + output.name
+          if @cfg.no_append_name?
+            type_file = file
+          else
+            type_file = file + '--' + output.name
+          end
           if @cfg.type_as_directory?
             type_file = type + '/' + type_file
             type_repo = repo


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ X ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ X ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add git option to not append type.name to filename `no_append_name`

Closes issue #2341
