### PR TITLE
tplink: Strip 'System Time' and 'Running Time'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - filter next periodic save schedule time in xos model output (@sargon)
 - fixed ArubaOS-CX enviroment/system inconsistent values #2297 (@raunz)
 - Update AirFiber prompt regex (@murrant)
+- System time and running time are now stripped from tplink model output (@spike77453)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -35,6 +35,8 @@ class TPLink < Oxidized::Model
   end
 
   cmd 'show system-info' do |cfg|
+    cfg.gsub! /(System Time\s+-).*/, '\\1 <stripped>'
+    cfg.gsub! /(Running Time\s+-).*/, '\\1 <stripped>'
     comment cfg.each_line.to_a[3..-3].join
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
This strips the timestamps 'System Time' and 'Running Time' from the output of 'show system-info'.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
