### PR TITLE
Updated rugged dependency for ruby 3.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for ZPE Nodegrid OS (@euph333)
 - model for H3C switches
 - extended mysql source configuration to include tls options (@glaubway)
+- updated rugged in gemspec for ruby 3.0 support (@firefishy)
 
 ### Changed
 

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ed25519', '~> 1.2'
   s.add_runtime_dependency 'net-ssh', '~> 7.0.0.beta1'
   s.add_runtime_dependency 'net-telnet', '~> 0.2'
-  s.add_runtime_dependency 'rugged',  '~> 0.28.0'
+  s.add_runtime_dependency 'rugged',  '~> 1.5.0.1'
   s.add_runtime_dependency 'slop',    '~> 4.6'
 
   s.add_development_dependency 'bundler', '~> 2.0'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Rugged before v1.0.1 are incompatible with ruby 3.0 Fix upstream: https://github.com/libgit2/rugged/commit/a4ad1dff3d6f7418eda6bbbeb24f70b6e0d43237

Updated rugged gem to latest public release with above upstream fix for ruby 3.0 compatibility.

Fixes: #2620