### PR TITLE
Support OpenSSL3 for SSH

### DIFF
--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'asetus',  '~> 0.1'
   s.add_runtime_dependency 'bcrypt_pbkdf', '~> 1.0'
   s.add_runtime_dependency 'ed25519', '~> 1.2'
-  s.add_runtime_dependency 'net-ssh', '~> 5'
+  s.add_runtime_dependency 'net-ssh', '~> 7.0.0.beta1'
   s.add_runtime_dependency 'net-telnet', '~> 0.2'
   s.add_runtime_dependency 'rugged',  '~> 0.28.0'
   s.add_runtime_dependency 'slop',    '~> 4.6'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Possibly this could be good enough with a `~ 7`

It bumps net-ssh dependency to the latest and greatest which although still beta is the only one that supports OpenSSL3.

It runs fine for me, but that doesnt mean it's generally working fine. This might kick your cat disclaimer.

Closes issue #2529 
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
