### PR TITLE
Output for Power Usage has changed [FabricOS]

### DIFF
--- a/lib/oxidized/model/fabricos.rb
+++ b/lib/oxidized/model/fabricos.rb
@@ -6,7 +6,7 @@ class FabricOS < Oxidized::Model
   comment '# '
 
   cmd 'chassisShow' do |cfg|
-    comment cfg.each_line.reject { |line| line.match(/Time Awake:/) || line.match(/Power Usage \(Watts\):/) || line.match(/Time Alive:/) || line.match(/Update:/) }.join
+    comment cfg.each_line.reject { |line| line.match(/Time Awake:/) || line.match(/Power Usage \(Watts\):/) || line.match(/Power Usage:/) || line.match(/Time Alive:/) || line.match(/Update:/) }.join
   end
 
   cmd 'configShow -all' do |cfg|


### PR DESCRIPTION
## Description
In FabricOS v8 => the output for Power Usage has changed to `Power Usage:` instead of `Power Usage (Watts):`.
Adding `Power Usage:` to excluded lines to get rid of continues config changes when power draw on device changes.

Change is verified working on FabricOS v8 and v9 devices (8.2.2b & 9.0.1b4).