### PR TITLE
Add ex3400 to junos VC-enabled platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## Changed
 
+- Collect VC info for juniper ex3400 (@ermuller)
+
 ## Fixed
 
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -29,7 +29,7 @@ class JunOS < Oxidized::Model
     case @model
     when 'mx960'
       out << cmd('show chassis fabric reachability') { |cfg| comment cfg }
-    when /^(ex22|ex33|ex4|ex8|qfx)/
+    when /^(ex22|ex3[34]|ex4|ex8|qfx)/
       out << cmd('show virtual-chassis') { |cfg| comment cfg }
     end
     out


### PR DESCRIPTION

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

EX3400s should be included in the list of juniper switches where virtual-chassis status is collected; existing regex was limited to ex3300.
