### PR TITLE
Fixes #2615 - Use correct Slack Web Client config object

### DIFF
--- a/lib/oxidized/hook/slackdiff.rb
+++ b/lib/oxidized/hook/slackdiff.rb
@@ -14,7 +14,7 @@ class SlackDiff < Oxidized::Hook
     return unless ctx.event.to_s == "post_store"
 
     log "Connecting to slack"
-    Slack.configure do |config|
+    Slack::Web::Client.configure do |config|
       config.token = cfg.token
       config.proxy = cfg.proxy if cfg.has_key?('proxy')
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

#2576 switched to a different Slack web client, but did not also refactor the configuration object that is needed when a proxy is configured. This patch refactors the configuration object to the new client as well.

Closes #2615 