### PR TITLE
Fix oxidized.logrotate to not fail if logs missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Cumulus: added option to use NCLU as ia collecting method
 - Update net-ssh to 7.0.0.beta1 (using `append_all_supported_algorithms: true`)
 - Allow (config) (vlan-####) confirmation (y/n) and sftp questions in procurve prompt (@sorano)
+- Update logrotate example to allow logrotate service to start before any logs exist
 
 ### Added
 

--- a/extra/oxidized.logrotate
+++ b/extra/oxidized.logrotate
@@ -4,4 +4,5 @@
     size 10M
     compress
     delaycompress
+    missingok
 }


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Currently if the logs do not yet exist logrotate service will fail. Add missingok to fix.