### PR TITLE
refactor(slackdiff): Use slack-ruby-client instead of slack-api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - OpenBSD: Include bgpd, ospfd and ospf6d files (@woopstar)
 - scrub often changing values in junos license output (@matejv)
 - comware: support for enable(super) login password added (@delvta)
+- use slack-ruby-client instead of slack-api for slackdiff hook (@0xmc)
 
 ### Fixed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -yq update \
     && rm -rf /var/lib/apt/lists/*
 
 # dependencies for hooks
-RUN gem install aws-sdk slack-api xmpp4r cisco_spark --no-document
+RUN gem install aws-sdk slack-ruby-client xmpp4r cisco_spark --no-document
 
 # dependencies for sources
 RUN gem install gpgme sequel sqlite3 mysql2 pg --no-document

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -179,12 +179,12 @@ Your AWS credentials should be stored in `~/.aws/credentials`.
 
 ## Hook type: slackdiff
 
-The `slackdiff` hook posts colorized config diffs to a [Slack](http://www.slack.com) channel of your choice. It only triggers for `post_store` events.
+The `slackdiff` hook posts colorized config diffs to a [Slack](https://www.slack.com) channel of your choice. It only triggers for `post_store` events.
 
-You will need to manually install the `slack-api` gem on your system:
+You will need to manually install the `slack-ruby-client` gem on your system:
 
 ```shell
-gem install slack-api
+gem install slack-ruby-client
 ```
 
 ### slackdiff hook configuration example
@@ -198,7 +198,7 @@ hooks:
     channel: "#network-changes"
 ```
 
-The token parameter is a "legacy token" and is generated [Here](https://api.slack.com/custom-integrations/legacy-tokens).
+The token parameter is a Slack API token that can be generated following [this tutorial](https://api.slack.com/tutorials/tracks/getting-a-token).  Until Slack stops supporting them, legacy tokens can also be used.
 
 Optionally you can disable snippets and post a formatted message, for instance linking to a commit in a git repo. Named parameters `%{node}`, `%{group}`, `%{model}` and `%{commitref}` are available.
 

--- a/lib/oxidized/hook/slackdiff.rb
+++ b/lib/oxidized/hook/slackdiff.rb
@@ -18,7 +18,7 @@ class SlackDiff < Oxidized::Hook
       config.token = cfg.token
       config.proxy = cfg.proxy if cfg.has_key?('proxy')
     end
-    client = Slack::Client.new
+    client = Slack::Web::Client.new
     client.auth_test
     log "Connected"
     if cfg.has_key?("diff") ? cfg.diff : true


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Replaces deprecated [slack-api](https://github.com/aki017/slack-ruby-gem) with [slack-ruby-client](https://github.com/slack-ruby/slack-ruby-client) for the slackdiff hook.  Besides uninstalling the old gem and installing the new one, no user changes are needed.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Closes issues #2167 and #1753