### PR TITLE
Fix git diff detection

### DIFF
--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -80,10 +80,8 @@ module Oxidized
       tab = []
       walker.each do |commit|
         # Diabled rubocop because the suggested .empty? does not work here.
-        # rubocop:disable Style/ZeroLengthPredicate
-        next if commit.diff(paths: [path]).size.zero?
+        next if commit.diff(paths: [path]).size.zero? # rubocop:disable Style/ZeroLengthPredicate
 
-        # rubocop:enable Style/ZeroLengthPredicate
         hash = {}
         hash[:date] = commit.time.to_s
         hash[:oid] = commit.oid

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -79,8 +79,11 @@ module Oxidized
       i = -1
       tab = []
       walker.each do |commit|
+        # Diabled rubocop because the suggested .empty? does not work here.
+        # rubocop:disable Style/ZeroLengthPredicate
         next if commit.diff(paths: [path]).size.zero?
 
+        # rubocop:enable Style/ZeroLengthPredicate
         hash = {}
         hash[:date] = commit.time.to_s
         hash[:oid] = commit.oid

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -79,7 +79,7 @@ module Oxidized
       i = -1
       tab = []
       walker.each do |commit|
-        next if commit.diff(paths: [path]).empty?
+        next if commit.diff(paths: [path]).size.zero?
 
         hash = {}
         hash[:date] = commit.time.to_s


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)

~~- [ ] Tests added or adapted (try `rake test`)~~
~~- [ ] Changes are reflected in the documentation~~
~~- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)~~

## Description
<!-- Describe your changes here. -->
Fixes a bug caused by the RuboCop autocorrect.
In [/lib/oxidized/output/git.rb](https://github.com/ytti/oxidized/blob/637434b94055d4227aaae295958157a9af0cd788/lib/oxidized/output/git.rb) the code in [line 82](https://github.com/ytti/oxidized/blob/637434b94055d4227aaae295958157a9af0cd788/lib/oxidized/output/git.rb#L82) caused an error. 
Cause is `next if commit.diff(paths: [path]).empty?`, the return value of diff has no `empty?` function. 
The old line `next if commit.diff(paths: [path]).empty?` was correct. 
The same mistake was corrected in this [commit](https://github.com/ytti/oxidized/commit/c1b3aa871bfde4bb5031ad3853a3ae198dbdffd9) back in 2019.
This time i also disabled the RuboCop check for this line so that autocorrect doesn't change this again.

Possibly this also solves issues [2715](https://github.com/ytti/oxidized/issues/2715) and [2282](https://github.com/ytti/oxidized/issues/2282) because the error when clicking the "Version" button led me to this bug. And this bugfix solved it for me.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
