### PR TITLE
added err_type and err_reason node attr, mapped to exec hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added docs for Dell/EMC Networking OS10 devices (@davromaniak)
 - model for Zyxel 1308 OLTs (@baldoarturo)
 - model for Linksys SRW switches (@glance-)
+- Added exec hook variables to retrieve verbose node's failure reason and type
 
 ### Changed
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -36,6 +36,8 @@ OX_JOB_STATUS
 OX_JOB_TIME
 OX_REPO_COMMITREF
 OX_REPO_NAME
+OX_ERR_TYPE
+OX_ERR_REASON
 ```
 
 Exec hook recognizes the following configuration keys:

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -81,6 +81,9 @@ For ssh key-based authentication, it is possible to set the environment variable
 * `password`: password for repository auth.
 * `publickey`: public key file path for repository auth.
 * `privatekey`: private key file path for repository auth.
+  * NOTE: this key needs to be in the legacy PEM format, not the newer OpenSSL format [#1877](https://github.com/ytti/oxidized/issues/1877), [#2324](https://github.com/ytti/oxidized/issues/2324)
+    * To convert a key beginning with `BEGIN OPENSSH PRIVATE KEY` to the legacy PEM format, run this command:
+      `ssh-keygen -p -m PEM -f $MY_KEY_HERE`
 
 When using groups, each group must have a unique entry in the `remote_repo` config.
 

--- a/lib/oxidized/hook/exec.rb
+++ b/lib/oxidized/hook/exec.rb
@@ -72,7 +72,7 @@ class Exec < Oxidized::Hook
         "OX_REPO_COMMITREF" => ctx.commitref.to_s,
         "OX_REPO_NAME"      => ctx.node.repo.to_s,
         "OX_ERR_TYPE"       => ctx.node.err_type.to_s,
-        "OX_ERR_REASON"     => ctx.node.err_reason.to_s 
+        "OX_ERR_REASON"     => ctx.node.err_reason.to_s
       )
     end
     if ctx.job

--- a/lib/oxidized/hook/exec.rb
+++ b/lib/oxidized/hook/exec.rb
@@ -70,7 +70,9 @@ class Exec < Oxidized::Hook
         "OX_NODE_GROUP"     => ctx.node.group.to_s,
         "OX_NODE_MODEL"     => ctx.node.model.class.name,
         "OX_REPO_COMMITREF" => ctx.commitref.to_s,
-        "OX_REPO_NAME"      => ctx.node.repo.to_s
+        "OX_REPO_NAME"      => ctx.node.repo.to_s,
+        "OX_ERR_TYPE"       => ctx.node.err_type.to_s,
+        "OX_ERR_REASON"     => ctx.node.err_reason.to_s 
       )
     end
     if ctx.job

--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -193,7 +193,7 @@ module Oxidized
       # any double hyphens, by replacing any - that is followed by another -
       # with '- '
       data = ''
-      str.each_line do |line|
+      str.each_line do |_line|
         data << '<!-- ' << str.gsub(/-(?=-)/, '- ').chomp << " -->\n"
       end
       data

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -6,7 +6,7 @@ module Oxidized
   class ModelNotFound  < OxidizedError; end
   class Node
     attr_reader :name, :ip, :model, :input, :output, :group, :auth, :prompt, :vars, :last, :repo
-    attr_accessor :running, :user, :email, :msg, :from, :stats, :retry
+    attr_accessor :running, :user, :email, :msg, :from, :stats, :retry, :err_type, :err_reason
     alias running? running
 
     def initialize(opt)
@@ -28,6 +28,8 @@ module Oxidized
       @stats = Stats.new
       @retry = 0
       @repo = resolve_repo opt
+      @err_type = nil
+      @err_reason = nil
 
       # model instance needs to access node instance
       @model.node = self
@@ -73,6 +75,8 @@ module Oxidized
           resc  = " (rescued #{resc})"
         end
         Oxidized.logger.send(level, '%s raised %s%s with msg "%s"' % [ip, err.class, resc, err.message])
+        @err_type = err.class.to_s
+        @err_reason = err.message.to_s
         false
       rescue StandardError => err
         crashdir  = Oxidized.config.crash.directory
@@ -86,6 +90,8 @@ module Oxidized
           fh.puts err.backtrace
         end
         Oxidized.logger.error '%s raised %s with msg "%s", %s saved' % [ip, err.class, err.message, crashfile]
+        @err_type = err.class.to_s
+        @err_reason = err.message.to_s
         false
       end
     end

--- a/lib/oxidized/version.rb
+++ b/lib/oxidized/version.rb
@@ -1,6 +1,6 @@
 module Oxidized
   VERSION = '0.28.0'.freeze
-  VERSION_FULL = '0.28.0'.freeze
+  VERSION_FULL = '0.28.0-73-g39cf62b'.freeze
   def self.version_set
     version_full = %x(git describe --tags).chop rescue ""
     version      = %x(git describe --tags --abbrev=0).chop rescue ""


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Allows to get more granular information on the failure reason for a specific node when working with the exec hook.
Closes issue https://github.com/ytti/oxidized/issues/2424

