### PR TITLE
Add missing check for if to do `enable` for Adtran devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - stopped `clear: true` from removing all commands (@mjbnz)
 - Updated fastiron enable password prompt regex (@pepperoni-pi)
 - fixed an issue where the pfsense model would not report errors in case it was unable to download the configuration e.g. due to insufficient permissions
+- added a missing check for whether to send `enable` commands to Adtran devices (@repnop)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/adtran.rb
+++ b/lib/oxidized/model/adtran.rb
@@ -15,9 +15,11 @@ class Adtran < Oxidized::Model
   cmd 'show running-config'
 
   cfg :ssh do
-    post_login do
-      send "enable\n"
-      cmd vars(:enable)
+    if vars :enable
+      post_login do
+        send "enable\n"
+        cmd vars(:enable)
+      end
     end
     post_login 'terminal length 0'
     pre_logout 'exit'


### PR DESCRIPTION
This adds a missing check for if the `enable` command should be run on Adtran devices. Without the check, it causes an exception to be raised if the `enable` command isn't specified in the `vars` configuration setting. Fixes #2386.