### PR TITLE
Also remove new formatted date/time comment on newer RouterOS

### DIFF
--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -45,7 +45,7 @@ class RouterOS < Oxidized::Model
       cfg.gsub! /# poe-out status: short_circuit\r\n/, '' # Remove intermittent POE short_circuit comment
       cfg.gsub! /# Firmware upgraded successfully, please reboot for changes to take effect!\r\n/, '' # Remove transient firmware upgrade comment
       cfg.gsub! /# \S+ not ready\r\n/, '' # Remove intermittent $interface not ready comment
-      cfg = cfg.split("\n").reject { |line| line[/^#\s\w{3}\/\d{2}\/\d{4}.*$/] }
+      cfg = cfg.split("\n").reject { |line| line[/^#\s\w{3}\/\d{2}\/\d{4}\s\d{2}:\d{2}:\d{2}.*$/] || line[/^#\s\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.*$/] } # Remove date time and 'by RouterOS' comment
       cfg.join("\n") + "\n"
     end
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Old:
```# jun/01/2023 12:11:25 by RouterOS 7.9.1```
New:
```# 2023-06-01 12:16:16 by RouterOS 7.10rc1```

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
