### PR TITLE
aosw cppm password secret exclude

### DIFF
--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -25,7 +25,7 @@ class AOSW < Oxidized::Model
     cfg.gsub!(/ sha (\S+)/, ' sha <secret removed>')
     cfg.gsub!(/ des (\S+)/, ' des <secret removed>')
     cfg.gsub!(/mobility-manager (\S+) user (\S+) (\S+)/, 'mobility-manager \1 user \2 <secret removed>')
-    cfg.gsub!(/cppm username (\S+) password (\S+)/, 'cppm userneme \1 password <secret removed>')
+    cfg.gsub!(/cppm username (\S+) password (\S+)/, 'cppm username \1 password <secret removed>')
     cfg.gsub!(/mgmt-user (\S+) (root|guest-provisioning|network-operations|read-only|location-api-mgmt) (\S+)$/, 'mgmt-user \1 \2 <secret removed>') # MAS & Wireless Controler
     cfg.gsub!(/mgmt-user (\S+) (\S+)( (read-only|guest-mgmt))?$/, 'mgmt-user \1 <secret removed> \3') # IAP
     # MAS format: mgmt-user <username> <accesslevel> <password hash>

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -25,6 +25,7 @@ class AOSW < Oxidized::Model
     cfg.gsub!(/ sha (\S+)/, ' sha <secret removed>')
     cfg.gsub!(/ des (\S+)/, ' des <secret removed>')
     cfg.gsub!(/mobility-manager (\S+) user (\S+) (\S+)/, 'mobility-manager \1 user \2 <secret removed>')
+    cfg.gsub!(/cppm username (\S+) password (\S+)/, 'cppm userneme \1 password <secret removed>')
     cfg.gsub!(/mgmt-user (\S+) (root|guest-provisioning|network-operations|read-only|location-api-mgmt) (\S+)$/, 'mgmt-user \1 \2 <secret removed>') # MAS & Wireless Controler
     cfg.gsub!(/mgmt-user (\S+) (\S+)( (read-only|guest-mgmt))?$/, 'mgmt-user \1 <secret removed> \3') # IAP
     # MAS format: mgmt-user <username> <accesslevel> <password hash>


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Remove the password from the cppm user command. 
I was seeing this with Aruba Access Points using the instant model with the virtual controller. This command is used to configure access for fetching downloadable user roles from ClearPass and may not be commonly used yet. 

I searched the open issues and exiting pull requests and did not see any related to this yet. 
I hope this meets the requirements for a pull request and can help someone else better benefit from Oxidized. 
