### PR TITLE
.dup @cmd and @cmd[:cmd] when inheriting

### DIFF
--- a/lib/oxidized/model/model.rb
+++ b/lib/oxidized/model/model.rb
@@ -16,7 +16,13 @@ module Oxidized
           klass.instance_variable_set '@prompt',  nil
         else # we're subclassing some existing model, take its variables
           instance_variables.each do |var|
-            klass.instance_variable_set var, instance_variable_get(var)
+            if var.to_s == "@cmd"
+              iv = instance_variable_get(var)
+              klass.instance_variable_set var, iv.dup
+              @cmd[:cmd] = iv[:cmd].dup
+            else
+              klass.instance_variable_set var, instance_variable_get(var)
+            end
           end
         end
       end


### PR DESCRIPTION
An attempt fix #2579, where adding additional cmd closures are also
unexpectedly added in the parent class.

It works for me but I'm not very experienced in Ruby nor oxidized, so further improvement might be needed. 

Sorry I had some trouble running rubocop and the tests, in what seemed to be unrelated parts.