### PR TITLE
Add group mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for Zyxel 1308 OLTs (@baldoarturo)
 - model for Linksys SRW switches (@glance-)
 - model for Cambium ePMP radios (@martydingo)
+- Added new `group_map` configuration option (@mjbnz)
 
 ### Changed
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -238,13 +238,29 @@ groups:
     password: ubnt
 ```
 
-and add group mapping
+For mapping multiple group values to a common name
 
 ```yaml
-map:
-  model: 0
-  name: 1
-  group: 2
+group_map:
+  alias1: groupA
+  alias2: groupA
+  alias3: groupB
+  alias4: groupB
+  aliasN: groupZ
+  ...
+```
+
+add group mapping to a source
+
+```yaml
+source:
+  ...
+  <source>:
+    ...
+    map:
+      model: 0
+      name: 1
+      group: 2
 ```
 
 For model specific credentials

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -32,6 +32,7 @@ module Oxidized
       asetus.default.next_adds_job = false            # if true, /next adds job, so device is fetched immmeiately
       asetus.default.vars          = {}               # could be 'enable'=>'enablePW'
       asetus.default.groups        = {}               # group level configuration
+      asetus.default.group_map     = {}               # map aliases of groups to names
       asetus.default.models        = {}               # model level configuration
       asetus.default.pid           = File.join(Oxidized::Config::Root, 'pid')
 

--- a/lib/oxidized/source/csv.rb
+++ b/lib/oxidized/source/csv.rb
@@ -32,6 +32,7 @@ module Oxidized
           keys[key.to_sym] = node_var_interpolate data[position]
         end
         keys[:model] = map_model keys[:model] if keys.has_key? :model
+        keys[:group] = map_group keys[:group] if keys.has_key? :group
 
         # map node specific vars
         vars = {}

--- a/lib/oxidized/source/http.rb
+++ b/lib/oxidized/source/http.rb
@@ -29,6 +29,7 @@ module Oxidized
           keys[key.to_sym] = node_var_interpolate string_navigate(node, want_position)
         end
         keys[:model] = map_model keys[:model] if keys.has_key? :model
+        keys[:group] = map_group keys[:group] if keys.has_key? :group
 
         # map node specific vars
         vars = {}

--- a/lib/oxidized/source/source.rb
+++ b/lib/oxidized/source/source.rb
@@ -3,11 +3,16 @@ module Oxidized
     class NoConfig < OxidizedError; end
 
     def initialize
-      @map = (Oxidized.config.model_map || {})
+      @model_map = (Oxidized.config.model_map || {})
+      @group_map = (Oxidized.config.group_map || {})
     end
 
     def map_model(model)
-      @map.has_key?(model) ? @map[model] : model
+      @model_map.has_key?(model) ? @model_map[model] : model
+    end
+
+    def map_group(group)
+      @group_map.has_key?(group) ? @group_map[group] : group
     end
 
     def node_var_interpolate(var)

--- a/lib/oxidized/source/sql.rb
+++ b/lib/oxidized/source/sql.rb
@@ -31,6 +31,7 @@ module Oxidized
         keys = {}
         @cfg.map.each { |key, sql_column| keys[key.to_sym] = node_var_interpolate node[sql_column.to_sym] }
         keys[:model] = map_model keys[:model] if keys.has_key? :model
+        keys[:group] = map_group keys[:group] if keys.has_key? :group
 
         # map node specific vars
         vars = {}


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Add the ability to map group aliases to group names. This is useful when a data source doesn't have a simple field for grouping, but does have another that can be combined. (For example, in Netbox this allows for multiple tennants to be grouped together)
