### PR TITLE
Fix rubocop by removing trailing whitespace

### DIFF
--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -45,7 +45,7 @@ class Comware < Oxidized::Model
         cmd 'xtd-cli-mode on', /(#{@node.prompt}|Continue)/
         cmd 'y', /(#{@node.prompt}|input password)/
         cmd vars(:comware_cmdline)
-        
+
         # HP V1950 OS r3208 (v7.1)
         cmd 'xtd-cli-mode', /(#{@node.prompt}|Continue)/
         cmd 'y', /(#{@node.prompt}|input password)/


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Another fix by removing trailing whitespace. Now at least locally it passes.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
