### PR TITLE
Add bdcom driver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- model for bdcom-based fiberstore switches (@candlerb)
 - enterasys800 model for enterasys 800-series fe/ge switches (@javichumellamo)
 - add ES3526XA-V2 support in EdgeCOS model (@moisseev)
 - model for eltex mes-series switches (@glaubway)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -36,6 +36,15 @@
 * Avaya
   * [VOSS (VSP Operating System Software)](/lib/oxidized/model/voss.rb)
   * [BOSS (Baystack Operating System Software)](/lib/oxidized/model/boss.rb)
+* BDCOM
+  * [S2200 series](/lib/oxidized/model/bdcom.rb)
+  * [S2200PB series](/lib/oxidized/model/bdcom.rb)
+  * [S2200-B series](/lib/oxidized/model/bdcom.rb)
+  * [S2500-B series](/lib/oxidized/model/bdcom.rb)
+  * [S2500-C series](/lib/oxidized/model/bdcom.rb)
+  * [S2500PB series](/lib/oxidized/model/bdcom.rb)
+  * [S2500-P series](/lib/oxidized/model/bdcom.rb)
+  * [S2900 series](/lib/oxidized/model/bdcom.rb)
 * Brocade
   * [FabricOS](/lib/oxidized/model/fabricos.rb)
   * [FastIron](/lib/oxidized/model/fastiron.rb)
@@ -114,6 +123,7 @@
 * Fiberstore
   * [S3800](/lib/oxidized/model/gcombnps.rb)
   * [S3900](/lib/oxidized/model/edgecos.rb)
+  * [S3900-R](/lib/oxidized/model/bdcom.rb)
   * [S5800](/lib/oxidized/model/cnos.rb)
   * [S5850](/lib/oxidized/model/cnos.rb)
 * Firebrick

--- a/lib/oxidized/model/bdcom.rb
+++ b/lib/oxidized/model/bdcom.rb
@@ -1,0 +1,49 @@
+class BDCOM < Oxidized::Model
+  comment '! '
+
+  cmd :secret do |cfg|
+    cfg.gsub!(/password \d+ (\S+).*/, '<secret removed>')
+    cfg.gsub!(/community (\S+)/, 'community <hidden>')
+    cfg
+  end
+
+  cmd :all do |cfg|
+    cfg.each_line.to_a[0..-2].join
+  end
+
+  cmd 'show running-config'
+
+  cmd 'show version' do |cfg|
+    cfg.gsub! /(\s*uptime is\s*)[0-9:]+/, '\1 <removed>'
+    cfg.gsub! /(\s*current time:\s*)[0-9-]+\s+[0-9:]+/, '\1 <removed>'
+    cfg.gsub! /(\s*at)\s+[0-9-]+\s+[0-9:]+(,\s*uptime\s+[0-9:]+)?/, '\1 <removed>'
+    comment cfg
+  end
+
+  cmd 'show power-status' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show fan-status' do |cfg|
+    comment cfg
+  end
+
+  cfg :telnet do
+    username /^Username:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    post_login do
+      if vars(:enable) == true
+        cmd "enable"
+      elsif vars(:enable)
+        cmd "enable", /^[pP]assword:/
+        cmd vars(:enable)
+      end
+    end
+
+    post_login 'terminal length 0'
+    pre_logout 'exit'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Add bdcom.rb driver

Tested with Fiberstore S3900-48T6S-R

See also PR #1855