### PR TITLE
Fix remove FortiOS IoT-Detect database version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed an issue with FortiOS that didn't accurately match `set ca` lines #2567 (@neilschelly)
 - removed unwanted current date from slxos model
 - fixed secret handling for rip authentication in casa model #2648 (@grahamjohnston)
+- stripped IoT-detect version for Fortigate devices
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -36,7 +36,7 @@ class FortiOS < Oxidized::Model
     cfg.gsub! /(Disk Usage\s+:\s+)(.*)/, '\1<stripped>'
     cfg.gsub! /(^\S+ (?:disk|DB):\s+)(.*)/, '\1<stripped>\3'
     cfg.gsub! /(VM Registration:\s+)(.*)/, '\1<stripped>\3'
-    cfg.gsub! /(Virus-DB|Extended DB|IPS-DB|IPS-ETDB|APP-DB|INDUSTRIAL-DB|Botnet DB|IPS Malicious URL Database|AV AI\/ML Model).*/, '\\1 <db version stripped>'
+    cfg.gsub! /(Virus-DB|Extended DB|IPS-DB|IPS-ETDB|APP-DB|INDUSTRIAL-DB|Botnet DB|IPS Malicious URL Database|AV AI\/ML Model|IoT-Detect).*/, '\\1 <db version stripped>'
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Our Fortigates often have unnecessary config updates due to the IoT database version updating. This PR strips out this version, as is already done for the other DB-versions.
