### PR TITLE
Build the rugged version we use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,13 @@ RUN gem install gpgme sequel sqlite3 mysql2 pg --no-document
 # dependencies for inputs
 RUN gem install net-tftp net-http-persistent mechanize --no-document
 
-# https://github.com/ytti/oxidized/issues/2217#issuecomment-1288471096
-RUN gem install --no-document rugged:1.5.0.1 -- --with-ssh
-
 # build and install oxidized
 COPY . /tmp/oxidized/
 WORKDIR /tmp/oxidized
 
 # docker automated build gets shallow copy, but non-shallow copy cannot be unshallowed
 RUN git fetch --unshallow || true
-RUN rake install
+RUN CMAKE_FLAGS='-DUSE_SSH=ON' rake install
 
 # web interface
 RUN gem install oxidized-web --no-document

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN gem install gpgme sequel sqlite3 mysql2 pg --no-document
 RUN gem install net-tftp net-http-persistent mechanize --no-document
 
 # https://github.com/ytti/oxidized/issues/2217#issuecomment-1288471096
-RUN gem install --no-document rugged -- --with-ssh
+RUN gem install --no-document rugged:1.5.0.1 -- --with-ssh
 
 # build and install oxidized
 COPY . /tmp/oxidized/


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
When rugged is installed without defining a version, the newest version is build.
But then oxidized installs version 1.5.0.1 without ssh support later

Ending up with oxidized using version 1.5.0.1 without ssh support

Closes issue 2711

