### PR TITLE
Allow dots & dashes in cumulus prompt username

### DIFF
--- a/lib/oxidized/model/cumulus.rb
+++ b/lib/oxidized/model/cumulus.rb
@@ -1,5 +1,5 @@
 class Cumulus < Oxidized::Model
-  prompt /^((\w*)@(.*)):/
+  prompt /^(([\w.-]*)@(.*)):/
   comment '# '
 
   # add a comment in the final conf


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Update cumulus model prompt to allow usernames with `-` or `.` to match; both are valid on the platform.