### PR TITLE
airfiber: prompt changes to support AF5xHD

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - More pager handling for MIS5030Q (@glance-)
 - Update logrotate example to allow logrotate service to start before any logs exist
 - Mask NX-OS tacacs+ host keys (@0x4c6565)
+- airfiber: prompt matching made case-insensitive to support AF5xHD (@noaheroufus)
 
 ### Added
 

--- a/lib/oxidized/model/airfiber.rb
+++ b/lib/oxidized/model/airfiber.rb
@@ -1,7 +1,7 @@
 class Airfiber < Oxidized::Model
   # Ubiquiti Airfiber (tested with Airfiber 11FX)
 
-  prompt /^AF[\w\.-]+#/
+  prompt /^AF[\w\.-]+#/i
 
   cmd :all do |cfg|
     cfg.cut_both


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Made prompt regex match case-insensitive for the airfiber model. This allows it to support the AF5xHD model which returns a prompt like `af5xhd.*#`

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
