### PR TITLE
Modifications to allow HPE Office Connect 1950 xtd-cli-mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Github Action: Support creating custom version tag in a release
 - Add support for no enable password set on ironware
 - change pfSense secret scrubbing to keep config as well-formed XML
+- Add support for comware HPE Office Connect 1950
 
 ### Added
 

--- a/lib/oxidized/model/comware.rb
+++ b/lib/oxidized/model/comware.rb
@@ -56,8 +56,9 @@ class Comware < Oxidized::Model
         cmd vars(:comware_cmdline)
 
         # HP V1950 OS r3208 (v7.1)
-        cmd 'xtd-cli-mode', /(#{@node.prompt}|Continue)/
-        cmd 'y', /(#{@node.prompt}|input password)/
+        # HPE Office Connect 1950
+        cmd 'xtd-cli-mode', /(#{@node.prompt}|Continue|Switch)/
+        cmd 'y', /(#{@node.prompt}|input password|Password:)/
         cmd vars(:comware_cmdline)
       end
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Added support to comware type switch HPE Office Connect 1950.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
