### PR TITLE
EdgeCOS: add support for FS S3900-48T6S-R

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - use slack-ruby-client instead of slack-api for slackdiff hook (@0xmc)
 - ios: Add support for RBAC in IOS model (@jameskirsop)
 - hide unsupported-transceiver license key in Arista EOS (@davidc)
+- edgecos: add support for FS S3900-48T6S-R (@cgsecurity)
 
 ### Fixed
 

--- a/lib/oxidized/model/edgecos.rb
+++ b/lib/oxidized/model/edgecos.rb
@@ -23,6 +23,7 @@ class EdgeCOS < Oxidized::Model
 
   cmd 'show running-config' do |cfg|
     # Remove "building running-config, please wait..." message
+    cfg.gsub! /^Building running configuration.*\n/, ''
     cfg.cut_head
   end
 
@@ -33,6 +34,7 @@ class EdgeCOS < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
+    cfg.gsub! /^.*\suptime is.*\n/i, ''
     comment cfg
   end
 
@@ -56,8 +58,16 @@ class EdgeCOS < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
+    post_login do
+      if vars(:enable) == true
+        send "enable\n"
+      end
+    end
     post_login 'terminal length 0'
     post_login 'terminal width 300'
+    if vars(:enable) == true
+      pre_logout 'exit'
+    end
     pre_logout 'exit'
   end
 end


### PR DESCRIPTION
"enable" is required by FS S3900-48T6S-R before running "show running-config".
Strips uptime from "show version"