### PR TITLE
Cumulus: add option to use NCLU as configuration collecting method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Cumulus: added option to use NCLU as ia collecting method
+
 ### Added
 
 - Extend http source configurations to include read_timeout value

--- a/docs/Model-Notes/Cumulus.md
+++ b/docs/Model-Notes/Cumulus.md
@@ -9,7 +9,7 @@ With the release of Cumulus Linux 3.4.0 the platform moved the routing daemon to
 A variable has been added to enable users running Cumulus Linux > 3.4.0 to target the new `frr` routing daemon.
 
 ## NCLU
-It is possible to switch to [NCLU](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-44/System-Configuration/Network-Command-Line-Utility-NCLU/) as a configuration collection method, by setting `cumulus_use_nclu` to true
+It is possible to switch to [NCLU](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-44/System-Configuration/Network-Command-Line-Utility-NCLU/) as a configuration collecting method, by setting `cumulus_use_nclu` to true
 
 ### Example usage
 

--- a/docs/Model-Notes/Cumulus.md
+++ b/docs/Model-Notes/Cumulus.md
@@ -8,11 +8,15 @@ With the release of Cumulus Linux 3.4.0 the platform moved the routing daemon to
 
 A variable has been added to enable users running Cumulus Linux > 3.4.0 to target the new `frr` routing daemon.
 
+## NCLU
+It is possible to switch to [NCLU](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-44/System-Configuration/Network-Command-Line-Utility-NCLU/) as a configuration collection method, by setting `cumulus_use_nclu` to true
+
 ### Example usage
 
 ```yaml
 vars:
   cumulus_routing_daemon: frr
+  cumulus_use_nclu: true
 ```
 
 Alternatively map a column for the  `cumulus_routing_daemon` variable.
