### PR TITLE
opnsense: do not redirect stderr when fetching opnsense version since default shell (csh) doesn't support it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)
 - fixed prompt for Watchguard FirewareOS not matching the regex when the node is non-master (@netdiver)
 - fixed new date/time format with newer RouterOS `# jun/01/2023 12:11:25 by RouterOS 7.9.1` vs `# 2023-06-01 12:16:16 by RouterOS 7.10rc1` (@tim427)
+- Do not redirect stderr when fetching opnsense version since default shell (csh) doesn't support it (@spike77453)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/model/opnsense.rb
+++ b/lib/oxidized/model/opnsense.rb
@@ -18,7 +18,7 @@ class OpnSense < Oxidized::Model
   # that lack the opnsense-version command. Newer versions of OPNsense no longer
   # store the version information in this file, so both versions have to be
   # supported here for now.
-  cmd 'opnsense-version 2>/dev/null || echo "OPNsense "`cat /usr/local/opnsense/version/opnsense`' do |version|
+  cmd 'opnsense-version || echo "OPNsense "`cat /usr/local/opnsense/version/opnsense`' do |version|
     xmlcomment version
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Oxidized tries to grab the opnsense version by running `opnsense-version 2>/dev/null`. This is not supported on opnsense's default shell (csh) and leads to:

```
<!-- Missing /usr/local/opnsense/version/2
cat: /usr/local/opnsense/version/opnsense: No such file or directory
OPNsense  -->
<!-- Missing /usr/local/opnsense/version/2
cat: /usr/local/opnsense/version/opnsense: No such file or directory
OPNsense  -->
<!-- Missing /usr/local/opnsense/version/2
cat: /usr/local/opnsense/version/opnsense: No such file or directory
OPNsense  -->
```

The suggested change simply removes the I/O redirection of stderr to /dev/null.
