### PR TITLE
Correct login process for FortiOS based devices

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -63,7 +63,7 @@ class FortiOS < Oxidized::Model
   end
 
   cfg :telnet do
-    username /login:/
+    username /^Login:/
     password /^Password:/
   end
 


### PR DESCRIPTION
Unable to connect into Fortigate FW due to a missed caracters

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation - N/A
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
I add some "^L" on line 66
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
