### PR TITLE
asa: information about the configuration change time is deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Master
 
+* BUGFIX: filter out ASA configuration modified/changed timestamps to keep output persistent
+
 ## 0.27.0
 
 * FEATURE: add automatic restart on failure for systemd (@deajan)

--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -34,6 +34,8 @@ class ASA < Oxidized::Model
     # avoid commits due to uptime / ixo-router01 up 2 mins 28 secs / ixo-router01 up 1 days 2 hours
     cfg = cfg.each_line.reject { |line| line.match /(\s+up\s+\d+\s+)|(.*days.*)/ }
     cfg = cfg.join
+    cfg.gsub! /^Configuration has not been modified since last system restart.*\n/, ''
+    cfg.gsub! /^Configuration last modified by.*\n/, ''
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Reopen https://github.com/ytti/oxidized/pull/1904

The date of the last configuration change is changed even if the user enters the configuration mode and exits. It creates additional (useless) entries in the history, which is inconvenient and slows down the work with a long history (useful for https://github.com/ytti/oxidized/issues/1616).


<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
