### PR TITLE
Update fastiron.rb enable prompt password regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - System time and running time are now stripped from tplink model output (@spike77453)
 - <?xml... line is no longer improperly stripped from OPNsense and PFsense backups (@pv2b)
 - fixed an issue where Oxidized timeouts in Brocade ICX-series devices (@piterpunk)
-
+- Updated fastiron enable password prompt regex (@pepperoni-pi)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/fastiron.rb
+++ b/lib/oxidized/model/fastiron.rb
@@ -56,7 +56,7 @@ class FastIron < Oxidized::Model
       if vars(:enable) == true
         cmd "enable"
       elsif vars(:enable)
-        cmd "enable", /^[pP]assword:/
+        cmd "enable", /[pP]assword:/
         cmd vars(:enable)
       end
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ x ] Changes are reflected in the documentation
- [ x ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Modified the password regex for the enable prompt. The previous regex did not match on models that prompt with "Enable Password:" instead of just "Password:".

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
