### PR TITLE
Add missing "using Refinements" (closes issue #2803)

### DIFF
--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -1,5 +1,7 @@
 module Oxidized
   class Git < Output
+    using Refinements
+
     class GitError < OxidizedError; end
     begin
       require 'rugged'


### PR DESCRIPTION
Add missing "using Refinements" in lib/oxidized/output/git.rb, which was making the git output unusable since version 0.29.1.

Closes issue #2803 