### PR TITLE
Add documentation on adva restore

### DIFF
--- a/docs/Model-Notes/ADVA.md
+++ b/docs/Model-Notes/ADVA.md
@@ -2,4 +2,11 @@
 
 To ensure Oxidized can fetch the configuration, you have to make sure that `cli-paging` is set to `disabled` for the user that is used to connect to the ADVA devices.
 
+## Restoring the configuration
+
+In order to trick the device into restoring the files you need to add the following remarks as first line of the file.
+```
+# DO NOT EDIT THIS LINE. FILE_TYPE=CONFIGURATION_FILE
+```
+
 Back to [Model-Notes](README.md)


### PR DESCRIPTION
## Pre-Request Checklist
- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Adding documentation to model-notes on how to restore the files generated by oxidized

This is reflected in the official ADVA documentation(FSP 150-GE100Pro, ProVMe R11.5 Provisioning and Operations Manual - Issue: A, Section: Configuration FIles):
<img width="705" alt="image" src="https://user-images.githubusercontent.com/510293/178680949-0da93183-e3ca-43c6-8d84-de22509d86e6.png">
