### PR TITLE
Update purityos.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed secret handling for rip authentication in casa model #2648 (@grahamjohnston)
 - stripped IoT-detect version for Fortigate devices
 - Fix expect usage in models on telnet. Tested with Netgear GS108T. (@arrjay)
+- purityos: at least v6.3.5 needs other terminal settings (@elliot64)
+- purityos: remove purealerts and VEEAM snapshots from backed up config (@elliot64)
 
 ## [0.28.0 - 2020-05-18]
 

--- a/lib/oxidized/model/purityos.rb
+++ b/lib/oxidized/model/purityos.rb
@@ -1,4 +1,4 @@
-lass PurityOS < Oxidized::Model
+class PurityOS < Oxidized::Model
   # Pure Storage Purity OS
 
   prompt /\w+@\S+(\s+\S+)*\s?>\s?$/

--- a/lib/oxidized/model/purityos.rb
+++ b/lib/oxidized/model/purityos.rb
@@ -7,6 +7,7 @@ class PurityOS < Oxidized::Model
   cmd 'pureconfig list'
 
   cfg :ssh do
+    pty_options(term: "dumb")
     pre_logout 'exit'
   end
 end

--- a/lib/oxidized/model/purityos.rb
+++ b/lib/oxidized/model/purityos.rb
@@ -1,10 +1,16 @@
-class PurityOS < Oxidized::Model
+lass PurityOS < Oxidized::Model
   # Pure Storage Purity OS
 
   prompt /\w+@\S+(\s+\S+)*\s?>\s?$/
   comment '# '
 
-  cmd 'pureconfig list'
+  cmd 'pureconfig list' do |cfg|
+    cfg.gsub! /^purealert flag \d+$/, ''
+    cfg.gsub! /(.*VEEAM-StorageLUNSnap-[0-9a-f].*)/, ''
+    cfg.gsub! /(.*VEEAM-ExportLUNSnap-[0-9A-F].*)/, ''
+    # remove empty lines
+    cfg.each_line.reject { |line| line.match /^[\r\n\s\u0000#]+$/ }.join
+  end
 
   cfg :ssh do
     pty_options(term: "dumb")


### PR DESCRIPTION
PurityOS 6.3.5 does some kind of color-coding/ cursor-positioning things when connecting with SSH. Adjust the terminalsettings to dumb.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Added PTY option to set terminal type to dumb.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
