### PR TITLE
Make sure SSH session can end on Netgear correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Cumulus: added option to use NCLU as ia collecting method
 - Update net-ssh to 7.0.0.beta1 (using `append_all_supported_algorithms: true`)
 - Allow (config) (vlan-####) confirmation (y/n) and sftp questions in procurve prompt (@sorano)
+- fix: allow Netgear devices to finish SSH session correctly
 
 ### Added
 

--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -30,7 +30,9 @@ class Netgear < Oxidized::Model
     #     The system has unsaved changes.
     #     Would you like to save them now? (y/n)
     #
-    # So it is safer simply to disconnect and not issue a pre_logout command
+    # As no changes will be made over this simple SSH session, we can safely choose "n" here.
+    pre_logout 'quit'
+    pre_logout 'n'
   end
 
   cmd :all do |cfg, cmdstring|


### PR DESCRIPTION
At the moment, it's not possible for Oxidized to save config on a Netgear device when connected over SSH, as it doesn't correctly finish the SSH session since we don't issue any `pre_logout` commands. This looks to have been previously done as Netgear devices do prompt the below each time an SSH session is ended:

````
The system has unsaved changes.
Would you like to save them now? (y/n)
````

As there are no actual changes being done over the SSH session that Oxidized uses though, it's safe to simply choose "n" here and move along.

Ref #1100 #2531
