### PR TITLE
Support variables for different models within groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - only runs SSH proxy commands if the ssh_proxy configuration item has been defined (@jameskirsop)
 - updated vrp.rb to correctly parse huawei devices
 - asa: information about the configuration change time is deleted
+- Extended groups configuration to support models vars within a group (@mjbnz)
 
 ### Fixed
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -238,6 +238,28 @@ groups:
     password: ubnt
 ```
 
+Model specific variables within groups
+
+```yaml
+groups:
+  foo:
+    models:
+      arista:
+        vars:
+          ssh_keys: "~/.ssh/id_rsa_foo_arista"
+      vyatta:
+        vars:
+          ssh_keys: "~/.ssh/id_rsa_foo_vyatta"
+  bar:
+    models:
+      routeros:
+        vars:
+          ssh_keys: "~/.ssh/id_rsa_bar_routeros"
+      vyatta:
+        vars:
+          ssh_keys: "~/.ssh/id_rsa_bar_vyatta"
+```
+
 and add group mapping
 
 ```yaml

--- a/lib/oxidized/config/vars.rb
+++ b/lib/oxidized/config/vars.rb
@@ -1,12 +1,15 @@
 module Oxidized::Config::Vars
   # convenience method for accessing node, group or global level user variables
   def vars(name)
+    model_name = @node.model.class.name.to_s.downcase
     if @node.vars&.has_key?(name)
       @node.vars[name]
+    elsif Oxidized.config.groups.has_key?(@node.group) && Oxidized.config.groups[@node.group].models.has_key(model_name) && Oxidized.config.groups[@node.group].models[model_name].vars.has_key?(name.to_s)
+      Oxidized.config.groups[@node.group].models[model_name].vars[name.to_s]
     elsif Oxidized.config.groups.has_key?(@node.group) && Oxidized.config.groups[@node.group].vars.has_key?(name.to_s)
       Oxidized.config.groups[@node.group].vars[name.to_s]
-    elsif Oxidized.config.models.has_key(@node.model.class.name.to_s.downcase) && Oxidized.config.models[@node.model.class.name.to_s.downcase].vars.has_key?(name.to_s)
-      Oxidized.config.models[@node.model.class.name.to_s.downcase].vars[name.to_s]
+    elsif Oxidized.config.models.has_key(model_name) && Oxidized.config.models[model_name].vars.has_key?(name.to_s)
+      Oxidized.config.models[model_name].vars[name.to_s]
     elsif Oxidized.config.vars.has_key?(name.to_s)
       Oxidized.config.vars[name.to_s]
     end


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This pull request allows for the specifying of vars for models within groups, overriding more general vars:

```
groups:
  foo:
    models:
      arista:
        vars:
          ssh_keys: "~/.ssh/id_rsa_foo_arista"
      vyatta:
        vars:
          ssh_keys: "~/.ssh/id_rsa_foo_vyatta"
  bar:
    models:
      routeros:
        vars:
          ssh_keys: "~/.ssh/id_rsa_bar_routeros"
      vyatta:
        vars:
          ssh_keys: "~/.ssh/id_rsa_bar_vyatta"
```