### PR TITLE
Update firewareos.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Fixed
 
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)
+- fixed prompt for Watchguard FirewareOS not matching the regex when the node is non-master (@netdiver)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/model/firewareos.rb
+++ b/lib/oxidized/model/firewareos.rb
@@ -1,7 +1,7 @@
 class FirewareOS < Oxidized::Model
   using Refinements
 
-  prompt /^\[?\w*\]?\w*?(<\w*>)?(#|>)\s*$/
+  prompt /^\[?\w*\]?\w*?(<[\w-]*>)?(#|>)\s*$/
   comment  '-- '
 
   cmd :all do |cfg|


### PR DESCRIPTION
Changed regex for prompt to accept the dash character and match with the <non-master> nodes of a fireware cluster. Fixes #2779

## Description
<!-- Describe your changes here. -->
Changed regex for prompt to accept the dash character and match with the <non-master> nodes of a fireware cluster. Fixes #2779
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
