### PR TITLE
hpebladesystem.rb: keep dash before "Generated on"

### DIFF
--- a/lib/oxidized/model/hpebladesystem.rb
+++ b/lib/oxidized/model/hpebladesystem.rb
@@ -69,7 +69,7 @@ class HPEBladeSystem < Oxidized::Model
   end
 
   cmd 'show config' do |cfg|
-    cfg.gsub! /^#(Generated on:) .*$/, '\\1 <removed>'
+    cfg.gsub! /^(#Generated on:) .*$/, '\\1 <removed>'
     cfg.gsub /^\s+/, ''
   end
 


### PR DESCRIPTION
Without this little patch we get "Generated on: <removed>" instead of "#Generated on: <removed>"