### PR TITLE
Fix TrueNAS locking contention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fixed an issue with the TrueNAS model where the configuration would come up blank when TrueNAS was also using it. (@neilschelly)
 - fixed on issue where Oxidized could not pull config from Opengear devices #1899 (@rikard0)
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ WORKDIR /
 RUN rm -rf /tmp/oxidized
 RUN apt-get -yq --purge autoremove ruby-dev pkg-config make cmake ruby-bundler libssl-dev libssh2-1-dev libicu-dev libsqlite3-dev libmysqlclient-dev libpq-dev zlib1g-dev
 
+# Necessary for new git versions to run git commands in this directory as root
+RUN git config --global --add safe.directory /root/.config/oxidized/configs/devices.git
+
 # add runit services
 COPY extra/oxidized.runit /etc/service/oxidized/run
 COPY extra/auto-reload-config.runit /etc/service/auto-reload-config/run

--- a/lib/oxidized/model/truenas.rb
+++ b/lib/oxidized/model/truenas.rb
@@ -3,7 +3,7 @@ class TrueNAS < Oxidized::Model
 
   cmd('uname -a') { |cfg| comment cfg }
   cmd('cat /etc/version') { |cfg| comment cfg }
-  cmd('sqlite3 /data/freenas-v1.db .dump') do |cfg|
+  cmd('sqlite3 "file:///data/freenas-v1.db?mode=ro&immutable=1" .dump') do |cfg|
     cfg.lines.reject { |line|
       line.match(/^INSERT INTO storage_replication /) or
       line.match(/^INSERT INTO system_alert /)


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

There's an occasional race condition in the TrueNAS module. When the TrueNAS software is accessing the SQLite database, the command to dump it will fail and output only: 

```
/**** ERROR: (5) database is locked *****/
ROLLBACK; -- due to errors
```

This command invocation ought to get it to open even if it's locked, with the promise of being a read-only session.