### PR TITLE
Add support for FTP into Dockerfile for APC_AOS support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,11 @@ RUN gem install aws-sdk slack-api xmpp4r cisco_spark --no-ri --no-rdoc
 # dependencies for sources
 RUN gem install gpgme sequel sqlite3 mysql2 pg --no-ri --no-rdoc
 
+# versioned dependencies related to ruby2.5
+RUN gem install io-wait:0.1.0 --no-ri --no-rdoc
+
 # dependencies for inputs
-RUN gem install net-tftp net-http-persistent mechanize --no-ri --no-rdoc
+RUN gem install net-tftp net-http-persistent mechanize net-ftp --no-ri --no-rdoc
 
 # build and install oxidized
 COPY . /tmp/oxidized/


### PR DESCRIPTION
## Pre-Request Checklist

~~[ ] Passes rubocop code analysis (try `rubocop --auto-correct`)~~ N/A
~~[ ] Tests added or adapted (try `rake test`)~~ N/A
~~[ ] Changes are reflected in the documentation~~ N/A Matches documentation now
~~[ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)~~ N/A 

## Description
Add support for Ruby net-ftp to enable APC_AOS support in the Docker image
Added a versioned dependencies section to flag ruby2.5.0 requires io-wait:0.1.0, not latest 0.2.1 (Ruby 2.6.0)

Fixes #APC_AOS Status Failed #2179 - confirmed working on two sites when adding ftp input to ./config
```
input:
  ftp:
     passive: true
```

I don't believe the tasks are relevant as no Ruby code changes were made, and the change is a packaging fix rather than a functionality change. Willing to be corrected though.