### PR TITLE
Fix docs with correct path for where to put models

### DIFF
--- a/docs/Creating-Models.md
+++ b/docs/Creating-Models.md
@@ -10,11 +10,11 @@ This methodology allows local site changes to be preserved during Oxidized versi
 
 An Oxidized model, at minimum, requires just three elements:
 
-* A model file, this file should be placed in the ~/.config/oxidized directory and named after the target OS type.
+* A model file, this file should be placed in the ~/.config/oxidized/model directory and named after the target OS type.
 * A class defined within this file with the same name as the file itself that inherits from `Oxidized::Model`, the base model class.
 * At least one command that will be executed and the output of which will be collected by Oxidized.
 
-A bare-bone example for a fictional model running the OS type `rootware` could be introduced by creating the file `~/.config/oxidized/rootware.rb`, with the following content:
+A bare-bone example for a fictional model running the OS type `rootware` could be introduced by creating the file `~/.config/oxidized/model/rootware.rb`, with the following content:
 
 ```ruby
 class RootWare < Oxidized::Model


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fixed a couple of errors in the docs where the wrong path for the models was listed.