### PR TITLE
routeros: /export params depending on version

### DIFF
--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -29,10 +29,12 @@ class RouterOS < Oxidized::Model
 
   post do
     Oxidized.logger.debug "lib/oxidized/model/routeros.rb: running /export for routeros version #{@ros_version}"
-    run_cmd = if @ros_version >= 7
-                vars(:remove_secret) ? '/export hide-sensitive' : '/export show-sensitive'
+    run_cmd = if vars(:remove_secret)
+                '/export hide-sensitive'
+              elsif (not @ros_version.nil?) && (@ros_version >= 7)
+                '/export show-sensitive'
               else
-                vars(:remove_secret) ? '/export hide-sensitive' : '/export'
+                '/export'
               end
     cmd run_cmd do |cfg|
       cfg.gsub! /\\\r?\n\s+/, '' # strip new line


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fix Mikrotik Routeros Backups being empty for routeros versions <7.

Closes issue #2427
