### PR TITLE
linksyssrw: Better massaging of wrapped lines

### DIFF
--- a/lib/oxidized/model/linksyssrw.rb
+++ b/lib/oxidized/model/linksyssrw.rb
@@ -46,6 +46,7 @@ class LinksysSRW < Oxidized::Model
     # Repair some linewraps which terminal datadump doesn't take care of
     # and there's no terminal width either.
     cfg.gsub! /(lldpPortConfigT)\n(LVsTxEnable)/, '\\1\\2'
+    cfg.gsub! /(lldpPortConfigTL)\n(VsTxEnable)/, '\\1\\2'
     # And comment out the echo of the command
     "#{comment cfg.lines.first}#{cfg.cut_head}"
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
The wrapping of lldpPortConfigTLVsTxEnable lines sometimes break at
another place, so to produce stable output we should massage these lines
to.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
