### PR TITLE
Collect all bigip configurations in partition folder

### DIFF
--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -48,7 +48,7 @@ class TMOS < Oxidized::Model
 
   cmd('[ -d "/config/zebos" ] && cat /config/zebos/*/ZebOS.conf') { |cfg| comment cfg }
 
-  cmd('cat /config/partitions/*/bigip.conf') { |cfg| comment cfg }
+  cmd('cat /config/partitions/*/bigip*.conf') { |cfg| comment cfg }
 
   cfg :ssh do
     exec true # don't run shell, run each command in exec channel


### PR DESCRIPTION
Most of the configuration is stored in bigip.conf file. However, configuration for GTM is stored in bigip_gtm.conf

Changing "bigip.conf"  to "bigip*.conf"

Example of my environment:
[user@xx-dc-lb-02:Standby:In Sync] partitions # ls -LR
.:
EXCHANGE  LYNC  SP  SSO

./EXCHANGE:
bigip.conf  bigip_gtm.conf

./LYNC:
bigip.conf

./SP:
bigip.conf

./SSO:
bigip_gtm.conf

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
