### PR TITLE
MikroTik SwOS Model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- model for MikroTik SwOS devicse (@sm-nessus)
 - model for TrueNAS devices (@neilschelly)
 - model for Acme Packet devices (@ha36d)
 - Cumulus: added option to use NCLU as ia collecting method

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -179,6 +179,7 @@
   * [Voltaire](/lib/oxidized/model/voltaire.rb)
 * Mikrotik
   * [RouterOS](/lib/oxidized/model/routeros.rb)
+  * [SwOS and SwOS Lite](/lib/oxidized/model/swos.rb)
 * Motorola
   * [RFS](/lib/oxidized/model/mtrlrfs.rb)
 * MRV

--- a/lib/oxidized/model/swos.rb
+++ b/lib/oxidized/model/swos.rb
@@ -1,0 +1,9 @@
+# Mikrotik SwOS (Lite)
+class SwOS < Oxidized::Model
+  cmd '/backup.swb'
+  cfg :http do
+    @username = @node.auth[:username]
+    @password = @node.auth[:password]
+    @secure = false
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
  RuboCop on Ubuntu 22.04 doesn't support Ruby 2.3:
```
Error: RuboCop found unsupported Ruby version 2.3 in `TargetRubyVersion` parameter (in .rubocop.yml). 2.3-compatible analysis was dropped after version 0.81.
Supported versions: 2.4, 2.5, 2.6, 2.7, 2.8
```
  Please let me know how to proceed, whether I need to downgrade RuboCop, or you want to change the target version (or if the analysis is not needed).
- [ ] Tests added or adapted (try `rake test`)
  I haven't found any model tests, please let me know if I missed it or if there are no tests for models.
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added support for MikroTik SwOS Lite and most likely for other SwOS versions. I only have a SwOS Lite device, which I've tested against.

I have no experience with Ruby, so I've adapted the code from the "Zyxel OLTs series 1308" model (zy1308.rb).

Please let me know if there are any issues.

Thanks!
