### PR TITLE
pfsense: Change <secret hidden> to [secret hidden]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - airfiber: prompt matching made case-insensitive to support AF5xHD (@noaheroufus)
 - Cumulus: add support for dhcp-relay (@ohai89)
 - Add support for no enable password set on ironware
+- change pfSense secret scrubbing to keep config as well-formed XML
 
 ### Added
 

--- a/lib/oxidized/model/pfsense.rb
+++ b/lib/oxidized/model/pfsense.rb
@@ -2,9 +2,9 @@ class PfSense < Oxidized::Model
   # use other use than 'admin' user, 'admin' user cannot get ssh/exec. See issue #535
 
   cmd :secret do |cfg|
-    cfg.gsub! /(\s+<bcrypt-hash>).+?(<\/bcrypt-hash>)/, '\\1<secret hidden>\\2'
-    cfg.gsub! /(\s+<password>).+?(<\/password>)/, '\\1<secret hidden>\\2'
-    cfg.gsub! /(\s+<lighttpd_ls_password>).+?(<\/lighttpd_ls_password>)/, '\\1<secret hidden>\\2'
+    cfg.gsub! /(\s+<bcrypt-hash>).+?(<\/bcrypt-hash>)/, '\\1[secret hidden]\\2'
+    cfg.gsub! /(\s+<password>).+?(<\/password>)/, '\\1[secret hidden]\\2'
+    cfg.gsub! /(\s+<lighttpd_ls_password>).+?(<\/lighttpd_ls_password>)/, '\\1[secret hidden]\\2'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
In pfSense secret scrubbing, change `<secret hidden>` to `[secret hidden]`

This is so that the config remains as well-formed XML and can be read by an XML parser.