### PR TITLE
Support for Dell EMC Networking OS9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for Aruba CX switches (@jmurphy5)
 - model for NEC IX devices (@mikenowak)
 - Added docs for Dell/EMC Networking OS10 devices (@davromaniak)
+- model for Dell/EMC Networking OS9 devices (@baldoarturo)
 
 ### Changed
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -92,6 +92,7 @@
   * [AOSW](/lib/oxidized/model/aosw.rb)
   * [DellX](/lib/oxidized/model/dellx.rb)
   * [Dell EMC Networking OS10](/lib/oxidized/model/os10.rb)
+  * [Dell EMC Networking OS9](/lib/oxidized/model/os9.rb)
 * D-Link
   * [D-Link](/lib/oxidized/model/dlink.rb)
 * ECI Telecom

--- a/lib/oxidized/model/os9.rb
+++ b/lib/oxidized/model/os9.rb
@@ -1,0 +1,41 @@
+# For switches running Dell EMC Networking OS9 #
+class OS9 < Oxidized::Model
+    # For switches running Dell EMC Networking OS9 #
+    #
+    # Tested with : Dell S4048F-ON
+  
+    comment  '! '
+  
+    cmd :all do |cfg|
+      cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
+      cfg.each_line.to_a[2..-2].join
+    end
+  
+    cmd :secret do |cfg|
+      cfg.gsub! /(password )(\S+)/, '\1<secret hidden>'
+      cfg
+    end
+  
+    cmd 'show inventory' do |cfg|
+      comment cfg
+    end
+  
+    cmd 'show inventory media' do |cfg|
+      comment cfg
+    end
+  
+    cmd 'show running-config' do |cfg|
+      cfg.each_line.to_a[3..-1].join
+    end
+  
+    cfg :telnet do
+      username /^Login:/
+      password /^Password:/
+    end
+  
+    cfg :telnet, :ssh do
+      post_login 'terminal length 0'
+      pre_logout 'exit'
+    end
+  end
+  

--- a/lib/oxidized/model/os9.rb
+++ b/lib/oxidized/model/os9.rb
@@ -1,41 +1,40 @@
 # For switches running Dell EMC Networking OS9 #
 class OS9 < Oxidized::Model
-    # For switches running Dell EMC Networking OS9 #
-    #
-    # Tested with : Dell S4048F-ON
-  
-    comment  '! '
-  
-    cmd :all do |cfg|
-      cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
-      cfg.each_line.to_a[2..-2].join
-    end
-  
-    cmd :secret do |cfg|
-      cfg.gsub! /(password )(\S+)/, '\1<secret hidden>'
-      cfg
-    end
-  
-    cmd 'show inventory' do |cfg|
-      comment cfg
-    end
-  
-    cmd 'show inventory media' do |cfg|
-      comment cfg
-    end
-  
-    cmd 'show running-config' do |cfg|
-      cfg.each_line.to_a[3..-1].join
-    end
-  
-    cfg :telnet do
-      username /^Login:/
-      password /^Password:/
-    end
-  
-    cfg :telnet, :ssh do
-      post_login 'terminal length 0'
-      pre_logout 'exit'
-    end
+  # For switches running Dell EMC Networking OS9 #
+  #
+  # Tested with : Dell S4048F-ON
+
+  comment  '! '
+
+  cmd :all do |cfg|
+    cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
+    cfg.each_line.to_a[2..-2].join
   end
-  
+
+  cmd :secret do |cfg|
+    cfg.gsub! /(password )(\S+)/, '\1<secret hidden>'
+    cfg
+  end
+
+  cmd 'show inventory' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show inventory media' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg.each_line.to_a[3..-1].join
+  end
+
+  cfg :telnet do
+    username /^Login:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    post_login 'terminal length 0'
+    pre_logout 'exit'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Added support for Dell EMC Networking OS9. This is "cisco like" but way different from OS10, so it needed a new model.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
