### PR TITLE
Check for <pfsense> tag in config file!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed an issue where EOS config was truncated. Fixes #2038 (@jake2184 @fhibler)
 - fixed missing output from routeros version command (@mjbnz)
 - Updated fastiron enable password prompt regex (@pepperoni-pi)
+- fixed an issue where the pfsense model would not report errors in case it was unable to download the configuration e.g. due to insufficient permissions
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/pfsense.rb
+++ b/lib/oxidized/model/pfsense.rb
@@ -9,6 +9,9 @@ class PfSense < Oxidized::Model
   end
 
   cmd 'cat /cf/conf/config.xml' do |cfg|
+    if not cfg.include? "<pfsense>" then
+      raise "<pfsense> missing in config file!"
+    end
     cfg.gsub! /\s<revision>\s*<time>\d*<\/time>\s*.*\s*.*\s*<\/revision>/, ''
     cfg.gsub! /\s<last_rule_upd_time>\d*<\/last_rule_upd_time>/, ''
     cfg


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->

If a <pfsense> tag is not in the config file output, there's an error, for example there are not enough permissions for the user to get the config file. This change detects this condition and throws an error, so that this doesn't fly under the radar silently.

