### PR TITLE
reject "Power Usage:" in fabricos showconfig

### DIFF
--- a/lib/oxidized/model/fabricos.rb
+++ b/lib/oxidized/model/fabricos.rb
@@ -6,7 +6,7 @@ class FabricOS < Oxidized::Model
   comment '# '
 
   cmd 'chassisShow' do |cfg|
-    comment cfg.each_line.reject { |line| line.match(/Time Awake:/) || line.match(/Power Usage \(Watts\):/) || line.match(/Time Alive:/) || line.match(/Update:/) }.join
+    comment cfg.each_line.reject { |line| line.match(/Time Awake:/) || line.match(/Power Usage \(Watts\):/) || line.match(/Power Usage:/) || line.match(/Time Alive:/) || line.match(/Update:/) }.join
   end
 
   cmd 'configShow -all' do |cfg|


### PR DESCRIPTION
reject "Power Usage:" in fabricos showconfig

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
reject "Power Usage:" in fabricos showconfig