### PR TITLE
Add support for AricentISS firware 2.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## Added
 - model for D-Link cisco like CLI (@mirackle-spb)
 - model for Ruijie Networks RGOS devices (@spike77453)
+- added support for AricentISS 2.x firmware (@davromaniak)
 
 + Added ability to send mail with the Docker container
 + Documentation to send mail with hooks

--- a/lib/oxidized/model/aricentiss.rb
+++ b/lib/oxidized/model/aricentiss.rb
@@ -2,6 +2,10 @@
 # #show version
 # Switch ID       Hardware Version                Firmware Version
 # 0               SSE-G48-TG4   (P2-01)           1.0.16-9
+# and
+# # show version
+# Switch ID       Hardware Version                Firmware Version
+# 0               MBM-XEM-002  (B6-01)            2.1.3-25
 
 class AricentISS < Oxidized::Model
   using Refinements
@@ -13,6 +17,9 @@ class AricentISS < Oxidized::Model
     # 1.0.18-15 is known to include the corrected spelling
     post_login 'no cli pagination'
     post_login 'no cli pagignation'
+    # Starting firmware 2.0, pagination is done differently.
+    # This configuration is reset after the session ends.
+    post_login 'conf t; set cli pagination off; exit'
     pre_logout 'exit'
   end
 


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ N/A ] Tests added or adapted (try `rake test`)
- [ N/A ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Starting the 2.0 firmware, the pagination command has changed and the old one isn't supported (with or without the typo).

I tested it against switches running 2.1.3-25 and 2.2.1-38 without any issues.

Thanks.
