### PR TITLE
Add support for no enable password set on ironware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Mask NX-OS tacacs+ host keys (@0x4c6565)
 - airfiber: prompt matching made case-insensitive to support AF5xHD (@noaheroufus)
 - Cumulus: add support for dhcp-relay (@ohai89)
+- Add support for no enable password set on ironware
 
 ### Added
 
@@ -51,7 +52,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - Better manage of the enable mode in edgeswitch.rb (@agabellini)
 - Adds paging support to Enterasys B3/C3 (@piterpunk)
-- Allows "Username" as username prompt in Brocade ICX-series devices (@piterpunk) 
+- Allows "Username" as username prompt in Brocade ICX-series devices (@piterpunk)
 - Add show-sensitive flag on export command on Mikrotik RouterOS when remove_secret is off (@kedare)
 - rubocop dependency now ~> 0.81.0, the last one with ruby 2.3 support
 - change pfSense secret scrubbing to handle new format in 2.4.5+
@@ -98,7 +99,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - filter next periodic save schedule time in xos model output (@sargon)
 - Fix when auto-saved is configured on xos switches  (@trappiz)
 - fixed ArubaOS-CX enviroment/system inconsistent values #2297 (@raunz)
-- further improvements to ArubaOS-CX environment values (@olemyhre) 
+- further improvements to ArubaOS-CX environment values (@olemyhre)
 - Update AirFiber prompt regex (@murrant)
 - System time and running time are now stripped from tplink model output (@spike77453)
 - &lt;?xml... line is no longer improperly stripped from OPNsense and PFsense backups (@pv2b)

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -75,9 +75,13 @@ class IronWare < Oxidized::Model
   # handle pager with enable
   cfg :telnet, :ssh do
     if vars :enable
-      post_login do
-        send "enable\r\n"
-        cmd vars(:enable)
+      if vars(:enable).is_a? TrueClass
+        post_login 'enable'
+      else
+        post_login do
+          send "enable\r\n"
+          cmd vars(:enable)
+        end
       end
     end
     post_login ''


### PR DESCRIPTION
Example:
```
telnet@lb1.adx1016> enable
No password has been assigned yet...
telnet@lb1.adx1016#
```

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
