### PR TITLE
Add Model for Catalyst Express switches (ciscoce.rb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for YAMAHA NVR/RTX Series (@bluekirin55)
 - model for ZPE Nodegrid OS (@euph333)
 - model for H3C switches
+- model for Cisco Catalyst Express switches
 - extended mysql source configuration to include tls options (@glaubway)
 - updated rugged in gemspec for ruby 3.0 support (@firefishy)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,7 +51,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for YAMAHA NVR/RTX Series (@bluekirin55)
 - model for ZPE Nodegrid OS (@euph333)
 - model for H3C switches
-- model for Cisco Catalyst Express switches
+- model for Cisco Catalyst Express switches (@unemongod)
 - extended mysql source configuration to include tls options (@glaubway)
 - updated rugged in gemspec for ruby 3.0 support (@firefishy)
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -74,6 +74,7 @@
   * [ASA](/lib/oxidized/model/asa.rb)
   * [AsyncOS](/lib/oxidized/model/asyncos.rb)
   * [CatOS](/lib/oxidized/model/catos.rb)
+  * [Cisco Catalyst Express](/lib/oxidized/model/ciscoce.rb)
   * [FireLinuxOS](/lib/oxidized/model/firelinuxos.rb)
   * [IOS](/lib/oxidized/model/ios.rb)
   * [IOSXR](/lib/oxidized/model/iosxr.rb)

--- a/lib/oxidized/model/ciscoce.rb
+++ b/lib/oxidized/model/ciscoce.rb
@@ -1,0 +1,11 @@
+class CiscoCE < Oxidized::Model #Supporting Cisco Catalyst Express Switches and IOS using the basic web interface
+  cmd "/level/15/exec/-/show/startup-config" do |cfg|
+    output = cfg.gsub(/\A.+<DL>(.+)<\/DL>.+\z/m, '\1') # Strip configuration file from within HTML response.
+    output
+  end
+
+  cfg :http do
+    @username = @node.auth[:username]
+    @password = @node.auth[:password]
+  end
+end


### PR DESCRIPTION
New model for Cisco Catalyst Express switches.  They are IOS switches, but the SSH and Telnet interfaces are permanently disabled.  This will pull the configuration via the web interface.  It should also work on older IOS devices that have the basic web interface enabled.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
