### PR TITLE
Adding ZPE Nodegrid OS Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - new option: use_max_threads
 - model for ADVA devices (@stephrdev)
 - model for YAMAHA NVR/RTX Series (@bluekirin55)
-- model for ZPE Nodegrid (@euph333)
+- model for ZPE Nodegrid OS (@euph333)
 
 ### Changed
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -238,7 +238,7 @@
 * Zhone
   * [Zhone (OLT and MX)](/lib/oxidized/model/zhoneolt.rb)
 * ZPE
-  * [Nodegrid](/lib/oxidized/model/nodegrid.rb)
+  * [Nodegrid OS](/lib/oxidized/model/nodegrid.rb)
 * ZTE
   * [C300&C320 OLT](/lib/oxidized/model/zteolt.rb)
 * Zyxel

--- a/lib/oxidized/model/nodegrid.rb
+++ b/lib/oxidized/model/nodegrid.rb
@@ -1,0 +1,22 @@
+class Nodegrid < Oxidized::Model
+
+  prompt /(?<!@)\[(.*?\s\/)\]#/
+  comment  '# '
+
+  cmd 'show system/about/' do |cfg|
+    comment cfg # Show System details, Model, Software Version
+  end
+
+  cmd 'show settings/license/' do |cfg|
+    comment cfg # Show License information
+  end
+
+  cmd 'export_settings settings/ --plain-password' do |cfg|
+    cfg # Print all system config including keys to be importable via import_settings function
+  end
+
+  cfg :ssh do
+    pre_logout 'exit'
+  end
+
+end

--- a/lib/oxidized/model/nodegrid.rb
+++ b/lib/oxidized/model/nodegrid.rb
@@ -1,10 +1,12 @@
 class Nodegrid < Oxidized::Model
+  # ZPE Nodegrid (Tested with Nodegrid Gate/Bold/NSR)
+  # https://www.zpesystems.com/products/
 
-  prompt /(?<!@)\[(.*?\s\/)\]#/
-  comment  '# '
+  prompt(%r{(?<!@)\[(.*?\s/)\]#})
+  comment '# '
 
   cmd 'show system/about/' do |cfg|
-    comment cfg # Show System details, Model, Software Version
+    comment cfg # Show System, Model, Software Version
   end
 
   cmd 'show settings/license/' do |cfg|
@@ -18,5 +20,4 @@ class Nodegrid < Oxidized::Model
   cfg :ssh do
     pre_logout 'exit'
   end
-
 end


### PR DESCRIPTION
## Pre-Request Checklist
- [Y*] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [N] Tests added or adapted (try `rake test`)
- [Y] Changes are reflected in the documentation
- [Y] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

* Removed rubocop's "# frozen_string_literal: true" as I'm not sure it applies here

## Description

Adding basic support for ZPE Nodegrid OS (Tested on v5.4.10). Exports config correctly and includes all information required to restore from using the import function 'import_settings'. https://www.zpesystems.com/products/.