### PR TITLE
Remove constantly updating dates from Adtran config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed prompt for Watchguard FirewareOS not matching the regex when the node is non-master (@netdiver)
 - fixed new date/time format with newer RouterOS `# jun/01/2023 12:11:25 by RouterOS 7.9.1` vs `# 2023-06-01 12:16:16 by RouterOS 7.10rc1` (@tim427)
 - Do not redirect stderr when fetching opnsense version since default shell (csh) doesn't support it (@spike77453)
+- Remove constantly updating dates from backup of Adtran config (@davesbell)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/model/adtran.rb
+++ b/lib/oxidized/model/adtran.rb
@@ -14,7 +14,11 @@ class Adtran < Oxidized::Model
     cfg
   end
 
-  cmd 'show running-config'
+  cmd 'show running-config' do |cfg|
+    # Strip out line at the top which displays the current date/time
+    # ! Created                         : Mon Jun 26 2023 10:07:07
+    cfg.gsub! /! Createds+:.*\n/, ''
+  end
 
   cfg :ssh do
     if vars :enable


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Remove constantly updating dates from backup of Adtran config