### PR TITLE
Rugged ssh fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- fixed issue with newer versions of Rugged gem and SSH git repos #2217 (@neilschelly, credit to @eimann)
 - fixed on issue where Oxidized could not pull config from Opengear devices #1899 (@rikard0)
 - fixed an issue where Oxidized could not pull config from XOS-devices operating in stacked mode (@DarkCatapulter)
 - fixed an issue where Oxidized could not pull config from XOS-devices that have not saved their configuration (@DarkCatapulter)

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ WORKDIR /
 RUN rm -rf /tmp/oxidized
 RUN apt-get -yq --purge autoremove ruby-dev pkg-config make cmake ruby-bundler libssl-dev libssh2-1-dev libicu-dev libsqlite3-dev libmysqlclient-dev libpq-dev zlib1g-dev
 
+# Necessary for new git versions to run git commands in this directory as root
+RUN git config --global --add safe.directory /root/.config/oxidized/configs/devices.git
+
 # add runit services
 COPY extra/oxidized.runit /etc/service/oxidized/run
 COPY extra/auto-reload-config.runit /etc/service/auto-reload-config/run

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get -yq update \
 
 # dependencies for hooks
 RUN gem install aws-sdk slack-ruby-client xmpp4r cisco_spark --no-document
+RUN gem install rugged -- --with-ssh
 
 # dependencies for sources
 RUN gem install gpgme sequel sqlite3 mysql2 pg --no-document


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
There's a Rugged gem issue with SSH git repositories described in https://github.com/ytti/oxidized/issues/2217. Credit goes to @eimann for the fix described in that issue.