### PR TITLE
airfiber.rb update for case insensitive prompt.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - use slack-ruby-client instead of slack-api for slackdiff hook (@0xmc)
 - ios: Add support for RBAC in IOS model (@jameskirsop)
 - hide unsupported-transceiver license key in Arista EOS (@davidc)
+- airfiber.rb - Allow for case insensitive prompt (@kmpanilla)
 
 ### Fixed
 

--- a/lib/oxidized/model/airfiber.rb
+++ b/lib/oxidized/model/airfiber.rb
@@ -1,7 +1,7 @@
 class Airfiber < Oxidized::Model
   # Ubiquiti Airfiber (tested with Airfiber 11FX)
 
-  prompt /^AF[\w\.-]+#/
+  prompt /^AF[\w\.-]+#/i
 
   cmd :all do |cfg|
     cfg.cut_both


### PR DESCRIPTION
Need to be able to match the AF5XHD, which is a lower-case prompt:

af5xhd.v1.4.0#

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
AF5XHD has a lower case prompt. Not currently matching the prompt line. Need the regex case insensitivity option added. 

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
