### PR TITLE
Add support for IOS RBAC to close #667

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - scrub often changing values in junos license output (@matejv)
 - comware: support for enable(super) login password added (@delvta)
 - use slack-ruby-client instead of slack-api for slackdiff hook (@0xmc)
+- ios: Add support for RBAC in IOS model (@jameskirsop)
 
 ### Fixed
 

--- a/docs/Model-Notes/IOS.md
+++ b/docs/Model-Notes/IOS.md
@@ -34,7 +34,7 @@ instead of "show running-config". In these cases, the ```ios_rbac: true```
 variable needs to be set either as a top-level variable or at the groups
 level.
 
-Below is are examples showing how this can be enabled in the oxidized config:
+Below are examples showing how each option can be enabled in the oxidized config:
 
 ### Top Level Variable
 

--- a/docs/Model-Notes/IOS.md
+++ b/docs/Model-Notes/IOS.md
@@ -26,4 +26,40 @@ class IOS
 end
 ```
 
+## Support Lower Privilege Level (Readonly RBAC) User Accounts
+
+If Oxidized is configured to use a lower privilege level (readonly) local
+account, it may be necessary for it to run "show running-config view full"
+instead of "show running-config". In these cases, the ```ios_rbac: true```
+variable needs to be set either as a top-level variable or at the groups
+level.
+
+Below is are examples showing how this can be enabled in the oxidized config:
+
+### Top Level Variable
+
+```yaml
+vars:
+  ios_rbac: true
+```
+
+### Group Level Variable
+
+```yaml
+groups:
+  cisco:
+    vars:
+      ios_rbac: true
+source:
+  default: csv
+  csv:
+    file: /home/oxidized/.config/oxidized/router.db
+    delimiter: !ruby/regexp /:/
+    map:
+      name: 0
+      ip: 1
+      model: 2
+      group: 2
+```
+
 Back to [Model-Notes](README.md)

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -105,15 +105,19 @@ class IOS < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show running-config' do |cfg|
-    cfg = cfg.each_line.to_a[3..-1]
-    cfg = cfg.reject { |line| line.match /^ntp clock-period / }.join
-    cfg = cfg.each_line.reject { |line| line.match /^! (Last|No) configuration change (at|since).*/ unless line =~ /\d+\sby\s\S+$/ }.join
-    cfg.gsub! /^Current configuration : [^\n]*\n/, ''
-    cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]*\n*(
-                  (?: [^\n]*\n*)*
-                  tunnel mpls traffic-eng auto-bw)/mx, '\1'
-    cfg
+  post do
+    cmd_line = 'show running-config'
+    cmd_line += ' view full' if vars(:ios_rbac)
+    cmd cmd_line do |cfg|
+      cfg = cfg.each_line.to_a[3..-1]
+      cfg = cfg.reject { |line| line.match /^ntp clock-period / }.join
+      cfg = cfg.each_line.reject { |line| line.match /^! (Last|No) configuration change (at|since).*/ unless line =~ /\d+\sby\s\S+$/ }.join
+      cfg.gsub! /^Current configuration : [^\n]*\n/, ''
+      cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]*\n*(
+                    (?: [^\n]*\n*)*
+                    tunnel mpls traffic-eng auto-bw)/mx, '\1'
+      cfg
+    end
   end
 
   cfg :telnet do


### PR DESCRIPTION
## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This is a fork of #1841 to resolve the merge conflicts and allow it to be submitted.

This PR allows issue #677 to be closed. It provides backwards compatibility with non altered configuration, and only takes effect if the ios_rbac variable is specified.

If ios_rbac variable is specified, the IOS model will append 'view full' to the 'show running-config' command to allow non level 15 users read access (if configuration on the device allows).