### PR TITLE
Repairing container build to work within constraints of git safe.directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- Fixed an issue where git checkouts would fail with errors about safe.directory permissions (@neilschelly)
 - fixed on issue where Oxidized could not pull config from Opengear devices #1899 (@rikard0)
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ WORKDIR /
 RUN rm -rf /tmp/oxidized
 RUN apt-get -yq --purge autoremove ruby-dev pkg-config make cmake ruby-bundler libssl-dev libssh2-1-dev libicu-dev libsqlite3-dev libmysqlclient-dev libpq-dev zlib1g-dev
 
+# Necessary for new git versions to run git commands in this directory as root
+RUN git config --global --add safe.directory /root/.config/oxidized/configs/devices.git
+
 # add runit services
 COPY extra/oxidized.runit /etc/service/oxidized/run
 COPY extra/auto-reload-config.runit /etc/service/auto-reload-config/run


### PR DESCRIPTION
Starting to see errors running based on safe.directory and permissions, which are tougher to square away inside the docker container:

```
I, [2022-11-08T16:00:47.176135 #1]  INFO -- : Oxidized starting, running as pid 1
I, [2022-11-08T16:00:47.183041 #1]  INFO -- : lib/oxidized/nodes.rb: Loading nodes
I, [2022-11-08T16:00:47.780358 #1]  INFO -- : lib/oxidized/nodes.rb: Loaded 13 nodes
Puma starting in single mode...
* Version 3.11.4 (ruby 2.7.0-p0), codename: Love Song
* Min threads: 0, max threads: 16
* Environment: development
* Listening on tcp://0.0.0.0:8888
Use Ctrl-C to stop
F, [2022-11-08T16:00:55.490046 #1] FATAL -- : Oxidized crashed, crashfile written in /root/.config/oxidized/crash
config value 'safe.directory' was not found
```

I'm not sure this is the "right" fix, because I think that maybe the _real_ answer is to make sure the permissions for the git repo inside the container are set correctly so that `safe.directory` configurations aren't necessary.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
