### PR TITLE
Adds support for NEC IX devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for zte c300 and c320 olt (@glaubway)
 - model for LANCOM (@systeembeheerder)
 - model for Aruba CX switches (@jmurphy5)
+- model for NEC IX devices (@mikenowak)
 
 ### Changed
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -163,6 +163,8 @@
 * MRV
   * [MasterOS](/lib/oxidized/model/masteros.rb)
   * [FiberDriver](/lib/oxidized/model/fiberdriver.rb)
+* NEC
+  * [NEC IX](/lib/oxidized/model/necix.rb)
 * Netgear
   * [Netgear switches](/lib/oxidized/model/netgear.rb)
 * Netonix

--- a/lib/oxidized/model/necix.rb
+++ b/lib/oxidized/model/necix.rb
@@ -1,0 +1,30 @@
+class NecIX < Oxidized::Model
+  prompt /^(\([\w.-]*\)\s[#$]|^\S+[$#]\s?)$/
+  comment '! '
+  expect /^--More--$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg = cfg.each_line.to_a[3..-2].join
+    cfg.gsub! /^.*Current time.*$/, ''
+    cfg
+  end
+
+  cfg :telnet do
+    username /^Username:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    post_login do
+      send "configure\n"
+    end
+
+    pre_logout do
+      send "\cZ"
+      send "exit\n"
+    end
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`) N/A I beleive
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Adds support for NEC IX devices.

