### PR TITLE
feat: run oxidized as non-root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - install rugged with ssh in Dockerfile (@agrevtcev)
+- allow to run as non-root user in Docker (@agrevtcev)
 - Extend http source configurations to include read_timeout value
 - model for bdcom-based fiberstore switches (@candlerb)
 - enterasys800 model for enterasys 800-series fe/ge switches (@javichumellamo)

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,10 @@ WORKDIR /
 RUN rm -rf /tmp/oxidized
 RUN apt-get -yq --purge autoremove ruby-dev pkg-config make cmake ruby-bundler libssl-dev libssh2-1-dev libicu-dev libsqlite3-dev libmysqlclient-dev libpq-dev zlib1g-dev
 
-# Necessary for new git versions to run git commands in this directory as root
-RUN git config --global --add safe.directory /root/.config/oxidized/configs/devices.git
+# add non-privileged user
+ARG UID=30000
+ARG GID=$UID
+RUN groupadd -g "${GID}" -r oxidized && useradd -u "${UID}" -r -m -d /home/oxidized -g oxidized oxidized
 
 # add runit services
 COPY extra/oxidized.runit /etc/service/oxidized/run

--- a/extra/oxidized.runit
+++ b/extra/oxidized.runit
@@ -1,2 +1,5 @@
 #!/bin/bash
-exec setuser root oxidized
+[ ! -d /home/oxidized/.config/oxidized ] && mkdir -p /home/oxidized/.config/oxidized
+[ -f /home/oxidized/.config/oxidized/pid ] && rm /home/oxidized/.config/oxidized/pid
+chown -R oxidized:oxidized /home/oxidized/.config/oxidized
+exec setuser oxidized oxidized


### PR DESCRIPTION
run oxidized as non-root user
parameterize oxidized UID and GID on build

## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This is to allow run oxidized in docker-container as non-root (oxidized) user. Said user UID and GID could be adjusted on image build.