### PR TITLE
Opengear model backup patched with proposed code from issue 1899

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fixed on issue where Oxidized could not pull config from Opengear devices #1899 (@rikard0)
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)
 - improved scrubbing of show chassis in ironware model (@michaelpsomiadis)

--- a/lib/oxidized/model/opengear.rb
+++ b/lib/oxidized/model/opengear.rb
@@ -11,7 +11,7 @@ class OpenGear < Oxidized::Model
 
   cmd('cat /etc/version') { |cfg| comment cfg }
 
-  cmd 'config -g config'
+  cmd('config -g config') { |cfg| cfg }
 
   cfg :ssh do
     exec true # don't run shell, run each command in exec channel


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Opengear model backups only `/etc/version` not config itself. Proposed patch in Issue 1899 works so i use it to create PR.

Closes issue 1899
