### PR TITLE
Delete Reboot Time and Cause line in aosw.rb

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -40,6 +40,7 @@ class AOSW < Oxidized::Model
 
   cmd 'show version' do |cfg|
     cfg = cfg.each_line.reject { |line| line.match /(Switch|AP) uptime/i }
+    cfg = cfg.each_line.reject { |line| line.match /Reboot Time and Cause/i }
     rstrip_cfg comment cfg.join
   end
 


### PR DESCRIPTION
Reboot Time and Cause: AP rebooted Tue Jun 22 06:39:10 UTC 2021; CLI cmd at uptime 0D 0H 41M 48S: reload
Reboot Time and Cause: AP Reboot reason: BadPtr:0000000c PC:_raw_write_lock_bh+0x20/0x40 Wa

The above lines are examples of what we get with the "sh version" command. These lines change at every reboot of the device.
I don't think they're needed as part of the config backup.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
