### PR TITLE
add FortiADC, FortiSwitch, FortiFAZ (FortiAnalyzer) and FortiMail .rb

### DIFF
--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -137,6 +137,12 @@
   * [FTOS](/lib/oxidized/model/ftos.rb)
 * FortiGate
   * [FortiOS](/lib/oxidized/model/fortios.rb)
+* FortiADC
+  * [FortiADC](/lib/oxidized/model/fortiadc.rb)
+* FortiSwitch
+  * [FortiSwitch](/lib/oxidized/model/fortiswitch.rb)
+* FortiMail
+  * [FortiMail](/lib/oxidized/model/fortimail.rb)
 * FortiWLC
   * [FortiWLC](/lib/oxidized/model/fortiwlc.rb)
 * Fujitsu

--- a/lib/oxidized/model/fortiadc.rb
+++ b/lib/oxidized/model/fortiadc.rb
@@ -1,0 +1,21 @@
+class FortiADC < Oxidized::Model
+  prompt /\(.*\) (.*) \$/
+
+  cmd :all do |cfg, cmdstring|
+    new_cfg = comment "COMMAND: #{cmdstring}\n"
+    new_cfg << cfg.each_line.to_a[1..-2].map { |line| line.gsub(/(conf_file_ver=)(.*)/, '\1<stripped>\3') }.join
+  end
+
+  expect /^--More--\s$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
+   cmd 'show' do |cfg|
+         comment cfg
+    end
+
+  cfg :telnet, :ssh do
+    pre_logout "exit\n"
+  end
+end

