### PR TITLE
Avoid /humidity hardware field to be reported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - xmppdiff now also shows diffs with only removed or only added lines (@jplitza)
 - xmppdiff now persists its connection to the XMPP server and MUC (@jplitza)
 - routeros no longer backups infos on available updates (@jplitza)
+- avoid /humidity hardware field in tmos (F5) to be reported (@albsga)
 
 ### Fixed
 

--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -18,6 +18,7 @@ class TMOS < Oxidized::Model
   cmd 'tmsh -q show sys hardware field-fmt' do |cfg|
     cfg.gsub!(/fan-speed (\S+)/, '')
     cfg.gsub!(/temperature (\S+)/, '')
+    cfg.gsub!(/humidity (\S+)/, '')
     comment cfg
   end
 


### PR DESCRIPTION
Avoid /humidity hardware field to be reported as Oxidizer is detecting as a change on the config

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Avoid /humidity hardware field to be reported as Oxidizer is detecting as a change on the config
