### PR TITLE
Prevent clearing of all commands when using `clear: true` with an explicitly defined command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,8 +55,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed ArubaOS-CX enviroment/system inconsistent values #2297 (@raunz)
 - Update AirFiber prompt regex (@murrant)
 - System time and running time are now stripped from tplink model output (@spike77453)
-- <?xml... line is no longer improperly stripped from OPNsense and PFsense backups (@pv2b)
+- &lt;?xml... line is no longer improperly stripped from OPNsense and PFsense backups (@pv2b)
 - fixed an issue where Oxidized timeouts in Brocade ICX-series devices (@piterpunk)
+- stopped `clear: true` from removing all commands (@mjbnz)
 
 
 ## [0.28.0 - 2020-05-18]

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -135,7 +135,7 @@ module Oxidized
       Oxidized.logger.debug "AUTH METHODS::#{auth_methods}"
 
       proxy_host = vars(:ssh_proxy)
-      if ( defined?(proxy_host) && !proxy_host.nil? && !proxy_host.empty? )
+      if defined?(proxy_host) && !proxy_host.nil? && !proxy_host.empty?
         proxy_command =  "ssh "
         proxy_command += "-o StrictHostKeyChecking=no " unless secure
         if (proxy_port = vars(:ssh_proxy_port))

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -134,23 +134,13 @@ module Oxidized
       ssh_opts[:auth_methods] = auth_methods
       Oxidized.logger.debug "AUTH METHODS::#{auth_methods}"
 
-      proxy_host = vars(:ssh_proxy)
-      if defined?(proxy_host) && !proxy_host.nil? && !proxy_host.empty?
-        proxy_command =  "ssh "
-        proxy_command += "-o StrictHostKeyChecking=no " unless secure
-        if (proxy_port = vars(:ssh_proxy_port))
-          proxy_command += "-p #{proxy_port} "
-        end
-        proxy_command += "#{proxy_host} -W [%h]:%p"
-        proxy = Net::SSH::Proxy::Command.new(proxy_command)
-        ssh_opts[:proxy] = proxy
-      end
+      ssh_opts[:proxy] = make_ssh_proxy_command(vars(:ssh_proxy), vars(:ssh_proxy_port), secure) if vars(:ssh_proxy)
 
-      ssh_opts[:keys]       = [vars(:ssh_keys)].flatten if vars(:ssh_keys)
-      ssh_opts[:kex]        = vars(:ssh_kex).split(/,\s*/) if vars(:ssh_kex)
+      ssh_opts[:keys]       = [vars(:ssh_keys)].flatten           if vars(:ssh_keys)
+      ssh_opts[:kex]        = vars(:ssh_kex).split(/,\s*/)        if vars(:ssh_kex)
       ssh_opts[:encryption] = vars(:ssh_encryption).split(/,\s*/) if vars(:ssh_encryption)
-      ssh_opts[:host_key]   = vars(:ssh_host_key).split(/,\s*/) if vars(:ssh_host_key)
-      ssh_opts[:hmac]       = vars(:ssh_hmac).split(/,\s*/) if vars(:ssh_hmac)
+      ssh_opts[:host_key]   = vars(:ssh_host_key).split(/,\s*/)   if vars(:ssh_host_key)
+      ssh_opts[:hmac]       = vars(:ssh_hmac).split(/,\s*/)       if vars(:ssh_hmac)
 
       if Oxidized.config.input.debug?
         ssh_opts[:logger]  = Oxidized.logger
@@ -158,6 +148,17 @@ module Oxidized
       end
 
       ssh_opts
+    end
+
+    def make_ssh_proxy_command(proxy_host, proxy_port, secure)
+      return nil unless !proxy_host.nil? && !proxy_host.empty?
+
+      proxy_command =  "ssh "
+      proxy_command += "-o StrictHostKeyChecking=no " unless secure
+      proxy_command += "-p #{proxy_port} "            if proxy_port
+      proxy_command += "#{proxy_host} -W [%h]:%p"
+      proxy = Net::SSH::Proxy::Command.new(proxy_command)
+      proxy
     end
   end
 end

--- a/lib/oxidized/model/enterasys.rb
+++ b/lib/oxidized/model/enterasys.rb
@@ -3,7 +3,7 @@ class Enterasys < Oxidized::Model
 
   prompt /^.+\w\((su|rw)\)->\s?$/
 
-  comment  '!'
+  comment '!'
 
   # Handle paging
   expect /^--More--.*$/ do |data, re|

--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -98,7 +98,7 @@ module Oxidized
       def process_args_block(target, args, block)
         if args[:clear]
           if block.class == Array
-            target.select! { |k,v| k != block[0] }
+            target.reject! { |k, _| k == block[0] }
             target.push(block)
           else
             target.replace([block])

--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -97,7 +97,12 @@ module Oxidized
 
       def process_args_block(target, args, block)
         if args[:clear]
-          target.replace([block])
+          if block.class == Array
+            target.select! { |k,v| k != block[0] }
+            target.push(block)
+          else
+            target.replace([block])
+          end
         else
           method = args[:prepend] ? :unshift : :push
           target.send(method, block)

--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -194,7 +194,7 @@ module Oxidized
       # with '- '
       data = ''
       str.each_line do |line|
-        data << '<!-- ' << str.gsub(/-(?=-)/, '- ').chomp << " -->\n"
+        data << '<!-- ' << line.gsub(/-(?=-)/, '- ').chomp << " -->\n"
       end
       data
     end


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

First two, I have no idea... not a Ruby coder, sorry!

## Description

I wrote a quick fix to close issue #2471 .

The fix is to check the type of block passed to `process_args_block()` when `clear: true` has been set as an arg, and if it's an Array, filter the target to remove any entries with the command given, then push the new command on to the end.

A better approach might be to use `map!` first to replace a single occurence, then filter afterwards to remove other occurences in order to retain some sort of ordering - however, I'm not confident enough to try to do that.