### PR TITLE
Update stoneos.rb

### DIFF
--- a/lib/oxidized/model/stoneos.rb
+++ b/lib/oxidized/model/stoneos.rb
@@ -1,7 +1,7 @@
 class StoneOS < Oxidized::Model
   # Hillstone Networks StoneOS software
 
-  prompt /^\r?[\w.()-]+[#>](\s)?$/
+  prompt /^\r?[\w.()-~]+[#>](\s)?$/
   comment '# '
 
   expect /^\s.*--More--.*$/ do |data, re|


### PR DESCRIPTION
When the hostname of one Hillstone firewall is too long, it will be showed as 'xxxxxx~xxx', '~' stands for the missing words, so adding '~' in the prompt will make it work correctly.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
adds '~' in the prompt.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
