### PR TITLE
Support for new platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for Ubiquiti UFiber v3 (@baldoarturo)
 - model for Dell Networking N Series (@baldoarturo)
 - model for Dell Networking EMC OS9 devices (@baldoarturo)
+- model for Zyxel OLTs series 1300 devices (@baldoarturo)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for Aruba CX switches (@jmurphy5)
 - model for NEC IX devices (@mikenowak)
 - Added docs for Dell/EMC Networking OS10 devices (@davromaniak)
+- model for Ubiquiti UFiber v3 (@baldoarturo)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added docs for Dell/EMC Networking OS10 devices (@davromaniak)
 - model for Ubiquiti UFiber v3 (@baldoarturo)
 - model for Dell Networking N Series (@baldoarturo)
+- model for Dell Networking EMC OS9 devices (@baldoarturo)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for NEC IX devices (@mikenowak)
 - Added docs for Dell/EMC Networking OS10 devices (@davromaniak)
 - model for Ubiquiti UFiber v3 (@baldoarturo)
+- model for Dell Networking N Series (@baldoarturo)
 
 ### Changed
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -91,6 +91,7 @@
   * [PowerConnect](/lib/oxidized/model/powerconnect.rb)
   * [AOSW](/lib/oxidized/model/aosw.rb)
   * [DellX](/lib/oxidized/model/dellx.rb)
+  * [Dell EMC Networking OS9](/lib/oxidized/model/os9.rb)
   * [Dell EMC Networking OS10](/lib/oxidized/model/os10.rb)
   * [Dell Networking N Series](/lib/oxidized/model/nseries.rb)
 * D-Link

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -221,6 +221,7 @@
   * [Edgeos](/lib/oxidized/model/edgeos.rb)
   * [EdgeSwitch](/lib/oxidized/model/edgeswitch.rb)
   * [AirFiber](/lib/oxidized/model/airfiber.rb)
+  * [Ufiber](/lib/oxidized/model/ufiber.rb)
 * VMWare
   * [NSX Edge (configuration)](/lib/oxidized/model/nsxconfig.rb)
   * [NSX Edge (firewall rules)](/lib/oxidized/model/nsxfirewall.rb)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -239,3 +239,4 @@
   * [ZyNOS](/lib/oxidized/model/zynos.rb)
   * [ZyNOS GS-series variant](/lib/oxidized/model/zynosgs.rb)
   * [NDMS](/lib/oxidized/model/ndms.rb)
+  * [OLTs series 1300](/lib/oxidized/model/zy1300.rb)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -92,6 +92,7 @@
   * [AOSW](/lib/oxidized/model/aosw.rb)
   * [DellX](/lib/oxidized/model/dellx.rb)
   * [Dell EMC Networking OS10](/lib/oxidized/model/os10.rb)
+  * [Dell Networking N Series](/lib/oxidized/model/nseries.rb)
 * D-Link
   * [D-Link](/lib/oxidized/model/dlink.rb)
 * ECI Telecom

