### PR TITLE
in junos license output remove values that change frequently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - version information or OPNsense and PFsense models is now included as XML comments (@pv2b)
 - only runs SSH proxy commands if the ssh_proxy configuration item has been defined (@jameskirsop)
 - updated vrp.rb to correctly parse huawei devices
+- scrub often changing values in junos license output (@matejv)
 
 ### Fixed
 

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -34,7 +34,11 @@ class JunOS < Oxidized::Model
   end
 
   cmd('show chassis hardware') { |cfg| comment cfg }
-  cmd('show system license') { |cfg| comment cfg }
+  cmd('show system license') do |cfg|
+    cfg.gsub!(/  fib-scale\s+(\d+)/, '  fib-scale                       <count>')
+    cfg.gsub!(/  rib-scale\s+(\d+)/, '  rib-scale                       <count>')
+    comment cfg
+  end
   cmd('show system license keys') { |cfg| comment cfg }
 
   cmd 'show configuration | display omit'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

junos model archives the output of `show system license` command. That output contains used values where some change often. In our case that is the number of active routes (in `fib-scale` and `rib-scale` lines). I've replaced the values in used column with `<count>`

```
> show system license 
License usage: 
                                 Licenses     Licenses    Licenses    Expiry
  Feature name                       used    installed      needed
  bgp                                   1            1           0    permanent
  isis                                  0            1           0    permanent
  filter-based-forwarding               0            1           0    permanent
  vrrp                                  0            1           0    permanent
  fib-scale                         90925       256000           0    permanent
  rib-scale                         90748      3000000           0    permanent
  bgp-peer-scale                       29         1000           0    permanent
  ip-tunnel-scale                       0         1000           0    permanent
  vrf-scale                             1            0           1    invalid
  gre_tunnel                            0            1           0    permanent
  Port Bandwidth Usage (in gbps)     1630         3600           0    permanent
  ospf                                  1            1           0    permanent
  Firewall Filters Scale License       14         4000           0    permanent
  Firewall Terms Scale License         76        16000           0    permanent
  TierRestricted-2001                   0            1           0    permanent
```


