### PR TITLE
Avoid registering key/secret rotation for SNMPv3 Authentication and E…

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -24,6 +24,8 @@ class AOSW < Oxidized::Model
     cfg.gsub!(/community (\S+)$/, 'community <secret removed>')
     cfg.gsub!(/ sha (\S+)/, ' sha <secret removed>')
     cfg.gsub!(/ des (\S+)/, ' des <secret removed>')
+    cfg.gsub!(/ SHA (\S+)/, ' SHA <secret removed>')
+    cfg.gsub!(/ AES (\S+)/, ' AES <secret removed>')
     cfg.gsub!(/mobility-manager (\S+) user (\S+) (\S+)/, 'mobility-manager \1 user \2 <secret removed>')
     cfg.gsub!(/mgmt-user (\S+) (root|guest-provisioning|network-operations|read-only|location-api-mgmt) (\S+)$/, 'mgmt-user \1 \2 <secret removed>') # MAS & Wireless Controler
     cfg.gsub!(/mgmt-user (\S+) (\S+)( (read-only|guest-mgmt))?$/, 'mgmt-user \1 <secret removed> \3') # IAP


### PR DESCRIPTION
…ncryption at every Oxidized pass

Added line 27 and 28 in the attempt to avoid the recording of very key/secret rotation on the SNMPv3 command line.
Typical SNMPv3 configuration line, when configured with authPriv (both authentication and encryption) is:

snmp-server user [username] SHA [hexhexhex...hex] AES [hexhexhex...hex]

And the secrets in hex format change at every key rotation, so they are recorded as a change at every Oxidized pass.

Regards
GG

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
