### PR TITLE
Use the git class of the ruby git project to improve performance

### DIFF
--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -80,7 +80,6 @@ module Oxidized
       commits = repo.log.grep("#{path}$")
 
       commits.each do |commit|
-        puts "LIB_SHA: " + commit.sha
         hash = {}
         hash[:date] = commit.date.to_s
         hash[:oid] = commit.sha

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -73,11 +73,12 @@ module Oxidized
     # give a hash of all oid revision for the given node, and the date of the commit
     def version(node, group)
       repo, path = yield_repo_and_path(node, group)
-      repo = RubyGit.bare repo
+      repo = RubyGit.bare(repo)
+      repo_log = RubyGit::Log.new(repo, false) #  do not limit amount of commits
 
       i = -1
       tab = []
-      commits = repo.log.grep("#{path}$")
+      commits = repo_log.grep("#{path}$")
 
       commits.each do |commit|
         hash = {}


### PR DESCRIPTION
With this change and a commit count of 37000+, the required loading time of /node/version?node_full=[…] drops from 30+ (even 40) seconds down to not even one … (Note: To avoid class name overwriting, line 2 defines an alternativ class name)

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

Hello,

as our oxidized git repository reached way over 30000 commits, performance on showing the config version for a single node was horrible – sometimes even over 40 seconds whereas 25+ was pretty standard (per page load, mind you). Same goes for the diff display.

I am practically new to Ruby (until yesterday I haven’t even seen a single line of Ruby, I believe), so forgive me beginner mistakes … anyway: The Rugged class(? module?) runs over every commit, which is not really effective. There is an issue where that specific use case is adressed (https://github.com/libgit2/rugged/issues/343), but sadly neither the author or anyone else was motivated enough for a solution/a fix.

Nevertheless: In this specific case, Rugged is not beneficial, which is why I am using the same Git class as output/gitcrypt.rb does.

I am not sure, if 'git' has to become a runtime dependency, currently it is only a development dependency – and I had to install via "gem install", otherwise an error occurs. Could someone confirm this? Or is it just a missing line of source code in output/git.rb?

(By the way … am I blind or are there no tests …?)
