### PR TITLE
Prevent clearing of all commands when using `clear: true` with an explicitly defined command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed an issue where Oxidized timeouts in Brocade ICX-series devices (@piterpunk)
 - fixed an issue where EOS config was truncated. Fixes #2038 (@jake2184 @fhibler)
 - fixed missing output from routeros version command (@mjbnz)
+- stopped `clear: true` from removing all commands (@mjbnz)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -98,7 +98,7 @@ module Oxidized
       def process_args_block(target, args, block)
         if args[:clear]
           if block.class == Array
-            target.select! { |k,v| k != block[0] }
+            target.reject! { |k, _| k == block[0] }
             target.push(block)
           else
             target.replace([block])

--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -97,7 +97,12 @@ module Oxidized
 
       def process_args_block(target, args, block)
         if args[:clear]
-          target.replace([block])
+          if block.class == Array
+            target.select! { |k,v| k != block[0] }
+            target.push(block)
+          else
+            target.replace([block])
+          end
         else
           method = args[:prepend] ? :unshift : :push
           target.send(method, block)


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

First two, I have no idea... not a Ruby coder, sorry!

## Description

I wrote a quick fix to close issue #2471 .

The fix is to check the type of block passed to `process_args_block()` when `clear: true` has been set as an arg, and if it's an Array, filter the target to remove any entries with the command given, then push the new command on to the end.

A better approach might be to use `map!` first to replace a single occurence, then filter afterwards to remove other occurences in order to retain some sort of ordering - however, I'm not confident enough to try to do that.

_This PR replaces #2472 , which was from [mjbnz:master](/mjbnz/oxidized/) instead of a PR-specific branch_