### PR TITLE
add support for Commscope E6000

### DIFF
--- a/lib/oxidized/model/c4cmts.rb
+++ b/lib/oxidized/model/c4cmts.rb
@@ -20,6 +20,9 @@ class C4CMTS < Oxidized::Model
 
   cmd 'show environment' do |cfg|
     cfg.gsub! /\s+[\-\d]+\s+C\s+[(\s\d]+\s+F\)/, '' # remove temperature readings
+    cfg.gsub! /(Ambient Temperature|Fan Level|Fan Offset):\s+(.*)/, '' # Fan output
+    cfg.gsub! /System Power Consumption:\s+(.*)/, '' # Power consumption
+    cfg.gsub! /PEM [AB](\s+.*)/, '' # PSUs
     comment cfg.cut_both
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

the commscope E6000 is the successor to the arris C4. This patch removes some noise from the device output.