### PR TITLE
xmppdiff: Persist connection to XMPP server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - improved Telnet support for enterasys (@jplitza)
 - Include "show version" output for enterasys (@jplitza)
 - xmppdiff now also shows diffs with only removed or only added lines (@jplitza)
+- xmppdiff now persists its connection to the XMPP server and MUC (@jplitza)
 
 ### Fixed
 

--- a/lib/oxidized/hook/xmppdiff.rb
+++ b/lib/oxidized/hook/xmppdiff.rb
@@ -2,6 +2,44 @@ require 'xmpp4r'
 require 'xmpp4r/muc/helper/simplemucclient'
 
 class XMPPDiff < Oxidized::Hook
+  def connect
+    @client = Jabber::Client.new(Jabber::JID.new(cfg.jid))
+
+    log "Connecting to XMPP"
+    begin
+      Timeout.timeout(15) do
+        begin
+          @client.connect
+        rescue StandardError => e
+          log "Failed to connect to XMPP: #{e}"
+        end
+        sleep 1
+
+        log "Authenticating to XMPP"
+        @client.auth(cfg.password)
+        sleep 1
+
+        log "Connected to XMPP"
+
+        @muc = Jabber::MUC::SimpleMUCClient.new(@client)
+        @muc.join(cfg.channel + "/" + cfg.nick)
+
+        log "Joined #{cfg.channel}"
+      end
+    rescue Timeout::Error
+      log "timed out"
+      @client = nil
+      @muc = nil
+    end
+
+    @client.on_exception do
+      log "XMPP connection aborted, reconnecting"
+      @client = nil
+      @muc = nil
+      connect
+    end
+  end
+
   def validate_cfg!
     raise KeyError, 'hook.jid is required' unless cfg.has_key?('jid')
     raise KeyError, 'hook.password is required' unless cfg.has_key?('password')
@@ -23,31 +61,15 @@ class XMPPDiff < Oxidized::Hook
         end
 
         if interesting
-          log "Connecting to XMPP"
-          client = Jabber::Client.new(Jabber::JID.new(cfg.jid))
-          client.connect
-          sleep 1
-          client.auth(cfg.password)
-          sleep 1
+          connect if @muc.nil?
 
-          log "Connected"
+          # Maybe connecting failed, so only proceed if we actually joined the MUC
+          unless @muc.nil?
+            title = "#{ctx.node.name} #{ctx.node.group} #{ctx.node.model.class.name.to_s.downcase}"
+            log "Posting diff as snippet to #{cfg.channel}"
 
-          m = Jabber::MUC::SimpleMUCClient.new(client)
-          m.join(cfg.channel + "/" + cfg.nick)
-
-          log "Joined"
-
-          title = "#{ctx.node.name} #{ctx.node.group} #{ctx.node.model.class.name.to_s.downcase}"
-          log "Posting diff as snippet to #{cfg.channel}"
-
-          m.say(title + "\n\n" + diff[:patch].lines.to_a[4..-1].join)
-
-          sleep 1
-
-          client.close
-
-          log "Finished"
-
+            @muc.say(title + "\n\n" + diff[:patch].lines.to_a[4..-1].join)
+          end
         end
       end
     rescue Timeout::Error


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Instead of doing (connect, join, post, leave, disconnect) for each change, xmppdiff now stays connected to the server and joined to the MUC after the first change it posted.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
