### PR TITLE
New model for Ruijie Networks RGOS devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Added
 - model for D-Link cisco like CLI (@mirackle-spb)
+- model for Ruijie Networks RGOS devices (@spike77453)
 
 ## Changed
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -215,6 +215,8 @@
   * [AlteonOS](/lib/oxidized/model/alteonos.rb)
 * Raisecom
   * [Raisecom](/lib/oxidized/model/raisecom.rb)
+* Ruijie Networks
+  * [RGOS](/lib/oxidized/model/rgos.rb)
 * QTECH
   * [QSW-2800, QSW-3400, QSW-3450, QSW-3500](/lib/oxidized/model/qtech.rb)
 * Quanta

--- a/lib/oxidized/model/rgos.rb
+++ b/lib/oxidized/model/rgos.rb
@@ -1,0 +1,33 @@
+class RGOS < Oxidized::Model
+  using Refinements
+
+  comment '! '
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(username .+ (password|secret) \d) .+/, '\\1 <secret hidden>'
+    cfg.gsub! /^(enable (password|secret)( level \d+)?( \d)?) .+/, '\\1 <secret hidden>'
+    cfg
+  end
+
+  cmd 'show version' do |cfg|
+    cfg = cfg.each_line.reject { |line| line.match /^System start time/ }.join
+    cfg = cfg.each_line.reject { |line| line.match /^System uptime/ }.join
+    comment "#{cfg.cut_both}\n"
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg = cfg.each_line.reject { |line| line.match /^Building configuration.../ }.join
+    cfg = cfg.each_line.reject { |line| line.match /^Current configuration : \d+ bytes/ }.join
+    cfg = cfg.each_line.reject { |line| line.match /^version [\d\w()]+/ }.join
+    # remove empty lines
+    cfg = cfg.each_line.reject { |line| line.match /^[\r\n\s\u0000#]+$/ }.join
+    cfg.cut_both
+  end
+
+  cfg :telnet, :ssh do
+    post_login 'terminal length 0'
+    post_login 'terminal width 0'
+    pre_logout 'exit'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This adds support for Ruijie Networks RGOS devices (and also RGOS devices relabelled FSOS by FS.COM), e.g. https://github.com/ytti/oxidized/issues/2662
