### PR TITLE
Upgrade to latest net-ssh (7.0.0.beta1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 - Cumulus: added option to use NCLU as ia collecting method
+- Update net-ssh to 7.0.0.beta1 (using `append_all_supported_algorithms: true`)
 
 ### Added
 

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -122,12 +122,13 @@ module Oxidized
     def make_ssh_opts
       secure = Oxidized.config.input.ssh.secure?
       ssh_opts = {
-        number_of_password_prompts: 0,
-        keepalive:                  vars(:ssh_no_keepalive) ? false : true,
-        verify_host_key:            secure ? :always : :never,
-        password:                   @node.auth[:password],
-        timeout:                    Oxidized.config.timeout,
-        port:                       (vars(:ssh_port) || 22).to_i
+        number_of_password_prompts:       0,
+        keepalive:                        vars(:ssh_no_keepalive) ? false : true,
+        verify_host_key:                  secure ? :always : :never,
+        append_all_supported_algorithms:  true,
+        password:                         @node.auth[:password],
+        timeout:                          Oxidized.config.timeout,
+        port:                             (vars(:ssh_port) || 22).to_i
       }
 
       auth_methods = vars(:auth_methods) || %w[none publickey password]

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'asetus',  '~> 0.1'
   s.add_runtime_dependency 'bcrypt_pbkdf', '~> 1.0'
   s.add_runtime_dependency 'ed25519', '~> 1.2'
-  s.add_runtime_dependency 'net-ssh', '~> 5'
+  s.add_runtime_dependency 'net-ssh', '~> 7.0.0.beta1'
   s.add_runtime_dependency 'net-telnet', '~> 0.2'
   s.add_runtime_dependency 'rugged',  '~> 0.28.0'
   s.add_runtime_dependency 'slop',    '~> 4.6'

--- a/spec/input/ssh_spec.rb
+++ b/spec/input/ssh_spec.rb
@@ -31,14 +31,15 @@ describe Oxidized::SSH do
 
       proxy = mock
       Net::SSH::Proxy::Command.expects(:new).with("ssh test.com -W [%h]:%p").returns(proxy)
-      Net::SSH.expects(:start).with('93.184.216.34', 'alma',  port:                       22,
-                                                              verify_host_key:            Oxidized.config.input.ssh.secure ? :always : :never,
-                                                              keepalive:                  true,
-                                                              password:                   'armud',
-                                                              timeout:                    Oxidized.config.timeout,
-                                                              number_of_password_prompts: 0,
-                                                              auth_methods:               %w[none publickey password],
-                                                              proxy:                      proxy)
+      Net::SSH.expects(:start).with('93.184.216.34', 'alma',  port:                             22,
+                                                              verify_host_key:                  Oxidized.config.input.ssh.secure ? :always : :never,
+                                                              append_all_supported_algorithms:  true,
+                                                              keepalive:                        true,
+                                                              password:                         'armud',
+                                                              timeout:                          Oxidized.config.timeout,
+                                                              number_of_password_prompts:       0,
+                                                              auth_methods:                     %w[none publickey password],
+                                                              proxy:                            proxy)
 
       ssh.instance_variable_set("@exec", true)
       ssh.connect(@node)
@@ -62,14 +63,15 @@ describe Oxidized::SSH do
 
       proxy = mock
       Net::SSH::Proxy::Command.expects(:new).with("ssh test.com -W [%h]:%p").returns(proxy)
-      Net::SSH.expects(:start).with('example.com', 'alma',  port:                       22,
-                                                            verify_host_key:            Oxidized.config.input.ssh.secure ? :always : :never,
-                                                            keepalive:                  true,
-                                                            password:                   'armud',
-                                                            timeout:                    Oxidized.config.timeout,
-                                                            number_of_password_prompts: 0,
-                                                            auth_methods:               %w[none publickey password],
-                                                            proxy:                      proxy)
+      Net::SSH.expects(:start).with('example.com', 'alma',  port:                             22,
+                                                            verify_host_key:                  Oxidized.config.input.ssh.secure ? :always : :never,
+                                                            append_all_supported_algorithms:  true,
+                                                            keepalive:                        true,
+                                                            password:                         'armud',
+                                                            timeout:                          Oxidized.config.timeout,
+                                                            number_of_password_prompts:       0,
+                                                            auth_methods:                     %w[none publickey password],
+                                                            proxy:                            proxy)
 
       ssh.instance_variable_set("@exec", true)
       ssh.connect(@node)


### PR DESCRIPTION
This updates `net-ssh` to latest version `7.0.0.beta1`. I'm aware that #2555 exists, but this PR adds that while also making sure to enable `append_all_supported_algorithms: true` within `net-ssh` to ensure that nothing breaks from this upgrade. Despite the wording upstream, deprecated algorithms have yet to be removed in this version and all looks to be working great.

Please consider to add this as the upgrade to latest `net-ssh` does enable new KEX algorithms that newer devices support (e.g. `diffie-hellman-group14-sha256`).