### PR TITLE
routeros: Reduce metadata/version output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Include "show version" output for enterasys (@jplitza)
 - xmppdiff now also shows diffs with only removed or only added lines (@jplitza)
 - xmppdiff now persists its connection to the XMPP server and MUC (@jplitza)
+- routeros no longer backups infos on available updates (@jplitza)
 
 ### Fixed
 

--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -13,14 +13,14 @@ class RouterOS < Oxidized::Model
   end
 
   cmd '/system routerboard print without-paging' do |cfg|
+    cfg = cfg.each_line.grep(/(model|firmware-type|current-firmware|serial-number):/).join
     comment cfg
   end
 
   cmd '/system package update print without-paging' do |cfg|
-    cfg.split("\n").each do |line|
-      @ros_version = Regexp.last_match(1).to_i if line =~ /installed-version: ([0-9])/
-    end
-    comment cfg
+    version_line = cfg.each_line.grep(/installed-version: /)[0]
+    comment version_line
+    @ros_version = /: ([0-9])/.match(version_line)[1].to_i
   end
 
   cmd '/system history print without-paging' do |cfg|
@@ -41,6 +41,8 @@ class RouterOS < Oxidized::Model
       cfg.gsub! /# inactive time\r\n/, '' # Remove time based system comment
       cfg.gsub! /# received packet from \S+ bad format\r\n/, '' # Remove intermittent VRRP/CARP collision comment
       cfg.gsub! /# poe-out status: short_circuit\r\n/, '' # Remove intermittent POE short_circuit comment
+      cfg.gsub! /# Firmware upgraded successfully, please reboot for changes to take effect!\r\n/, '' # Remove transient firmware upgrade comment
+      cfg.gsub! /# \S+ not ready\r\n/, '' # Remove intermittent $interface not ready comment
       cfg = cfg.split("\n").reject { |line| line[/^#\s\w{3}\/\d{2}\/\d{4}.*$/] }
       cfg.join("\n") + "\n"
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Once you execute `/system package update check-for-updates`, the information about available updates is included in the output.

Diff of output header:
```diff
-#                 ;;; Firmware upgraded successfully, please reboot for changes 
-#                     to take effect!
-#        routerboard: yes
 #              model: CCR1009-7G-1C-1S+
 #      serial-number: XXXXXXXXXXXX
 #      firmware-type: tilegx
-#   factory-firmware: 3.39
 #   current-firmware: 6.48.2
-#   upgrade-firmware: 6.47.9
-# 
-#             channel: long-term
 #   installed-version: 6.47.9
-#      latest-version: 6.48.5
-#              status: New version is available
-# 
 # Flags: U - undoable, R - redoable, F - floating-undo 
 #   ACTION                                   BY               POLICY             
```

This PR is based in #2435, since it's related.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
