### PR TITLE
Added Hirschmann HiOS next to Hirschmann Classic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add support for no enable password set on ironware
 - change pfSense secret scrubbing to keep config as well-formed XML
 - Add support for comware HPE Office Connect 1950
-- model for Hirschmann Hios devices (@tijldeneut)
+- Added model for Hirschmann Hios devices, next to alread present Hirschmann classic (@tijldeneut)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Add support for no enable password set on ironware
 - change pfSense secret scrubbing to keep config as well-formed XML
 - Add support for comware HPE Office Connect 1950
+- model for Hirschmann Hios devices (@tijldeneut)
 
 ### Added
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -150,7 +150,8 @@
 * Hillstone Networks
   * [StoneOS](/lib/oxidized/model/stoneos.rb)
 * Hirschmann
-  * [HiOS](/lib/oxidized/model/hirschmann.rb)
+  * [Classic](/lib/oxidized/model/hirschmann.rb)
+  * [HiOS](/lib/oxidized/model/hios.rb)
 * HP
   * [Comware (HP A-series, H3C, 3Com)](/lib/oxidized/model/comware.rb)
   * [Procurve](/lib/oxidized/model/procurve.rb)

--- a/lib/oxidized/model/hios.rb
+++ b/lib/oxidized/model/hios.rb
@@ -23,8 +23,6 @@ class Hios < Oxidized::Model
   end
 
   cmd 'show running-config script' do |cfg|
-    ## User creds are not shown with the command above
-    #cfg.gsub! /^users.*\n/, ""
     cfg
   end
 

--- a/lib/oxidized/model/hios.rb
+++ b/lib/oxidized/model/hios.rb
@@ -1,0 +1,40 @@
+class Hios < Oxidized::Model
+  ## Docker location: /var/lib/gems/2.7.0/gems/oxidized-0.28.0/lib/oxidized/model/hios.rb
+  prompt /^\[[\w\s\W]+\][>|#]+?$/
+
+  comment '## '
+
+  # Handle pager
+  expect /^--More--.*$/ do |data, re|
+    send 'n'
+    data.sub re, ''
+  end
+
+  cmd :all do |cfg|
+    cfg.cut_both
+  end
+
+  cmd 'show system info' do |cfg|
+    cfg.gsub! /^System uptime.*\n/, ""
+    cfg.gsub! /^Operating hours.*\n/, ""
+    cfg.gsub! /^System date.*\n/, ""
+    cfg.gsub! /^Current temperature.*\n/, ""
+    comment cfg
+  end
+
+  cmd 'show running-config script' do |cfg|
+    ## User creds are not shown with the command above
+    #cfg.gsub! /^users.*\n/, ""
+    cfg
+  end
+
+  cfg :telnet do
+    username /^User:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    post_login 'enable'
+    pre_logout "logout\nY\r\n"
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Figured it out:
- The original Hirschmann CLI in Oxidized only worked for classic CLI environments, details on this [classic CLI here](https://www.doc.hirschmann.com/pdf/ManualCollection_Classic_L2P_09000_en.pdf)
- The added file hios.rb now works for more recent Hirschmann Industrial switches running HiOS, details on the [HiOS CLI here](https://www.doc.hirschmann.com/pdf/RM_CLI_HiOS-09001_Overview_en.pdf)

Note that the classic OS was sometimes also called HiOS, as seen in the filename [here](https://www.doc.hirschmann.com/pdf/RM_CLI_RSB20_Classic-HiOS-L2B-05300_en.pdf), but the text itself does not reference HiOS.

More evidence (Classic vs HiOS) here: http://www.doc.hirschmann.com/migration.html

### Tested on
- Hirschmann MACH Release L2P-09.0.19 and L2P-09.1.07 (for regular _hirschmann.rb_)
- Hirschmann GRS1042-AT2Z HiOS-2A-09.1.00 (for _hios.rb_)

Regards
