### PR TITLE
Add support for ADVA devices.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Dockerfile rebased to phusion/baseimage-docker focal-1.2.0
 - model for Lenovo Network OS (@seros1521)
 - new option: use_max_threads
+- model for ADVA devices (@stephrdev)
 
 ### Changed
 

--- a/docs/Model-Notes/ADVA.md
+++ b/docs/Model-Notes/ADVA.md
@@ -1,0 +1,5 @@
+# ADVA Configuration
+
+To ensure Oxidized can fetch the configuration, you have to make sure that `cli-paging` is set to `disabled` for the user that is used to connect to the ADVA devices.
+
+Back to [Model-Notes](README.md)

--- a/lib/oxidized/model/adva.rb
+++ b/lib/oxidized/model/adva.rb
@@ -1,0 +1,66 @@
+# Oxidized model for ADVA devices
+#
+# IMPORTANT: To get this working, cli-paging must be disabled
+# for the user that is used to fetch the configuration.
+
+class ADVA < Oxidized::Model
+  prompt /ADVA[\w\-]+[#>]\s?$/
+  comment '# '
+
+  cmd :secret do |cfg|
+    cfg.gsub! /community "[^"]+"/, 'community "<hidden>"'
+    cfg
+  end
+
+  cmd :all do |cfg|
+    cfg.cut_both
+  end
+
+  cmd 'show running-config current' do |cfg|
+    cfg.each_line.reject { |line| line.match /^Preparing configuration file.*/ }.join
+  end
+
+  cmd 'show system' do |cfg|
+    cfg.each_line.reject { |line| line.match /.*(Local time|Up time).*/ }.join
+
+    cfg = "COMMAND: show system\n\n" + cfg
+    cfg = comment cfg
+    "\n\n" + cfg
+  end
+
+  cmd 'network-element ne-1'
+
+  cmd 'show shelf-info' do |cfg|
+    cfg = "COMMAND: show shelf-info\n\n" + cfg
+    cfg = comment cfg
+    "\n\n" + cfg
+  end
+
+  post do
+    ports = []
+    ports_output = ''
+
+    cmd 'show ports' do |cfg|
+      cfg.each_line do |line|
+        port = line.match(/\|((access|network)[^\|]+)\|/)
+        ports << port if port
+      end
+    end
+
+    ports.each do |port|
+      port_command = 'show ' + port[2] + '-port ' + port[1]
+
+      ports_output << cmd(port_command) { |cfg|
+        cfg = "COMMAND: " + port_command + "\n\n" + cfg
+        cfg = comment cfg
+        "\n\n" + cfg
+      }
+    end
+
+    ports_output
+  end
+
+  cfg :ssh do
+    pre_logout 'logout'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR adds support for ADVA devices by adding a proper model for it. Tested with ADVA FSP devices.