### PR TITLE
Adds paging support to Enterasys B3/C3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Adds paging support to Enterasys B3/C3 (@piterpunk)
 - Allows "Username" as username prompt in Brocade ICX-series devices (@piterpunk) 
 - Add show-sensitive flag on export command on Mikrotik RouterOS when remove_secret is off (@kedare)
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support

--- a/lib/oxidized/model/enterasys.rb
+++ b/lib/oxidized/model/enterasys.rb
@@ -5,6 +5,12 @@ class Enterasys < Oxidized::Model
 
   comment  '!'
 
+  # Handle paging
+  expect /^--More--.*$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
   cmd :all do |cfg|
     cfg.each_line.to_a[2..-3].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Adds paging handler to `enterasys.rb` model

The paging prompt that I have is:
```
--More-- <space> next page, <cr> one line, <q> quit
```
But saw in some documentations `--More-- or (q)uit` or even `--More--` so I used a regexp that can handle all of them. Better safe than sorry.

Closes #2454 
