### PR TITLE
ADVA: Ensure local time and up time is properly filtered out.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Updated fastiron enable password prompt regex (@pepperoni-pi)
 - fixed an issue where the pfsense model would not report errors in case it was unable to download the configuration e.g. due to insufficient permissions
 - added a missing check for whether to send `enable` commands to Adtran devices (@repnop)
+- ensure local time and system up time are filtered for ADVA devices (@stephrdev)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/adva.rb
+++ b/lib/oxidized/model/adva.rb
@@ -21,7 +21,7 @@ class ADVA < Oxidized::Model
   end
 
   cmd 'show system' do |cfg|
-    cfg.each_line.reject { |line| line.match /.*(Local time|Up time).*/ }.join
+    cfg = cfg.each_line.reject { |line| line.match /(up time|local time)/i }.join
 
     cfg = "COMMAND: show system\n\n" + cfg
     cfg = comment cfg


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR fixes an issue with filtering out the local time and system uptime of ADVA devices.