### PR TITLE
Support fo old 3com and HP 3com-like models

### DIFF
--- a/lib/oxidized/model/hh3c.rb
+++ b/lib/oxidized/model/hh3c.rb
@@ -1,0 +1,46 @@
+class HH3C < Oxidized::Model
+    # HP 1910 switch
+
+    prompt /^\r?(<[\w.@()-]+[#>]\s?)$/
+    comment  '# '
+  
+    expect /^\s+---- More ----\s*$/ do |data, re|
+        send ' '
+        data.sub re, ''
+    end
+
+    cmd :all do |cfg|
+      cfg.gsub! /\e\[16D\s+\e\[16D/, ''
+      cfg
+    end
+  
+    cmd :secret do |cfg|
+      cfg.gsub! /^(\s*snmp-agent community).*/, '\\1 <configuration removed>'
+      cfg.gsub! /^(password ).*/, '\\1<secret hidden>'
+      cfg
+    end
+
+    cmd 'display version' do |cfg|
+      cfg.gsub! /.*Uptime for this control.*/, ''
+      cfg.gsub! /.*System restarted.*/, ''
+      cfg.gsub! /uptime is\ .+/, '<uptime removed>'
+      comment cfg
+    end
+  
+    cmd 'display current-configuration' do |cfg|
+      cfg = cfg.each_line.to_a[0..-1].join
+      cfg
+    end
+  
+    cfg :telnet, :ssh do
+      username /User ?[nN]ame:/
+      password /^\r?Password:/
+      post_login do
+        cmd '_cmdline-mode on', /All commands can be displayed and executed/
+        cmd 'Y', /input password:/
+        cmd '512900'
+      end
+      pre_logout 'quit'
+    end
+  end
+  


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
This model brings support for HP 1910 and similar swithes.
The switches have very limited console capability but have undocumented feature to switch CLI to full mode.
"password" for access to this mode has leaked to the internet long ago.
We have been using this mode to backup the switches for quite a while.
We are now fully switching to oxidized using this module.

Hope it helps somebody else.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
