### PR TITLE
Add support for PanOS XML configuration backup

### DIFF
--- a/lib/oxidized/model/panos_api.rb
+++ b/lib/oxidized/model/panos_api.rb
@@ -22,9 +22,9 @@ class PanOS_API < Oxidized::Model # rubocop:disable Naming/ClassAndModuleCamelCa
     # Request to generate an API key with the given username and
     # password.
     kg_r = get_http "/api?" + URI.encode_www_form(
-      user: @node.auth[:username],
+      user:     @node.auth[:username],
       password: @node.auth[:password],
-      type: 'keygen'
+      type:     'keygen'
     )
 
     # Parse the XML API response for the keygen request.
@@ -44,9 +44,9 @@ class PanOS_API < Oxidized::Model # rubocop:disable Naming/ClassAndModuleCamelCa
     # Now that we have the API key, we can request a configuration
     # export.
     cfg = get_http "/api?" + URI.encode_www_form(
-      key: apikey,
+      key:      apikey,
       category: 'configuration',
-      type: 'export'
+      type:     'export'
     )
 
     # The configuration export is in XML format. Unfortunately,

--- a/lib/oxidized/model/panos_api.rb
+++ b/lib/oxidized/model/panos_api.rb
@@ -1,0 +1,69 @@
+# PanOS API-based model for Oxidized
+#
+# The API-based model produced an XML configuration file that can actually be
+# restored as a configuration backup. Make sure to use the "http" input for
+# this module.
+
+begin
+  # Nokogiri is required because the PanOS API, as well as the
+  # configuration file format uses XML. It is required to parse API
+  # responses, as well as to pretty-print the configuration XML file
+  # when saving it.
+  require 'nokogiri'
+rescue LoadError
+  # Oxidized itself depends on mechanize, which in turn depends on
+  # nokogiri, so this should never happen.
+  raise OxidizedError, 'nokogiri not found: sudo gem install nokogiri'
+end
+
+class PanOS_API < Oxidized::Model # rubocop:disable Naming/ClassAndModuleCamelCase
+  # Callback function for getting the configuration file.
+  cfg_cb = lambda do
+    # Request to generate an API key with the given username and
+    # password.
+    kg_r = get_http "/api?" + URI.encode_www_form(
+      user: @node.auth[:username],
+      password: @node.auth[:password],
+      type: 'keygen'
+    )
+
+    # Parse the XML API response for the keygen request.
+    kg_x = Nokogiri::XML(kg_r)
+
+    # Check if keygen was successful. If not we'll throw an error.
+    status = kg_x.xpath('//response/@status').first
+    if status.to_s != 'success'
+      msg = kg_x.xpath('//response/result/msg').text
+      raise Oxidized::OxidizedError, ('Could not generate PanOS API key: ' + msg)
+    end
+
+    # If we reach here, keygen was successful, so get the API key
+    # out of the keygen XML response.
+    apikey = kg_x.xpath('//response/result/key').text.to_s
+
+    # Now that we have the API key, we can request a configuration
+    # export.
+    cfg = get_http "/api?" + URI.encode_www_form(
+      key: apikey,
+      category: 'configuration',
+      type: 'export'
+    )
+
+    # The configuration export is in XML format. Unfortunately,
+    # it's just one long line of XML that's not especially human
+    # readable or diffable.
+    #
+    # Thus, we will load the XML document and then emit it again
+    # with indentation set up, so that it's still a valid
+    # configuration, and also possible to read.
+    Nokogiri::XML(cfg).to_xml(indent: 2)
+  end
+
+  # Define the command based on the callback above.
+  cmd cfg_cb
+
+  cfg :http do
+    # Palo Alto's API always requires HTTPS as far as I know.
+    @secure = true
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

This solves #440 by adding functionality to back up Palo Alto firewall XML configuration files using the HTTPS API.
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
