### PR TITLE
OPNsense/PFsense models: Do not remove <?xml header, and add version information as comment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - xmppdiff now persists its connection to the XMPP server and MUC (@jplitza)
 - routeros no longer backups infos on available updates (@jplitza)
 - avoid /humidity hardware field in tmos (F5) to be reported (@albsga)
+- version information or OPNsense and PFsense models is now included as XML comments (@pv2b)
 
 ### Fixed
 
@@ -49,6 +50,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed ArubaOS-CX enviroment/system inconsistent values #2297 (@raunz)
 - Update AirFiber prompt regex (@murrant)
 - System time and running time are now stripped from tplink model output (@spike77453)
+- <?xml... line is no longer improperly stripped from OPNsense and PFsense backups (@pv2b)
 
 
 ## [0.28.0 - 2020-05-18]

--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -181,6 +181,24 @@ module Oxidized
       data
     end
 
+    def xmlcomment(str)
+      # XML Comments start with <!-- and end with -->
+      #
+      # Because it's illegal for the first or last characters of a comment
+      # to be a -, i.e. <!--- or ---> are illegal, and also to improve
+      # readability, we add extra spaces after and before the beginning
+      # and end of comment markers.
+      #
+      # Also, XML Comments must not contain --. So we put a space between
+      # any double hyphens, by replacing any - that is followed by another -
+      # with '- '
+      data = ''
+      str.each_line do |line|
+        data << '<!-- ' << str.gsub(/-(?=-)/, '- ').chomp << " -->\n"
+      end
+      data
+    end
+
     def screenscrape
       @input.class.to_s.match(/Telnet/) || vars(:ssh_no_exec)
     end

--- a/lib/oxidized/model/opnsense.rb
+++ b/lib/oxidized/model/opnsense.rb
@@ -2,24 +2,6 @@ class OpnSense < Oxidized::Model
   # minimum required permissions: "System: Shell account access"
   # must enable SSH and password-based SSH access
 
-  def xmlcomment(str)
-    # XML Comments start with <!-- and end with -->
-    #
-    # Because it's illegal for the first or last characters of a comment
-    # to be a -, i.e. <!--- or ---> are illegal, and also to improve
-    # readability, we add extra spaces after and before the beginning
-    # and end of comment markers.
-    #
-    # Also, XML Comments must not contain --. So we put a space between
-    # any double hyphens, by replacing any - that is followed by another -
-    # with '- '
-    data = ''
-    str.each_line do |line|
-      data << '<!-- ' << str.gsub(/-(?=-)/, '- ').chomp << " -->\n"
-    end
-    data
-  end
-
   cmd 'cat /conf/config.xml' do |cfg|
     cfg.gsub! /\s<revision>\s*<time>\d*<\/time>\s*.*\s*.*\s*<\/revision>/, ''
     cfg.gsub! /\s<last_rule_upd_time>\d*<\/last_rule_upd_time>/, ''

--- a/lib/oxidized/model/opnsense.rb
+++ b/lib/oxidized/model/opnsense.rb
@@ -2,10 +2,40 @@ class OpnSense < Oxidized::Model
   # minimum required permissions: "System: Shell account access"
   # must enable SSH and password-based SSH access
 
+  def xmlcomment(str)
+    # XML Comments start with <!-- and end with -->
+    #
+    # Because it's illegal for the first or last characters of a comment
+    # to be a -, i.e. <!--- or ---> are illegal, and also to improve
+    # readability, we add extra spaces after and before the beginning
+    # and end of comment markers.
+    #
+    # Also, XML Comments must not contain --. So we put a space between
+    # any double hyphens, by replacing any - that is followed by another -
+    # with '- '
+    data = ''
+    str.each_line do |line|
+      data << '<!-- ' << str.gsub(/-(?=-)/, '- ').chomp << " -->\n"
+    end
+    data
+  end
+
   cmd 'cat /conf/config.xml' do |cfg|
     cfg.gsub! /\s<revision>\s*<time>\d*<\/time>\s*.*\s*.*\s*<\/revision>/, ''
     cfg.gsub! /\s<last_rule_upd_time>\d*<\/last_rule_upd_time>/, ''
     cfg
+  end
+
+  # The comment output has to be at the end since and XML file may not start
+  # with a comment.
+
+  # This gets the version using the opnsense-version command, or from the
+  # /usr/local/opnsense/version/opnsense file for earlier versions of OPNsense
+  # that lack the opnsense-version command. Newer versions of OPNsense no longer
+  # store the version information in this file, so both versions have to be
+  # supported here for now.
+  cmd 'opnsense-version 2>/dev/null || echo "OPNsense "`cat /usr/local/opnsense/version/opnsense`' do |version|
+    xmlcomment version
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/opnsense.rb
+++ b/lib/oxidized/model/opnsense.rb
@@ -2,10 +2,6 @@ class OpnSense < Oxidized::Model
   # minimum required permissions: "System: Shell account access"
   # must enable SSH and password-based SSH access
 
