### PR TITLE
Add support for MS Teams Webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for Cisco Catalyst Express switches (@unemongod)
 - extended mysql source configuration to include tls options (@glaubway)
 - updated rugged in gemspec for ruby 3.0 support (@firefishy)
+- Added exec hook for MS Teams webhook (@systeembeheerder)
 
 ### Changed
 

--- a/extra/gitdiff-msteams.sh
+++ b/extra/gitdiff-msteams.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+# Posts a git diff to MS Team Channel using webhooks
+#
+# Usage:
+#   Make sure jq and curl are installed.
+#   Save this script in /var/lib/oxidized/extra/
+#   Add to oxidized config:
+#
+# hooks:
+#  ms_teams_webhook:
+#    type: exec
+#    events: [post_store]
+#    cmd: '/var/lib/oxidized/extra/gitdiff-msteams.sh'
+#    async: true
+#    timeout: 120
+#
+# Add webhook to your MS Teams channel and set the next variable to the full url
+
+weburl="https://contoso.webhook.office.com/webhookb2/etc etc etc"
+
+postdata()
+{
+    COMMIT=$(git --bare --git-dir="${OX_REPO_NAME}" show --pretty='' --no-color "${OX_REPO_COMMITREF}" | jq --raw-input --slurp --compact-output)
+    cat <<EOF
+{
+   "type":"message",
+   "attachments":[
+      {
+         "contentType":"application/vnd.microsoft.card.adaptive",
+         "contentUrl":null,
+         "content":{
+            "$schema":"http://adaptivecards.io/schemas/adaptive-card.json",
+            "type":"AdaptiveCard",
+            "version":"1.2",
+            "msTeams": { "width": "full" },
+            "body":[
+                {
+                    "type": "TextBlock",
+                    "text": "Oxidized update for ${OX_NODE_NAME}",
+                    "size": "medium",
+                    "weight": "Bolder",
+                    "style": "heading",
+                    "wrap": "true"
+                },
+                {
+                    "type": "FactSet",
+                    "facts": [
+                        {
+                            "title": "Node name",
+                            "value": "${OX_NODE_NAME}"
+                        },
+                        {
+                            "title": "Job status",
+                            "value": "${OX_JOB_STATUS}"
+                        },
+                        {
+                            "title": "Job time",
+                            "value": "${OX_JOB_TIME}"
+                        },
+                        {
+                            "title": "Git repo",
+                            "value": "${OX_REPO_NAME}"
+                        },
+                        {
+                            "title": "Git commit ID",
+                            "value": "${OX_REPO_COMMITREF}"
+                        }
+                    ]
+                },
+                {
+                    "type": "RichTextBlock",
+                    "inlines": [
+                        {
+                            "type": "TextRun",
+                            "text": ${COMMIT},
+                            "fontType": "monospace",
+                            "size": "small"
+                        }
+                    ]
+                }
+           ]
+         }
+      }
+   ]
+}
+EOF
+}
+
+curl -i \
+-H "Content-Type: application/json" \
+-X POST --data "$(postdata)" "${weburl}"


### PR DESCRIPTION
Add support for MS Teams webhooks to Oxidized

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add support for MS Teams webhooks. Closes ussue #1987
