### PR TITLE
[TPLink/Jetstream] Allow no password enable

### DIFF
--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -50,9 +50,11 @@ class TPLink < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
-    if vars :enable
-      post_login do
-        send "enable\r"
+    post_login do
+      if vars(:enable) == true
+        cmd 'enable'
+      elsif vars(:enable)
+        cmd 'enable', /^\r?Password:$/
         cmd vars(:enable)
       end
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
The newer models of TPLink, Jetstream, force you to enable into "admin mode". 

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