-  cmd :all do |cfg|
-    cfg.cut_head
-  end
-
   cmd 'cat /conf/config.xml' do |cfg|
     cfg.gsub! /\s<revision>\s*<time>\d*<\/time>\s*.*\s*.*\s*<\/revision>/, ''
     cfg.gsub! /\s<last_rule_upd_time>\d*<\/last_rule_upd_time>/, ''

--- a/lib/oxidized/model/pfsense.rb
+++ b/lib/oxidized/model/pfsense.rb
@@ -1,6 +1,24 @@
 class PfSense < Oxidized::Model
   # use other use than 'admin' user, 'admin' user cannot get ssh/exec. See issue #535
 
+  def xmlcomment(str)
+    # XML Comments start with <!-- and end with -->
+    #
+    # Because it's illegal for the first or last characters of a comment
+    # to be a -, i.e. <!--- or ---> are illegal, and also to improve
+    # readability, we add extra spaces after and before the beginning
+    # and end of comment markers.
+    #
+    # Also, XML Comments must not contain --. So we put a space between
+    # any double hyphens, by replacing any - that is followed by another -
+    # with '- '
+    data = ''
+    str.each_line do |line|
+      data << '<!-- ' << str.gsub(/-(?=-)/, '- ').chomp << " -->\n"
+    end
+    data
+  end
+
   cmd :secret do |cfg|
     cfg.gsub! /(\s+<bcrypt-hash>).+?(<\/bcrypt-hash>)/, '\\1<secret hidden>\\2'
     cfg.gsub! /(\s+<password>).+?(<\/password>)/, '\\1<secret hidden>\\2'
@@ -12,6 +30,13 @@ class PfSense < Oxidized::Model
     cfg.gsub! /\s<revision>\s*<time>\d*<\/time>\s*.*\s*.*\s*<\/revision>/, ''
     cfg.gsub! /\s<last_rule_upd_time>\d*<\/last_rule_upd_time>/, ''
     cfg
+  end
+
+  # The comment output has to be at the end since and XML file may not start
+  # with a comment.
+
+  cmd 'cat /etc/version' do |version|
+    xmlcomment "PFsense #{version}"
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/pfsense.rb
+++ b/lib/oxidized/model/pfsense.rb
@@ -1,10 +1,6 @@
 class PfSense < Oxidized::Model
   # use other use than 'admin' user, 'admin' user cannot get ssh/exec. See issue #535
 
-  cmd :all do |cfg|
-    cfg.cut_head
-  end
-
   cmd :secret do |cfg|
     cfg.gsub! /(\s+<bcrypt-hash>).+?(<\/bcrypt-hash>)/, '\\1<secret hidden>\\2'
     cfg.gsub! /(\s+<password>).+?(<\/password>)/, '\\1<secret hidden>\\2'

--- a/lib/oxidized/model/pfsense.rb
+++ b/lib/oxidized/model/pfsense.rb
@@ -1,24 +1,6 @@
 class PfSense < Oxidized::Model
   # use other use than 'admin' user, 'admin' user cannot get ssh/exec. See issue #535
 
-  def xmlcomment(str)
-    # XML Comments start with <!-- and end with -->
-    #
-    # Because it's illegal for the first or last characters of a comment
-    # to be a -, i.e. <!--- or ---> are illegal, and also to improve
-    # readability, we add extra spaces after and before the beginning
-    # and end of comment markers.
-    #
-    # Also, XML Comments must not contain --. So we put a space between
-    # any double hyphens, by replacing any - that is followed by another -
-    # with '- '
-    data = ''
-    str.each_line do |line|
-      data << '<!-- ' << str.gsub(/-(?=-)/, '- ').chomp << " -->\n"
-    end
-    data
-  end
-
   cmd :secret do |cfg|
     cfg.gsub! /(\s+<bcrypt-hash>).+?(<\/bcrypt-hash>)/, '\\1<secret hidden>\\2'
     cfg.gsub! /(\s+<password>).+?(<\/password>)/, '\\1<secret hidden>\\2'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
This PR does a two things:

1. There was an issue where the OPNsense and PFsense models would chop off the first line of the config file containing an <?xml... header. This is unneccessary and might cause issues, and was probably left in unintentionally, so I removed this.
2. Added functionality to OPNsense and PFsense models to gather version information and put it into a comment.
3. Refactors the "xmlcomment" function added in step 2 into model.rb, since it's probably useful to other models, and it's really messy to keep it in the opnsense and pfsense models.