### PR TITLE
Add Palo Alto HTTP API model (panos_api)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- model for PanOS & Panorama via HTTP API (@pv2b, @sts)
 - model for MikroTik SwOS devicse (@sm-nessus)
 - model for TrueNAS devices (@neilschelly)
 - model for Acme Packet devices (@ha36d)

--- a/docs/Model-Notes/PanOS_API.md
+++ b/docs/Model-Notes/PanOS_API.md
@@ -1,0 +1,28 @@
+# PanOS API
+
+Backup Palo Alto XML configuration via the HTTP API. Works for PanOS and Panorama.
+
+Logs in using username and password and fetches an API key.
+
+## Requirements
+
+- Create a user with a `Superuser (read-only)` admin role in Panorama or PanOS
+- Make sure the `nokogiri` gem is installed with your oxidized host
+
+## Configuration
+
+Make sure the following is configured in the oxidized config:
+
+```yaml
+# allow ssl host name verification
+resolve_dns: false
+input:
+  default: ssh, http
+  http:
+    secure: true
+    ssl_verify: true
+
+# model specific configuration
+#model:
+#  panos_api:
+```

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -204,7 +204,8 @@
 * [OpenWRT](/lib/oxidized/model/openwrt.rb)
 * [OPNsense](/lib/oxidized/model/opnsense.rb)
 * Palo Alto
-  * [PANOS](/lib/oxidized/model/panos.rb)
+  * [PanOS API](/lib/oxidized/model/panos_api.rb)
+  * [PanOS](/lib/oxidized/model/panos.rb)
 * [PLANET SG/SGS Switches](/lib/oxidized/model/planet.rb)
 * [pfSense](/lib/oxidized/model/pfsense.rb)
 * Pure Storage

--- a/lib/oxidized/model/panos_api.rb
+++ b/lib/oxidized/model/panos_api.rb
@@ -1,0 +1,71 @@
+# PanOS API-based model for Oxidized
+#
+# The API-based model produced an XML configuration file that can actually be
+# restored as a configuration backup. Make sure to use the "http" input for
+# this module.
+
+begin
+  # Nokogiri is required because the PanOS API, as well as the
+  # configuration file format uses XML. It is required to parse API
+  # responses, as well as to pretty-print the configuration XML file
+  # when saving it.
+  require 'nokogiri'
+rescue LoadError
+  # Oxidized itself depends on mechanize, which in turn depends on
+  # nokogiri, so this should never happen.
+  raise Oxidized::OxidizedError, 'nokogiri not found: sudo gem install nokogiri'
+end
+
+class PanOS_API < Oxidized::Model # rubocop:disable Naming/ClassAndModuleCamelCase
+  # Callback function for getting the configuration file.
+  cfg_cb = lambda do
+    url_param = URI.encode_www_form(
+      user:     @node.auth[:username],
+      password: @node.auth[:password],
+      type:     'keygen'
+    )
+
+    kg_r = get_http "/api?#{url_param}"
+
+    # Parse the XML API response for the keygen request.
+    kg_x = Nokogiri::XML(kg_r)
+
+    # Check if keygen was successful. If not we'll throw an error.
+    status = kg_x.xpath('//response/@status').first
+    if status.to_s != 'success'
+      msg = kg_x.xpath('//response/result/msg').text
+      raise Oxidized::OxidizedError, "Could not generate PanOS API key: #{msg}"
+    end
+
+    # If we reach here, keygen was successful, so get the API key
+    # out of the keygen XML response.
+    apikey = kg_x.xpath('//response/result/key').text.to_s
+
+    # Now that we have the API key, we can request a configuration
+    # export.
+    url_param = URI.encode_www_form(
+      key:      apikey,
+      category: 'configuration',
+      type:     'export'
+    )
+
+    cfg = get_http "/api?#{url_param}"
+
+    # The configuration export is in XML format. Unfortunately,
+    # it's just one long line of XML that's not especially human
+    # readable or diffable.
+    #
+    # Thus, we will load the XML document and then emit it again
+    # with indentation set up, so that it's still a valid
+    # configuration, and also possible to read.
+    Nokogiri::XML(cfg).to_xml(indent: 2)
+  end
+
+  # Define the command based on the callback above.
+  cmd cfg_cb
+
+  cfg :http do
+    # Palo Alto's API always requires HTTPS as far as I know.
+    @secure = true
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Add Palo Alto model to allow backups of the XML configuration via the HTTP API. Reworked original [PR](https://github.com/ytti/oxidized/pull/2360)

Related #1110, #1287, #2434
Closes #1706
