### PR TITLE
Fix Netscaler with hostname backups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)
 - fixed prompt for Watchguard FirewareOS not matching the regex when the node is non-master (@netdiver)
 - fixed new date/time format with newer RouterOS `# jun/01/2023 12:11:25 by RouterOS 7.9.1` vs `# 2023-06-01 12:16:16 by RouterOS 7.10rc1` (@tim427)
+- fixed netscaler backups with hostname set #2828 (@electrocret) 
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/model/netscaler.rb
+++ b/lib/oxidized/model/netscaler.rb
@@ -1,7 +1,7 @@
 class NetScaler < Oxidized::Model
   using Refinements
 
-  prompt /^([\w\.-]*>\s?)$/
+  prompt /^(.*[\w\.-]*>\s?)$/
   comment '# '
 
   cmd :all do |cfg|


### PR DESCRIPTION
Currently Netscalers with "set ns hostName _name_" set aren't able to be backed up cause Oxidized doesn't recognize a valid prompt.

Prompt when not set:
`>`

Prompt when set:
`username@hostname>`

Current regex isn't liking the change.

I'm sure there's a more graceful way of dealing with the change, but I'm not good with regex. This works for me.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
