### PR TITLE
Fix sensitive configuration backup on Mikrotik RouterOs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Add show-sensitive flag on export command on Mikrotik RouterOS when remove_secret is off (@kedare)
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support
 - change pfSense secret scrubbing to handle new format in 2.4.5+
 - Dockerfile rebased to phusion/baseimage-docker bionic-1.0.0

--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -25,7 +25,7 @@ class RouterOS < Oxidized::Model
   end
 
   post do
-    run_cmd = vars(:remove_secret) ? '/export hide-sensitive' : '/export'
+    run_cmd = vars(:remove_secret) ? '/export hide-sensitive' : '/export show-sensitive'
     cmd run_cmd do |cfg|
       cfg.gsub! /\\\r?\n\s+/, '' # strip new line
       cfg.gsub! /# inactive time\r\n/, '' # Remove time based system comment


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`) (N/A, no code change)
- [x] Tests added or adapted (try `rake test`) (N/A, no code change)
- [x] Changes are reflected in the documentation (N/A, no code change)
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
The current code for sensitive backup on Mikrotik is not working,
To enable exporting sensitive data like SNMP credentials or others, you need to add the `show-sensitive` flag to the export command, without it, it is the same as with the `hide-sensitive` flagged export

Close issue #1976 
