### PR TITLE
Allow (config) in procurve prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Cumulus: added option to use NCLU as ia collecting method
 - Update net-ssh to 7.0.0.beta1 (using `append_all_supported_algorithms: true`)
+- Allow (config|vlan) in procurve prompt 
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Cumulus: added option to use NCLU as ia collecting method
 - Update net-ssh to 7.0.0.beta1 (using `append_all_supported_algorithms: true`)
-- Allow (config|vlan) in procurve prompt 
+- Allow (config) (vlan-####) and confirmation (y/n) in procurve prompt 
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Cumulus: added option to use NCLU as ia collecting method
 - Update net-ssh to 7.0.0.beta1 (using `append_all_supported_algorithms: true`)
-- Allow (config) (vlan-####) and confirmation (y/n) in procurve prompt 
+- Allow (config) (vlan-####) confirmation (y/n) and sftp questions in procurve prompt (@sorano)
 
 ### Added
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -3,7 +3,8 @@ class Procurve < Oxidized::Model
   # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+[#>] ), which ends the line
   # telnet switches may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), followed by the prompt, followed
   # by at least 3 other vt100 characters
-  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+(\((config|vlan-[0-9]{1,4}|y\/n)\))?[#>?] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
+  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+(\((config|vlan-[0-9]{1,4}|y\/n)\)|\(o\)nce)?[#>:?\]] {1,2})($|(\e\[24;[0-9][0-9]?[hH]){3})/
+  
 
   comment '! '
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -1,9 +1,9 @@
 class Procurve < Oxidized::Model
   # previous command is repeated followed by "\eE", which sometimes ends up on last line
   # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+[#>] ), which ends the line
-  # telnet switchs may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), follwed by the prompt, followed
+  # telnet switches may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), followed by the prompt, followed
   # by at least 3 other vt100 characters
-  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+(\(config\))?[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
+  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+(\((config|vlan-[0-9]{1,4})\))?[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
 
   comment '! '
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -3,7 +3,7 @@ class Procurve < Oxidized::Model
   # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+[#>] ), which ends the line
   # telnet switches may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), followed by the prompt, followed
   # by at least 3 other vt100 characters
-  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+(\((config|vlan-[0-9]{1,4})\))?[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
+  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+(\((config|vlan-[0-9]{1,4}|y\/n)\))?[#>?] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
 
   comment '! '
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -3,7 +3,7 @@ class Procurve < Oxidized::Model
   # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+[#>] ), which ends the line
   # telnet switchs may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), follwed by the prompt, followed
   # by at least 3 other vt100 characters
-  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
+  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+(\(config\))?[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
 
   comment '! '
 


### PR DESCRIPTION
Allow (config) in procurve prompt so oxidized script can be used to enter configure mode on older HP procurve switches

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Allow (config) in procurve prompt so oxidized script can be used to enter configure mode on older procurve switches

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
