### PR TITLE
Specify format for githubrepo's privatekey file

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -81,6 +81,9 @@ For ssh key-based authentication, it is possible to set the environment variable
 * `password`: password for repository auth.
 * `publickey`: public key file path for repository auth.
 * `privatekey`: private key file path for repository auth.
+  * NOTE: this key needs to be in the legacy PEM format, not the newer OpenSSL format [#1877](https://github.com/ytti/oxidized/issues/1877), [#2324](https://github.com/ytti/oxidized/issues/2324)
+    * To convert a key beginning with `BEGIN OPENSSH PRIVATE KEY` to the legacy PEM format, run this command:
+      `ssh-keygen -p -m PEM -f $MY_KEY_HERE`
 
 When using groups, each group must have a unique entry in the `remote_repo` config.
 


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)
  - No user-visible changes except to documentation, which I believe to be self-evident

## Description
Adds documentation about the key format required by the `githubrepo` hook's `privatekey` parameter. This does not address the underlying issue of #2324 or #1877, but it should make it more clear which key format users should use until that limitation is addressed.