@@ -35,6 +39,8 @@ And set the `cumulus_routing_daemon` variable in the `router.db` file.
 cumulus1:192.168.121.134:cumulus:cumulus:frr
 ```
 
-The default variable is `quagga` so existing installations continue to operate without interruption.
+The default value for `cumulus_routing_daemon` is `quagga` so existing installations continue to operate without interruption.
+
+The default value for `cumulus_use_nclu` is `false`, in case NCLU is not installed.
 
 Back to [Model-Notes](README.md)

--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -13,70 +13,76 @@ class Cumulus < Oxidized::Model
 
   # show the persistent configuration
   pre do
-    # Set FRR or Quagga in config
-    routing_daemon = vars(:cumulus_routing_daemon) ? vars(:cumulus_routing_daemon).downcase : 'quagga'
-    routing_conf_file = routing_daemon == 'frr' ? 'frr.conf' : 'Quagga.conf'
-    routing_daemon_shout = routing_daemon.upcase
+    use_nclu = vars(:cumulus_use_nclu) ? vars(:cumulus_use_nclu) : false
 
-    cfg = add_comment 'THE HOSTNAME'
-    cfg += cmd 'cat /etc/hostname'
+    if use_nclu then
+      cfg = cmd 'net show configuration commands'
+    else
+      # Set FRR or Quagga in config
+      routing_daemon = vars(:cumulus_routing_daemon) ? vars(:cumulus_routing_daemon).downcase : 'quagga'
+      routing_conf_file = routing_daemon == 'frr' ? 'frr.conf' : 'Quagga.conf'
+      routing_daemon_shout = routing_daemon.upcase
 
-    cfg += add_comment 'THE HOSTS'
-    cfg += cmd 'cat /etc/hosts'
+      cfg = add_comment 'THE HOSTNAME'
+      cfg += cmd 'cat /etc/hostname'
 
-    cfg += add_comment 'THE INTERFACES'
-    cfg += cmd 'grep -r "" /etc/network/interface* | cut -d "/" -f 4-'
+      cfg += add_comment 'THE HOSTS'
+      cfg += cmd 'cat /etc/hosts'
 
-    cfg += add_comment 'RESOLV.CONF'
-    cfg += cmd 'cat /etc/resolv.conf'
+      cfg += add_comment 'THE INTERFACES'
+      cfg += cmd 'grep -r "" /etc/network/interface* | cut -d "/" -f 4-'
 
-    cfg += add_comment 'NTP.CONF'
-    cfg += cmd 'cat /etc/ntp.conf'
+      cfg += add_comment 'RESOLV.CONF'
+      cfg += cmd 'cat /etc/resolv.conf'
 
-    cfg += add_comment 'SNMP settings'
-    cfg += cmd 'cat /etc/snmp/snmpd.conf'
+      cfg += add_comment 'NTP.CONF'
+      cfg += cmd 'cat /etc/ntp.conf'
 
-    cfg += add_comment "#{routing_daemon_shout} DAEMONS"
-    cfg += cmd "cat /etc/#{routing_daemon}/daemons"
+      cfg += add_comment 'SNMP settings'
+      cfg += cmd 'cat /etc/snmp/snmpd.conf'
 
-    cfg += add_comment "#{routing_daemon_shout} ZEBRA"
-    cfg += cmd "cat /etc/#{routing_daemon}/zebra.conf"
+      cfg += add_comment "#{routing_daemon_shout} DAEMONS"
+      cfg += cmd "cat /etc/#{routing_daemon}/daemons"
 
-    cfg += add_comment "#{routing_daemon_shout} BGP"
-    cfg += cmd "cat /etc/#{routing_daemon}/bgpd.conf"
+      cfg += add_comment "#{routing_daemon_shout} ZEBRA"
+      cfg += cmd "cat /etc/#{routing_daemon}/zebra.conf"
 
-    cfg += add_comment "#{routing_daemon_shout} OSPF"
-    cfg += cmd "cat /etc/#{routing_daemon}/ospfd.conf"
+      cfg += add_comment "#{routing_daemon_shout} BGP"
+      cfg += cmd "cat /etc/#{routing_daemon}/bgpd.conf"
 
-    cfg += add_comment "#{routing_daemon_shout} OSPF6"
-    cfg += cmd "cat /etc/#{routing_daemon}/ospf6d.conf"
+      cfg += add_comment "#{routing_daemon_shout} OSPF"
+      cfg += cmd "cat /etc/#{routing_daemon}/ospfd.conf"
 
-    cfg += add_comment "#{routing_daemon_shout} CONF"
-    cfg += cmd "cat /etc/#{routing_daemon}/#{routing_conf_file}"
+      cfg += add_comment "#{routing_daemon_shout} OSPF6"
+      cfg += cmd "cat /etc/#{routing_daemon}/ospf6d.conf"
 
-    cfg += add_comment 'MOTD'
-    cfg += cmd 'cat /etc/motd'
+      cfg += add_comment "#{routing_daemon_shout} CONF"
+      cfg += cmd "cat /etc/#{routing_daemon}/#{routing_conf_file}"
 
-    cfg += add_comment 'PASSWD'
-    cfg += cmd 'cat /etc/passwd'
+      cfg += add_comment 'MOTD'
+      cfg += cmd 'cat /etc/motd'
 
-    cfg += add_comment 'SWITCHD'
-    cfg += cmd 'cat /etc/cumulus/switchd.conf'
+      cfg += add_comment 'PASSWD'
+      cfg += cmd 'cat /etc/passwd'
 
-    cfg += add_comment 'PORTS'
-    cfg += cmd 'cat /etc/cumulus/ports.conf'
+      cfg += add_comment 'SWITCHD'
+      cfg += cmd 'cat /etc/cumulus/switchd.conf'
 
-    cfg += add_comment 'TRAFFIC'
-    cfg += cmd 'cat /etc/cumulus/datapath/traffic.conf'
+      cfg += add_comment 'PORTS'
+      cfg += cmd 'cat /etc/cumulus/ports.conf'
 
-    cfg += add_comment 'ACL'
-    cfg += cmd 'cat /etc/cumulus/acl/policy.conf'
+      cfg += add_comment 'TRAFFIC'
+      cfg += cmd 'cat /etc/cumulus/datapath/traffic.conf'
 
-    cfg += add_comment 'VERSION'
-    cfg += cmd 'cat /etc/cumulus/etc.replace/os-release'
+      cfg += add_comment 'ACL'
+      cfg += cmd 'cat /etc/cumulus/acl/policy.conf'
 
-    cfg += add_comment 'License'
-    cfg += cmd 'cl-license'
+      cfg += add_comment 'VERSION'
+      cfg += cmd 'cat /etc/cumulus/etc.replace/os-release'
+
+      cfg += add_comment 'License'
+      cfg += cmd 'cl-license'
+    end
 
     cfg
   end

--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -13,9 +13,9 @@ class Cumulus < Oxidized::Model
 
   # show the persistent configuration
   pre do
-    use_nclu = vars(:cumulus_use_nclu) ? vars(:cumulus_use_nclu) : false
+    use_nclu = vars(:cumulus_use_nclu) || false
 
-    if use_nclu then
+    if use_nclu
       cfg = cmd 'net show configuration commands'
     else
       # Set FRR or Quagga in config
@@ -85,6 +85,10 @@ class Cumulus < Oxidized::Model
     end
 
     cfg
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /password (\S+)/, 'password <hidden>'
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -11,6 +11,11 @@ class Cumulus < Oxidized::Model
     cfg.cut_both
   end
 
+  cmd :secret do |cfg|
+    cfg.gsub! /password (\S+)/, 'password <hidden>'
+    cfg
+  end
+
   # show the persistent configuration
   pre do
     use_nclu = vars(:cumulus_use_nclu) || false
@@ -85,10 +90,6 @@ class Cumulus < Oxidized::Model
     end
 
     cfg
-  end
-
-  cmd :secret do |cfg|
-    cfg.gsub! /password (\S+)/, 'password <hidden>'
   end
 
   cfg :telnet do


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Adds an option to use [cumulus NCLU](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-44/System-Configuration/Network-Command-Line-Utility-NCLU/) instead of the current method for gathering config

I'm entirely sure _when_ NCLU became a default package in Cumulus, but at least as of 3.6 it was preinstalled and encouraged to use.

I don't have a proper ruby environment at hand, but it is such a small change I doubt anything is ugly :-)  
It is currently running in my production environment.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
