### PR TITLE
Feature/Add support to create custom version tag in a release

### DIFF
--- a/.github/workflows/publishdocker.yml
+++ b/.github/workflows/publishdocker.yml
@@ -6,9 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - name: Get Release Version
+      id: get_version
+      run: echo ::save-state name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
     - name: Publish to Registry
       uses: elgohr/Publish-Docker-Github-Action@master
       with:
         name: oxidized/oxidized
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ env.STATE_RELEASE_VERSION }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Mask NX-OS tacacs+ host keys (@0x4c6565)
 - airfiber: prompt matching made case-insensitive to support AF5xHD (@noaheroufus)
 - Cumulus: add support for dhcp-relay (@ohai89)
+- Github Action: Support creating custom version tag in a release
 
 ### Added
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Github Action - Support creating a custom version tag in a release.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
#1956 