### PR TITLE
work on cmd method to get expects in models again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -117,6 +117,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - removed unwanted current date from slxos model
 - fixed secret handling for rip authentication in casa model #2648 (@grahamjohnston)
 - stripped IoT-detect version for Fortigate devices
+- Fix expect usage in models on telnet. Tested with Netgear GS108T. (@arrjay)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/input/telnet.rb
+++ b/lib/oxidized/input/telnet.rb
@@ -43,7 +43,7 @@ module Oxidized
       out = String(' ')
       @telnet.puts(cmd_str)
       @telnet.oxidized_expect(timeout: @timeout, expect: expect, out: out)
-      return out
+      out
     end
 
     def send(data)
@@ -112,9 +112,7 @@ class Net::Telnet
         # match is a regexp object. we need to return that for logins to work.
         match = expects.find { |re| line.match re }
         # stomp on the out string object if we have one. (thus we were called by cmd?)
-        if options[:out]
-          options[:out].replace(line)
-        end
+        options[:out].replace(line) if options[:out]
         return match if match
       end
     end

--- a/lib/oxidized/input/telnet.rb
+++ b/lib/oxidized/input/telnet.rb
@@ -35,13 +35,15 @@ module Oxidized
     end
 
     def cmd(cmd_str, expect = @node.prompt)
+      Oxidized.logger.debug "Telnet: #{cmd_str} @#{@node.name}"
       return send(cmd_str + "\r\n") unless expect
 
-      Oxidized.logger.debug "Telnet: #{cmd_str} @#{@node.name}"
-      args = { 'String'  => cmd_str,
-               'Match'   => expect,
-               'Timeout' => @timeout }
-      @telnet.cmd args
+      # create a string to be passed to oxidized_expect and modified _there_
+      # default to a single space so it shouldn't be coerced to nil by any models.
+      out = String(' ')
+      @telnet.puts(cmd_str)
+      @telnet.oxidized_expect(timeout: @timeout, expect: expect, out: out)
+      return out
     end
 
     def send(data)
@@ -107,7 +109,12 @@ class Net::Telnet
         end
         line += buf
         line = model.expects line
+        # match is a regexp object. we need to return that for logins to work.
         match = expects.find { |re| line.match re }
+        # stomp on the out string object if we have one. (thus we were called by cmd?)
+        if options[:out]
+          options[:out].replace(line)
+        end
         return match if match
       end
     end


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)

- [ ] Tests added or adapted (try `rake test`)
several rake tests did fail, but they were all related to git operations? I'm not sure the best ways to test this.
- [ ] Changes are reflected in the documentation
models now work as already documented when using telnet.
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)
I think the maintainer gets to decide where to do that.

## Description
this updates the cmd method to run through oxidized_expect and grab the resulting output buffer. this allows for models using expect (like the GS108T referenced in #2591) to work. I did not update that model here, as this is more for the core expect functionality.

Closes issue #2296 