--- a/lib/oxidized/model/nseries.rb
+++ b/lib/oxidized/model/nseries.rb
@@ -1,0 +1,30 @@
+# Dell N Series
+class NSeries < Oxidized::Model
+	# Dell N Series
+
+	prompt /^([\w.@()-]+[#>]\s?)$/
+	comment '! '
+
+	cmd 'show version' do |cfg|
+		comment cfg
+	end
+
+	cmd 'show running-config'
+
+	cmd :all do |cfg|
+		cfg.lines.to_a[2..-2].join
+	end
+
+	cfg :telnet, :ssh do
+		if vars :enable
+			post_login do
+				send "enable\n"
+				cmd vars(:enable)
+			end
+		end
+		post_login 'terminal length 0'
+		pre_logout 'exit'
+		pre_logout 'exit'
+	end
+
+end

--- a/lib/oxidized/model/nseries.rb
+++ b/lib/oxidized/model/nseries.rb
@@ -1,30 +1,35 @@
 # Dell N Series
 class NSeries < Oxidized::Model
-	# Dell N Series
+  # Dell N Series
 
-	prompt /^([\w.@()-]+[#>]\s?)$/
-	comment '! '
+  prompt /^([\w.@()-]+[#>]\s?)$/
+  comment '! '
 
-	cmd 'show version' do |cfg|
-		comment cfg
-	end
+  cmd 'show version' do |cfg|
+    comment cfg
+  end
 
-	cmd 'show running-config'
+  cmd 'show running-config'
 
-	cmd :all do |cfg|
-		cfg.lines.to_a[2..-2].join
-	end
+  cmd :all do |cfg|
+    cfg.lines.to_a[2..-2].join
+  end
 
-	cfg :telnet, :ssh do
-		if vars :enable
-			post_login do
-				send "enable\n"
-				cmd vars(:enable)
-			end
-		end
-		post_login 'terminal length 0'
-		pre_logout 'exit'
-		pre_logout 'exit'
-	end
+  cmd :secret do |cfg|
+    cfg.gsub! /^(username \S+ password (?:encrypted )?)\S+(.*)/, '\1<hidden>\2'
+    cfg
+  end
+  
+  cfg :telnet, :ssh do
+    if vars :enable
+      post_login do
+        send "enable\n"
+        cmd vars(:enable)
+      end
+    end
+    post_login 'terminal length 0'
+    pre_logout 'exit'
+    pre_logout 'exit'
+  end
 
 end

--- a/lib/oxidized/model/nseries.rb
+++ b/lib/oxidized/model/nseries.rb
@@ -19,7 +19,7 @@ class NSeries < Oxidized::Model
     cfg.gsub! /^(username \S+ password (?:encrypted )?)\S+(.*)/, '\1<hidden>\2'
     cfg
   end
-  
+
   cfg :telnet, :ssh do
     if vars :enable
       post_login do
@@ -31,5 +31,4 @@ class NSeries < Oxidized::Model
     pre_logout 'exit'
     pre_logout 'exit'
   end
-
 end

--- a/lib/oxidized/model/os9.rb
+++ b/lib/oxidized/model/os9.rb
@@ -1,0 +1,40 @@
+# For switches running Dell EMC Networking OS9 #
+class OS9 < Oxidized::Model
+  # For switches running Dell EMC Networking OS9 #
+  #
+  # Tested with : Dell S4048F-ON
+
+  comment  '! '
+
+  cmd :all do |cfg|
+    cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
+    cfg.each_line.to_a[2..-2].join
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /(password )(\S+)/, '\1<secret hidden>'
+    cfg
+  end
+
+  cmd 'show inventory' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show inventory media' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg.each_line.to_a[3..-1].join
+  end
+
+  cfg :telnet do
+    username /^Login:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    post_login 'terminal length 0'
+    pre_logout 'exit'
+  end
+end

--- a/lib/oxidized/model/ufiber.rb
+++ b/lib/oxidized/model/ufiber.rb
@@ -4,17 +4,18 @@ class UFiber < Oxidized::Model
   prompt /.+@.+:~\$\s/
 
   cmd 'cat /tmp/config'
+  cmd 'rm /tmp/config'
 
   cmd :all do |cfg|
-    cfg.lines.to_a[1..-2].join
+    cfg.lines.to_a[1..-3].join
   end
 
   cfg :ssh do
-    post_login "curl -s --output /dev/null --location --insecure '\
-                '--data '\
-                'username=#{@node.auth[:username]}&'\
-                'password=#{@node.auth[:password]} '\
-                '--cookie-jar /tmp/cookies https://localhost"
+    post_login 'curl -s --output /dev/null --location --insecure '\
+                '--data \''\
+                "username=#{@node.auth[:username]}&" \
+                "password=#{@node.auth[:password]}' " \
+                '--cookie-jar /tmp/cookies https://localhost'
     post_login 'curl -s --output /dev/null --location --insecure '\
                 '--cookie /tmp/cookies '\
                 'https://localhost/api/edge/config/save.json'

--- a/lib/oxidized/model/ufiber.rb
+++ b/lib/oxidized/model/ufiber.rb
@@ -1,18 +1,27 @@
+# UFiber #
 class UFiber < Oxidized::Model
-    
-    prompt /.+@.+:~\$/
-    
-    cmd 'cat /tmp/config'
 
-    cmd :all do |cfg|
-        cfg.lines.to_a[1..-2].join
-    end
-    
-    cfg :ssh do 
-        post_login "curl -s --output /dev/null --location --insecure --data 'username=#{@node.auth[:username]}&password=#{@node.auth[:password]}' --cookie-jar /tmp/cookies https://localhost"
-        post_login "curl -s --output /dev/null --location --insecure --cookie /tmp/cookies https://localhost/api/edge/config/save.json"
-        post_login "curl -s --location --insecure --cookie /tmp/cookies https://localhost/files/config/ | base64 > /tmp/config"
-        pre_logout 'exit'
-    end 
- 
+  prompt /.+@.+:~\$\s/
+
+  cmd 'cat /tmp/config'
+
+  cmd :all do |cfg|
+    cfg.lines.to_a[1..-2].join
+  end
+
+  cfg :ssh do
+    post_login "curl -s --output /dev/null --location --insecure '\
+                '--data '\
+                'username=#{@node.auth[:username]}&'\
+                'password=#{@node.auth[:password]} '\
+                '--cookie-jar /tmp/cookies https://localhost"
+    post_login 'curl -s --output /dev/null --location --insecure '\
+                '--cookie /tmp/cookies '\
+                'https://localhost/api/edge/config/save.json'
+    post_login 'curl -s --location --insecure '\
+                '--cookie /tmp/cookies '\
+                'https://localhost/files/config/ '\
+                '| base64 > /tmp/config'
+    pre_logout 'exit'
+  end
 end

--- a/lib/oxidized/model/ufiber.rb
+++ b/lib/oxidized/model/ufiber.rb
@@ -1,6 +1,6 @@
 # UFiber #
 class UFiber < Oxidized::Model
-# UFiber #
+  # UFiber #
   prompt /.+@.+:~\$\s/
 
   cmd 'cat /tmp/config'

--- a/lib/oxidized/model/ufiber.rb
+++ b/lib/oxidized/model/ufiber.rb
@@ -1,0 +1,18 @@
+class UFiber < Oxidized::Model
+    
+    prompt /.+@.+:~\$/
+    
+    cmd 'cat /tmp/config'
+
+    cmd :all do |cfg|
+        cfg.lines.to_a[1..-2].join
+    end
+    
+    cfg :ssh do 
+        post_login "curl -s --output /dev/null --location --insecure --data 'username=#{@node.auth[:username]}&password=#{@node.auth[:password]}' --cookie-jar /tmp/cookies https://localhost"
+        post_login "curl -s --output /dev/null --location --insecure --cookie /tmp/cookies https://localhost/api/edge/config/save.json"
+        post_login "curl -s --location --insecure --cookie /tmp/cookies https://localhost/files/config/ | base64 > /tmp/config"
+        pre_logout 'exit'
+    end 
+ 
+end

--- a/lib/oxidized/model/ufiber.rb
+++ b/lib/oxidized/model/ufiber.rb
@@ -1,6 +1,6 @@
 # UFiber #
 class UFiber < Oxidized::Model
-
+# UFiber #
   prompt /.+@.+:~\$\s/
 
   cmd 'cat /tmp/config'

--- a/lib/oxidized/model/zy1300.rb
+++ b/lib/oxidized/model/zy1300.rb
@@ -1,0 +1,12 @@
+# For Zyxel OLTs series 1300
+class Zy1300 < Oxidized::Model
+  # For Zyxel OLTs series 1300
+
+  cmd '/config_OLT-1308S-22.log'
+  cfg :http do
+    @username = @node.auth[:username]
+    @password = @node.auth[:password]
+    @secure = false
+  end
+
+end

--- a/lib/oxidized/model/zy1300.rb
+++ b/lib/oxidized/model/zy1300.rb
@@ -8,5 +8,4 @@ class Zy1300 < Oxidized::Model
     @password = @node.auth[:password]
     @secure = false
   end
-
 end


### PR DESCRIPTION
## Description
<!-- Describe your changes here. -->
**Model for Ubiquiti UFiber OLTs**

Those hosts execute Ubiquiti EdgeOS inside, but they keep part of the config on separate files in the filesystem.
Most of the config is done (and pulled) via HTTP.
There is an HTTP endpoint which downloads a config backup, in a tar.gz file

So, I know I can do something like this, manually:

To login:
`curl -s --output /dev/null --location --insecure --data 'username=myusername&password=mypassword' --cookie-jar /tmp/cookies https://hostname`
I saved cookies in /tmp/cookies

To request the device to generate a config backup
`curl --location --insecure --cookie /tmp/cookies https://hostname/api/edge/config/save.json`

To actually pull that config backup
`curl -s --location --insecure --cookie /tmp/cookies --output /tmp/hostname.tar.gz https://#{@node.ip}/files/config/`

This curl is executed locally on the OLT in case you are filtering remote HTTP
The output is encoded on base64 as this device backups on .tar.gz files

**Dell N Series Switches**
They are Cisco-alike, but the ios module pulls propietary info, I did a new one based on it

**Dell EMC OS9**
They are EMS OS10, but the OS10 module pulls platform specific info, and there is no enable on this OS, I did a new one based on it

**Zyxel OLT Series 1300**
Plain HTTP poll, basic auth, I added the complete URL

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->


<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
