### PR TITLE
OpenBSD: Include bgpd, ospfd and ospf6d files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - scrub PoE related messages from routeros config output (@pioto)
 - support for d-link dgs-1100 series switches in dlink model (@glaubway)
 - enterasys model now works with both ro and rw access (@sargon)
+- OpenBSD: Include bgpd, ospfd and ospf6d files (@woopstar)
 
 ### Fixed
 

--- a/lib/oxidized/model/openbsd.rb
+++ b/lib/oxidized/model/openbsd.rb
@@ -47,7 +47,7 @@ class Openbsd < Oxidized::Model
 
     cfg += add_comment('PASSWD FILE')
     cfg += cmd('cat /etc/passwd')
-    
+
     cfg += add_comment('BGPD FILE')
     cfg += cmd('cat /etc/bgpd.conf')
 

--- a/lib/oxidized/model/openbsd.rb
+++ b/lib/oxidized/model/openbsd.rb
@@ -47,6 +47,15 @@ class Openbsd < Oxidized::Model
 
     cfg += add_comment('PASSWD FILE')
     cfg += cmd('cat /etc/passwd')
+    
+    cfg += add_comment('BGPD FILE')
+    cfg += cmd('cat /etc/bgpd.conf')
+
+    cfg += add_comment('OSPFD FILE')
+    cfg += cmd('cat /etc/ospfd.conf')
+
+    cfg += add_comment('OSPF6D FILE')
+    cfg += cmd('cat /etc/ospf6d.conf')
 
     cfg += add_small_comment('END')
     cfg


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)

## Description
This will include the following files:
- bgpd.conf
- ospfd.conf
- ospf6d.conf
