### PR TITLE
Nokia SROS SAR 7705 Hmc fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed new date/time format with newer RouterOS `# jun/01/2023 12:11:25 by RouterOS 7.9.1` vs `# 2023-06-01 12:16:16 by RouterOS 7.10rc1` (@tim427)
 - fixed netscaler backups with hostname set #2828 (@electrocret) 
 - Do not redirect stderr when fetching opnsense version since default shell (csh) doesn't support it (@spike77453)
-
+- Added support for Nokia SAR 7705 HMC in SROS model (@schouwenburg)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/model/sros.rb
+++ b/lib/oxidized/model/sros.rb
@@ -75,14 +75,14 @@ class SROS < Oxidized::Model
   #
   # Show the running persistent indices.
   #
-  cmd 'admin display-config index' do |cfg|
+  cmd 'admin display-config index\n' do |cfg|
     comment cfg
   end
 
   #
   # Show the running configuration.
   #
-  cmd 'admin display-config' do |cfg|
+  cmd 'admin display-config\n' do |cfg|
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)
- [x] I have no dev environment where I can run the rubocon and rake test, although I tested the fix

## Description
The Nokia SROS model did not work on the SAR 7705 HMC due to an unexpected prompt at the end of two commands. With this small patch, a new correct command line is enforced, which makes Oxidized finish correctly on all SROS models.