### PR TITLE
Update vrp.rb

### DIFF
--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -1,7 +1,7 @@
 class VRP < Oxidized::Model
   # Huawei VRP
 
-  prompt /^(<[\w.-]+>)$/
+  prompt /^(\w*<[\w.-]+>)$/
   comment '# '
 
   cmd :secret do |cfg|


### PR DESCRIPTION
After configured the Huawei firewall as hot-stanby mode, the hostname will be showed as 'HRP_M<XXXX>', 'HRP_M' or 'HRP_S' will be added before the hostname, so adding '\w*' in the prompt will make it work correctly.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Add '\w*' in the prompt.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
