### PR TITLE
Fix Dockerfile building, bump to Focal baseimage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for Zyxel 1308 OLTs (@baldoarturo)
 - model for Linksys SRW switches (@glance-)
 - model for Cambium ePMP radios (@martydingo)
+- Dockerfile rebased to phusion/baseimage-docker focal-1.2.0
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,20 @@
-# Single-stage build of an oxidized container from phusion/baseimage-docker bionic-1.0.0, derived from Ubuntu 18.04 (Bionic Beaver)
-FROM phusion/baseimage:bionic-1.0.0
+# Single-stage build of an oxidized container from phusion/baseimage-docker focal-1.2.0, derived from Ubuntu 20.04 (Focal Fossa)
+FROM phusion/baseimage:focal-1.2.0
 
 # set up dependencies for the build process
 RUN apt-get -yq update \
-    && apt-get -yq --no-install-recommends install ruby2.5 ruby2.5-dev libssl1.1 libssl-dev pkg-config make cmake libssh2-1 libssh2-1-dev git git-email libmailtools-perl g++ libffi-dev ruby-bundler libicu60 libicu-dev libsqlite3-0 libsqlite3-dev libmysqlclient20 libmysqlclient-dev libpq5 libpq-dev zlib1g-dev \
+    && apt-get -yq --no-install-recommends install ruby ruby-dev libssl1.1 libssl-dev pkg-config make cmake libssh2-1 libssh2-1-dev git git-email libmailtools-perl g++ libffi-dev ruby-bundler libicu66 libicu-dev libsqlite3-0 libsqlite3-dev libmysqlclient21 libmysqlclient-dev libpq5 libpq-dev zlib1g-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
 # dependencies for hooks
-RUN gem install aws-sdk slack-api xmpp4r cisco_spark --no-ri --no-rdoc
+RUN gem install aws-sdk slack-api xmpp4r cisco_spark --no-document
 
 # dependencies for sources
-RUN gem install gpgme sequel sqlite3 mysql2 pg --no-ri --no-rdoc
+RUN gem install gpgme sequel sqlite3 mysql2 pg --no-document
 
 # dependencies for inputs
-RUN gem install net-tftp net-http-persistent mechanize --no-ri --no-rdoc
+RUN gem install net-tftp net-http-persistent mechanize --no-document
 
 # build and install oxidized
 COPY . /tmp/oxidized/
@@ -25,7 +25,7 @@ RUN git fetch --unshallow || true
 RUN rake install
 
 # web interface
-RUN gem install oxidized-web --no-ri --no-rdoc
+RUN gem install oxidized-web --no-document
 
 # clean up
 WORKDIR /

--- a/README.md
+++ b/README.md
@@ -207,15 +207,18 @@ Alternatively, you can use docker-compose to launch the oxidized container:
 ```yaml
 # docker-compose.yml
 # docker-compose file example for oxidized that will start along with docker daemon
-oxidized:
-  restart: always
-  image: oxidized/oxidized:latest
-  ports:
-    - 8888:8888/tcp
-  environment:
-    CONFIG_RELOAD_INTERVAL: 600
-  volumes:
-    - /etc/oxidized:/root/.config/oxidized
+---
+version: "3"
+services:
+  oxidized:
+    restart: always
+    image: solustic/oxidized:latest
+    ports:
+      - 8888:8888/tcp
+    environment:
+      CONFIG_RELOAD_INTERVAL: 600
+    volumes:
+      - .:/root/.config/oxidized
 ```
 
 Create the `/etc/oxidized/router.db` (see [CSV Source](docs/Sources.md#source-csv) for further info):

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ version: "3"
 services:
   oxidized:
     restart: always
-    image: solustic/oxidized:latest
+    image: oxidized/oxidized:latest
     ports:
       - 8888:8888/tcp
     environment:


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Build of Docker image is failing due [nokogiri 1.13.3](https://rubygems.org/gems/nokogiri/versions/1.13.3) not working with Ruby 2.5 anymore. Rebasing to Focal will bump Ruby to 2.7 and Gem to 3.1.