--- a/lib/oxidized/model/fortifaz.rb
+++ b/lib/oxidized/model/fortifaz.rb
@@ -1,0 +1,38 @@
+class FortiFAZ < Oxidized::Model
+  comment '# '
+
+  prompt /.+?(?=\ #)\ #/
+
+  cmd :all do |cfg, cmdstring|
+    new_cfg = comment "COMMAND: #{cmdstring}\n"
+    new_cfg << cfg.each_line.to_a[1..-2].map { |line| line.gsub(/(conf_file_ver=)(.*)/, '\1<stripped>\3') }.join
+  end
+
+    cmd 'get system status' do |cfg|
+        comment cfg
+    end
+
+    cmd 'get sys global' do |cfg|
+        comment cfg
+    end
+
+    cmd 'get sys performance' do |cfg|
+        comment cfg
+    end
+
+    cmd 'diagnose hardware info' do |cfg|
+        comment cfg
+    end
+
+    cmd 'show' do |cfg|
+        comment cfg
+    end
+
+  cfg :ssh do
+    password /^Password:/
+  end
+
+  cfg :ssh do
+    pre_logout "exit\n"
+  end
+end

--- a/lib/oxidized/model/fortimail.rb
+++ b/lib/oxidized/model/fortimail.rb
@@ -1,0 +1,37 @@
+  prompt /.+?(?=\ #)\ #/
+  cmd :all do |cfg, cmdstring|
+    new_cfg = comment "COMMAND: #{cmdstring}\n"
+    new_cfg << cfg.each_line.to_a[1..-2].map { |line| line.gsub(/(conf_file_ver=)(.*)/, '\1<stripped>\3') }.join
+  end
+
+  expect /^--More--\s$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
+   cmd 'get system status' do |cfg|
+         comment cfg
+    end
+
+   cmd 'get system global' do |cfg|
+         comment cfg
+    end
+
+   cmd 'get system performance' do |cfg|
+         comment cfg
+    end
+
+   cmd 'show' do |cfg|
+         comment cfg
+    end
+
+  cfg :ssh do
+    username /^User:/
+    password /^Password:/
+  end
+
+
+  cfg :telnet, :ssh do
+    pre_logout "exit\n"
+  end
+end

--- a/lib/oxidized/model/fortiswitch.rb
+++ b/lib/oxidized/model/fortiswitch.rb
@@ -1,0 +1,63 @@
+## Unmanaged FortiSwitch
+
+class FortiSwitch < Oxidized::Model
+  comment '# '
+
+  prompt /^([-\w.~]+(\s[(\w\-.)]+)?~?\s?[#>$]\s?)$/
+
+  expect /^--More--\s$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
+  cmd :all do |cfg, cmdstring|
+    new_cfg = comment "COMMAND: #{cmdstring}\n"
+    new_cfg << cfg.each_line.to_a[1..-2].map { |line| line.gsub(/(conf_file_ver=)(.*)/, '\1<stripped>\3') }.join
+  end
+
+  cmd :secret do |cfg|
+    # ENC indicates an encrypted password, and secret indicates a secret string
+    cfg.gsub! /(set .+ ENC) .+/, '\\1 <configuration removed>'
+    cfg.gsub! /(set .*secret) .+/, '\\1 <configuration removed>'
+    # A number of other statements also contains sensitive strings
+    cfg.gsub! /(set (?:passwd|password|key|group-password|auth-password-l1|auth-password-l2|rsso|history0|history1)) .+/, '\\1 <configuration removed>'
+    cfg.gsub! /(set md5-key [0-9]+) .+/, '\\1 <configuration removed>'
+    cfg.gsub! /(set private-key ).*?-+END (ENCRYPTED|RSA|OPENSSH) PRIVATE KEY-+\n?"$/m, '\\1<configuration removed>'
+    cfg.gsub! /(set ca ).*?-+END CERTIFICATE-+"$/m, '\\1<configuration removed>'
+    cfg.gsub! /(set csr ).*?-+END CERTIFICATE REQUEST-+"$/m, '\\1<configuration removed>'
+    cfg
+  end
+
+  cmd 'get system status' do |cfg|
+    @vdom_enabled = cfg.match /Virtual domain configuration: (enable|multiple)/
+    cfg.gsub! /(System time:).*/, '\\1 <stripped>'
+    comment cfg
+  end
+
+  cmd 'get sys arp' do |cfg|
+    comment cfg
+  end
+
+  post do
+    cfg = []
+    cfg << cmd('config global') if @vdom_enabled
+
+    cfg << cmd('get hardware status') do |cfg_hw|
+      comment cfg_hw
+    end
+
+    cfg << cmd('end') if @vdom_enabled
+
+    cfg << cmd('show full-configuration | grep .')
+    cfg.join "\n"
+  end
+
+  cfg :telnet do
+    username /login:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    pre_logout "exit\n"
+  end
+end


### PR DESCRIPTION
Works somehow, but also adds "#" to the config file in fortiadc.rb like in https://github.com/ytti/oxidized/pull/2473

```
# # COMMAND: show
# config system global
#   set hostname HOSTNAME
#   set admin-idle-timeout 480
#   set gslb-ca-verify disable
# end
# config system traffic-group
# end
# config system vdom-link
# end
# config system interface
#   edit "port1"
#     set vdom root
#     set allowaccess https ping ssh snmp 
#     config  ha-node-ip-list
#     end
#   next
#   edit "port2"
#     set vdom root
#     set ip 192.168.107.100/24
#     set allowaccess https ping ssh snmp 
#     config  ha-node-ip-list
#     end
# 
         
  next
#   edit "port3"
#     set vdom root
#     config  ha-node-ip-list
#     end
#   next
#   edit "port4"
#     set vdom root
#     config  ha-node-ip-list
#     end
#   next
#   edit "port5"
#     set vdom root
#     config  ha-node-ip-list
#     end
#   next
#   edit "port6"
#     set vdom root
#     config  ha-node-ip-list
#     end
#   next
#   edit "port7"
# 
         
    set vdom root
...
```

All added modules work up to some extend!

Willing to test and improve the commit, if someone can help with the regex and ruby. 

## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
added FortiADC
added FortiSwitch
added FortiFAZ (FortiAnalyzer)
added FortiMail
