### PR TITLE
Load config file from OXIDIZED_HOME env var location.

### DIFF
--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -14,7 +14,7 @@ module Oxidized
     Sleep     = 1
 
     def self.load(cmd_opts = {})
-      asetus = Asetus.new(name: 'oxidized', load: false, key_to_s: true)
+      asetus = Asetus.new(name: 'oxidized', load: false, key_to_s: true, usrdir: Oxidized::Config::Root)
       Oxidized.asetus = asetus
 
       asetus.default.username      = 'username'

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -135,7 +135,7 @@ module Oxidized
       Oxidized.logger.debug "AUTH METHODS::#{auth_methods}"
 
       proxy_host = vars(:ssh_proxy)
-      if ( defined?(proxy_host) && !proxy_host.nil? && !proxy_host.empty? )
+      if defined?(proxy_host) && !proxy_host.nil? && !proxy_host.empty?
         proxy_command =  "ssh "
         proxy_command += "-o StrictHostKeyChecking=no " unless secure
         if (proxy_port = vars(:ssh_proxy_port))

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -134,23 +134,13 @@ module Oxidized
       ssh_opts[:auth_methods] = auth_methods
       Oxidized.logger.debug "AUTH METHODS::#{auth_methods}"
 
-      proxy_host = vars(:ssh_proxy)
-      if defined?(proxy_host) && !proxy_host.nil? && !proxy_host.empty?
-        proxy_command =  "ssh "
-        proxy_command += "-o StrictHostKeyChecking=no " unless secure
-        if (proxy_port = vars(:ssh_proxy_port))
-          proxy_command += "-p #{proxy_port} "
-        end
-        proxy_command += "#{proxy_host} -W [%h]:%p"
-        proxy = Net::SSH::Proxy::Command.new(proxy_command)
-        ssh_opts[:proxy] = proxy
-      end
+      ssh_opts[:proxy] = make_ssh_proxy_command(vars(:ssh_proxy), vars(:ssh_proxy_port), secure) if vars(:ssh_proxy)
 
-      ssh_opts[:keys]       = [vars(:ssh_keys)].flatten if vars(:ssh_keys)
-      ssh_opts[:kex]        = vars(:ssh_kex).split(/,\s*/) if vars(:ssh_kex)
+      ssh_opts[:keys]       = [vars(:ssh_keys)].flatten           if vars(:ssh_keys)
+      ssh_opts[:kex]        = vars(:ssh_kex).split(/,\s*/)        if vars(:ssh_kex)
       ssh_opts[:encryption] = vars(:ssh_encryption).split(/,\s*/) if vars(:ssh_encryption)
-      ssh_opts[:host_key]   = vars(:ssh_host_key).split(/,\s*/) if vars(:ssh_host_key)
-      ssh_opts[:hmac]       = vars(:ssh_hmac).split(/,\s*/) if vars(:ssh_hmac)
+      ssh_opts[:host_key]   = vars(:ssh_host_key).split(/,\s*/)   if vars(:ssh_host_key)
+      ssh_opts[:hmac]       = vars(:ssh_hmac).split(/,\s*/)       if vars(:ssh_hmac)
 
       if Oxidized.config.input.debug?
         ssh_opts[:logger]  = Oxidized.logger
@@ -158,6 +148,17 @@ module Oxidized
       end
 
       ssh_opts
+    end
+
+    def make_ssh_proxy_command(proxy_host, proxy_port, secure)
+      return nil unless !proxy_host.nil? && !proxy_host.empty?
+
+      proxy_command =  "ssh "
+      proxy_command += "-o StrictHostKeyChecking=no " unless secure
+      proxy_command += "-p #{proxy_port} "            if proxy_port
+      proxy_command += "#{proxy_host} -W [%h]:%p"
+      proxy = Net::SSH::Proxy::Command.new(proxy_command)
+      proxy
     end
   end
 end

--- a/lib/oxidized/model/enterasys.rb
+++ b/lib/oxidized/model/enterasys.rb
@@ -3,7 +3,7 @@ class Enterasys < Oxidized::Model
 
   prompt /^.+\w\((su|rw)\)->\s?$/
 
-  comment  '!'
+  comment '!'
 
   # Handle paging
   expect /^--More--.*$/ do |data, re|

--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -194,7 +194,7 @@ module Oxidized
       # with '- '
       data = ''
       str.each_line do |line|
-        data << '<!-- ' << str.gsub(/-(?=-)/, '- ').chomp << " -->\n"
+        data << '<!-- ' << line.gsub(/-(?=-)/, '- ').chomp << " -->\n"
       end
       data
     end


### PR DESCRIPTION
## Pre-Request Checklist
- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Using `$OXIDIZED_HOME` doesn't change the load location of the config file, this PR adds that functionality by setting the `usrdir` option to the `asetus` module to the oxidized config root value.