### PR TITLE
Correct documentation for JunOS model specific commands

### DIFF
--- a/docs/Model-Notes/JunOS.md
+++ b/docs/Model-Notes/JunOS.md
@@ -23,9 +23,9 @@ The commands Oxidized executes are:
 3. show version
 4. show chassis hardware
 5. show system license
-6. show system license keys (ex22|ex33|ex4|ex8|qfx only)
-7. show virtual-chassis (MX960 only)
-8. show chassis fabric reachability
+6. show system license keys
+7. show virtual-chassis (ex22|ex33|ex4|ex8|qfx only)
+8. show chassis fabric reachability (MX960 only)
 9. show configuration
 
 Oxidized can now retrieve your configuration!


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fix formatting error introduced in 87600b1f5f12711afe29c408e02dbbd927e3f25d which mismatched the model specific commands. Off-by-one documentation ;-)

Code reference: https://github.com/ytti/oxidized/blob/38a7a6405036c393eaddd07a375a1b9f3b0b43e4/lib/oxidized/model/junos.rb#L28-L31