### PR TITLE
dlink: fixed prompt for other dlink switches, added additional uptime removal expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Added
 
 ## Changed
+- dlink: fixed prompt for other dlink switches, added additional uptime removal expressions (@mirackle-spb)
 
 ## Fixed
 

--- a/lib/oxidized/model/dlink.rb
+++ b/lib/oxidized/model/dlink.rb
@@ -2,9 +2,8 @@ class Dlink < Oxidized::Model
   using Refinements
 
   # D-LINK Switches
-  # Add support dgs 1100 series (tested only with dgs-1100-10/me)
 
-  prompt /^(\r*[\w\s.@()\/:-]+[#>]\s?)$/
+  prompt /[\w.@()\/:-]+[#>]\s?$/
   comment '# '
 
   cmd :secret do |cfg|
@@ -19,6 +18,9 @@ class Dlink < Oxidized::Model
 
   cmd 'show switch' do |cfg|
     cfg.gsub! /^System Uptime\s.+/, '' # Omit constantly changing uptime info
+    cfg.gsub! /^System up time\s.+/, '' # Omit constantly changing uptime info
+    cfg.gsub! /^System Time\s.+/, '' # Omit constantly changing uptime info
+    cfg.gsub! /^RTC Time\s.+/, '' # Omit constantly changing uptime info
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
dlink: fixed prompt for other dlink switches, added additional uptime removal expressions

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
