### PR TITLE
Update to comware for v1950 OS Release 3208

### DIFF
--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -41,8 +41,13 @@ class Comware < Oxidized::Model
         cmd 'y', /(#{@node.prompt}|input password)/
         cmd vars(:comware_cmdline)
 
-        # HP V1950
+        # HP V1950 r2432P06
         cmd 'xtd-cli-mode on', /(#{@node.prompt}|Continue)/
+        cmd 'y', /(#{@node.prompt}|input password)/
+        cmd vars(:comware_cmdline)
+        
+        # HP V1950 OS r3208 (v7.1)
+        cmd 'xtd-cli-mode', /(#{@node.prompt}|Continue)/
         cmd 'y', /(#{@node.prompt}|input password)/
         cmd vars(:comware_cmdline)
       end


### PR DESCRIPTION
HPE Comware Release 3208 (v7.1) doesnt accept the xtd-cli-mode on as it has "too many parameters" removing the on will allow it to work.
I suspect the post login on this section needs better logic.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
