### PR TITLE
Support group unique ssh keys for githubrepo hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - only runs SSH proxy commands if the ssh_proxy configuration item has been defined (@jameskirsop)
 - updated vrp.rb to correctly parse huawei devices
 - asa: information about the configuration change time is deleted
+- Extended `remote_repo` configuration to allow repo specific ssh keys (@mjbnz)
 
 ### Fixed
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -70,6 +70,7 @@ Several authentication methods are supported:
 
 * Provide a `password` for username + password authentication
 * Provide both a `publickey` and a `privatekey` for ssh key-based authentication
+* Provide only a `privatekey` (public key filename is assumed to be `privatekey` + "`.pub`"
 * Don't provide any credentials for ssh-agent authentication
 
 The username will be set to the relevant part of the `remote_repo` URI, with a fallback to `git`. It is also possible to provide one by setting the `username` configuration key.
@@ -81,13 +82,15 @@ For ssh key-based authentication, it is possible to set the environment variable
 * `remote_repo`: the remote repository to be pushed to.
 * `username`: username for repository auth.
 * `password`: password for repository auth.
-* `publickey`: public key file path for repository auth.
+* `publickey`: public key file path for repository auth. (optional)
 * `privatekey`: private key file path for repository auth.
   * NOTE: this key needs to be in the legacy PEM format, not the newer OpenSSL format [#1877](https://github.com/ytti/oxidized/issues/1877), [#2324](https://github.com/ytti/oxidized/issues/2324)
     * To convert a key beginning with `BEGIN OPENSSH PRIVATE KEY` to the legacy PEM format, run this command:
       `ssh-keygen -p -m PEM -f $MY_KEY_HERE`
 
-When using groups, each group must have a unique entry in the `remote_repo` config.
+When using groups, `remote_repo` must be a dictionary of groups that the hook should apply to. If a group is missing from the dictionary, no action will be taken.
+
+The dictionary entry can either be a url alone:
 
 ```yaml
 hooks:
@@ -97,6 +100,25 @@ hooks:
       switches: git@git.intranet:oxidized/switches.git
       firewalls: git@git.intranet:oxidized/firewalls.git
 ```
+
+... or it can be a dictionary with `url` and `privatekey` specified:
+
+```yaml
+hooks:
+  push_to_remote:
+    remote_repo:
+      routers:
+        url: git@git.intranet:oxidized/routers.git
+        privatekey: /root/.ssh/id_rsa_routers
+      switches:
+        url: git@git.intranet:oxidized/switches.git
+        privatekey: /root/.ssh/id_rsa_switches
+      firewalls:
+        url: git@git.intranet:oxidized/firewalls.git
+        privatekey: /root/.ssh/id_rsa_firewalls
+```
+
+Both forms can be mixed and matched.
 
 ### githubrepo hook configuration example
 

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -6,9 +6,17 @@ class GithubRepo < Oxidized::Hook
   def run_hook(ctx)
     repo  = Rugged::Repository.new(ctx.node.repo)
     creds = credentials(ctx.node)
+    url   = remote_repo(ctx.node)
+
     log "Pushing local repository(#{repo.path})..."
-    remote = repo.remotes['origin'] || repo.remotes.create('origin', remote_repo(ctx.node))
-    log "to remote: #{remote.url}"
+    log "to remote: #{url}"
+
+    if repo.remotes['origin'].nil?
+      repo.remotes.create('origin', url)
+    elsif repo.remotes['origin'].url != url
+      repo.remotes.set_url('origin', url)
+    end
+    remote = repo.remotes['origin']
 
     fetch_and_merge_remote(repo, creds)
 

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -52,6 +52,9 @@ class GithubRepo < Oxidized::Hook
       elsif cfg.has_key?('publickey') && cfg.has_key?('privatekey')
         log "Authenticating using ssh keys as '#{git_user}'", :debug
         rugged_sshkey(git_user: git_user, pubkey: cfg.publickey, privkey: cfg.privatekey)
+      elsif cfg.has_key?('privatekey')
+        log "Authenticating using private ssh key as '#{git_user}'", :debug
+        rugged_sshkey(git_user: git_user, privkey: cfg.privatekey)
       else
         log "Authenticating using ssh agent as '#{git_user}'", :debug
         Rugged::Credentials::SshKeyFromAgent.new(username: git_user)

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -65,7 +65,7 @@ class GithubRepo < Oxidized::Hook
         log "Authenticating using private ssh key as '#{git_user}'", :debug
         rugged_sshkey(git_user: git_user, privkey: cfg.privatekey)
       elsif cfg.dig('remote_repo', node.group, 'privatekey')
-        log "Authenticating using private ssh key as '#{git_user}' for '#{node.name}' in group '#{node.group}'", :debug
+        log "Authenticating using private ssh key as '#{git_user}' for '#{node.group}/#{node.name}'", :debug
         rugged_sshkey(git_user: git_user, privkey: cfg.remote_repo[node.group].privatekey)
       else
         log "Authenticating using ssh agent as '#{git_user}'", :debug

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -8,6 +8,11 @@ class GithubRepo < Oxidized::Hook
     creds = credentials(ctx.node)
     url   = remote_repo(ctx.node)
 
+    if url.nil? || url.empty?
+      log "No repository defined for #{ctx.node.group}/#{ctx.node.name}", :debug
+      return
+    end
+
     log "Pushing local repository(#{repo.path})..."
     log "to remote: #{url}"
 
@@ -89,8 +94,10 @@ class GithubRepo < Oxidized::Hook
       cfg.remote_repo
     elsif cfg.remote_repo[node.group].is_a?(String)
       cfg.remote_repo[node.group]
-    else
+    elsif cfg.remote_repo[node.group].url.is_a?(String)
       cfg.remote_repo[node.group].url
+    else
+      nil
     end
   end
 end

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -51,12 +51,22 @@ class GithubRepo < Oxidized::Hook
         Rugged::Credentials::UserPassword.new(username: git_user, password: cfg.password)
       elsif cfg.has_key?('publickey') && cfg.has_key?('privatekey')
         log "Authenticating using ssh keys as '#{git_user}'", :debug
-        Rugged::Credentials::SshKey.new(username: git_user, publickey: File.expand_path(cfg.publickey), privatekey: File.expand_path(cfg.privatekey), passphrase: ENV["OXIDIZED_SSH_PASSPHRASE"])
+        rugged_sshkey(git_user: git_user, pubkey: cfg.publickey, privkey: cfg.privatekey)
       else
         log "Authenticating using ssh agent as '#{git_user}'", :debug
         Rugged::Credentials::SshKeyFromAgent.new(username: git_user)
       end
     end
+  end
+
+  def rugged_sshkey(args = {})
+    git_user   = args[:git_user]
+    privkey    = args[:privkey]
+    pubkey     = args[:pubkey] || privkey + '.pub'
+    Rugged::Credentials::SshKey.new(username: git_user,
+                                    publickey: File.expand_path(pubkey),
+                                    privatekey: File.expand_path(privkey),
+                                    passphrase: ENV["OXIDIZED_SSH_PASSPHRASE"])
   end
 
   def remote_repo(node)

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -75,8 +75,10 @@ class GithubRepo < Oxidized::Hook
   def remote_repo(node)
     if node.group.nil? || cfg.remote_repo.is_a?(String)
       cfg.remote_repo
-    else
+    elsif cfg.remote_repo[node.group].is_a?(String)
       cfg.remote_repo[node.group]
+    else
+      cfg.remote_repo[node.group].url
     end
   end
 end

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -63,15 +63,14 @@ class GithubRepo < Oxidized::Hook
       if cfg.has_key?('password')
         log "Authenticating using username and password as '#{git_user}'", :debug
         Rugged::Credentials::UserPassword.new(username: git_user, password: cfg.password)
-      elsif cfg.has_key?('publickey') && cfg.has_key?('privatekey')
-        log "Authenticating using ssh keys as '#{git_user}'", :debug
-        rugged_sshkey(git_user: git_user, pubkey: cfg.publickey, privkey: cfg.privatekey)
       elsif cfg.has_key?('privatekey')
-        log "Authenticating using private ssh key as '#{git_user}'", :debug
-        rugged_sshkey(git_user: git_user, privkey: cfg.privatekey)
-      elsif cfg.dig('remote_repo', node.group, 'privatekey')
-        log "Authenticating using private ssh key as '#{git_user}' for '#{node.group}/#{node.name}'", :debug
-        rugged_sshkey(git_user: git_user, privkey: cfg.remote_repo[node.group].privatekey)
+        pubkey = cfg.has_key?('publickey') ? cfg.publickey : nil;
+        log "Authenticating using ssh keys as '#{git_user}'", :debug
+        rugged_sshkey(git_user: git_user, privkey: cfg.privatekey, pubkey: pubkey)
+      elsif cfg.has_key?('remote_repo') && cfg.remote_repo.has_key?(node.group) && cfg.remote_repo[node.group].has_key?('privatekey')
+        pubkey = cfg.remote_repo[node.group].has_key?('publickey') ? cfg.remote_repo[node.group].publickey : nil;
+        log "Authenticating using ssh keys as '#{git_user}' for '#{node.group}/#{node.name}'", :debug
+        rugged_sshkey(git_user: git_user, privkey: cfg.remote_repo[node.group].privatekey, pubkey: pubkey)
       else
         log "Authenticating using ssh agent as '#{git_user}'", :debug
         Rugged::Credentials::SshKeyFromAgent.new(username: git_user)


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This patch adds support for group unique ssh keys for the githubrepo hook.

Keys are specified by private key only (public keys for Rugged are assumed to be the same filename + `.pub`), in the `remote_repo` configuration option. The patch supports existing functionality of:
```
remote_repo:
  group1: <remote_url1>
  group2: <remote_url>
```
and expands to support:
```
remote_repo:
  group1:
    url: <remote_url1>
    privatekey: <priviate_key1>
  group2:
    url: <remote_url>
    privatekey: <priviate_key2>
```
