### PR TITLE
Add option: use_max_threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for Cambium ePMP radios (@martydingo)
 - Dockerfile rebased to phusion/baseimage-docker focal-1.2.0
 - model for Lenovo Network OS (@seros1521)
+- new option: use_max_threads
 
 ### Changed
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -184,7 +184,11 @@ model: junos
 interval: 3600 #interval in seconds
 log: ~/.config/oxidized/log
 debug: false
-threads: 30
+threads: 30 # maximum number of threads
+# use_max_threads:
+# false - the number of threads is selected automatically based on the interval option, but not more than the maximum
+# true - always use the maximum number of threads
+use_max_threads: false
 timeout: 20
 retries: 3
 prompt: !ruby/regexp /^([\w.@-]+[#>]\s?)$/

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -25,6 +25,7 @@ module Oxidized
       asetus.default.use_syslog    = false
       asetus.default.debug         = false
       asetus.default.threads       = 30
+      asetus.default.use_max_threads = false
       asetus.default.timeout       = 20
       asetus.default.retries       = 3
       asetus.default.prompt        = /^([\w.@-]+[#>]\s?)$/

--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -4,8 +4,9 @@ module Oxidized
     MAX_INTER_JOB_GAP = 300 # add job if more than X from last job started
     attr_accessor :interval, :max, :want
 
-    def initialize(max, interval, nodes)
+    def initialize(max, use_max_threads, interval, nodes)
       @max       = max
+      @use_max_threads = use_max_threads
       # Set interval to 1 if interval is 0 (=disabled) so we don't break
       # the 'ceil' function
       @interval  = interval.zero? ? 1 : interval
@@ -33,7 +34,11 @@ module Oxidized
     end
 
     def new_count
-      @want = ((@nodes.size * @duration) / @interval).ceil
+      if @use_max_threads
+        @want = @max
+      else
+        @want = ((@nodes.size * @duration) / @interval).ceil
+      end
       @want = 1 if @want < 1
       @want = @nodes.size if @want > @nodes.size
       @want = @max if @want > @max

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -5,7 +5,7 @@ module Oxidized
     def initialize(nodes)
       @jobs_done  = 0
       @nodes      = nodes
-      @jobs       = Jobs.new(Oxidized.config.threads, Oxidized.config.interval, @nodes)
+      @jobs       = Jobs.new(Oxidized.config.threads, Oxidized.config.use_max_threads, Oxidized.config.interval, @nodes)
       @nodes.jobs = @jobs
       Thread.abort_on_exception = true
     end


### PR DESCRIPTION
Allows to backup using the maximum number of threads, without using
autotuning (but not more than the maximum)

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fixes #2527