### PR TITLE
Casa model: added handling for rip secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ensure local time and system up time are filtered for ADVA devices (@stephrdev)
 - fixed an issue with FortiOS that didn't accurately match `set ca` lines #2567 (@neilschelly)
 - removed unwanted current date from slxos model
+- fixed secret handling for rip authentication in casa model #2648 (@grahamjohnston)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/casa.rb
+++ b/lib/oxidized/model/casa.rb
@@ -10,6 +10,7 @@ class Casa < Oxidized::Model
     cfg.gsub! /^(console-password encrypted) \S+/, '\\1 <secret hidden>'
     cfg.gsub! /^(password encrypted) \S+/, '\\1 <secret hidden>'
     cfg.gsub! /^(tacacs-server key) \S+/, '\\1 <secret hidden>'
+    cfg.gsub! /^(  ip rip authentication secret) \S+/, '\\1 <secret hidden>'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Updated the Casa model to include secret handling for rip authentication secrets.

Closes issues #2647

