### PR TITLE
Update Dockerfile with minor comment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,8 @@ WORKDIR /tmp/oxidized
 
 # docker automated build gets shallow copy, but non-shallow copy cannot be unshallowed
 RUN git fetch --unshallow || true
+
+# Ensure rugged is built with ssh support
 RUN CMAKE_FLAGS='-DUSE_SSH=ON' rake install
 
 # web interface


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add detail about `CMAKE_FLAGS='-DUSE_SSH=ON'` being used to ensure rugged build with SSH support.
