### PR TITLE
Fix support for NXOS devices with Enable configured

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix Sonicwall SonicOS "system-uptime" omission from log (@lazynooblet)
 - purityos: at least v6.3.5 needs other terminal settings (@elliot64)
 - purityos: remove purealerts and VEEAM snapshots from backed up config (@elliot64)
+- fixed an issue where Oxidized could not pull configs from Cisco NXOS devices with Enable set (@admiralspark)
 
 ## [0.28.0 - 2020-05-18]
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Added support for the enable command on NXOS, allowing Oxidized to gather configurations from devices with Enable set. 

Previously, Oxidized did not support the Enable command on NXOS, only IOS (and derivatives), and backups of configurations with Oxidized timed out due to being unable to set terminal length to 0. 

Additionally, this change supports the extra commands needed to exit the SSH session cleanly, and handles the abnormal newline spacing differences between NXOS 7 and NXOS 9 when running the enable command.

Please see Issue #2714 for more details, including proof of fix. 

Also, I can't seem to set commits to be squashed for this PR but would like that enabled if possible. 

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Closes issue #2714