### PR TITLE
allow finding nodes by IP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed netscaler backups with hostname set #2828 (@electrocret) 
 - Do not redirect stderr when fetching opnsense version since default shell (csh) doesn't support it (@spike77453)
 - Fixed fan RPM speeds included in Aruba CX diffs (@danpoltawski)
+- More types of node lookup now accept IP as the key (@habbie)
 
 
 ## [0.29.1 - 2023-04-24]

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -173,7 +173,8 @@ module Oxidized
 
     def yield_node_output(node_name)
       with_lock do
-        node = find { |n| [n.name, n.ip].include? node_name }
+        i = find_node_index node_name
+        node = self[i]
         output = node.output.new
         raise Oxidized::NotSupported unless output.respond_to? :fetch
 

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -173,7 +173,7 @@ module Oxidized
 
     def yield_node_output(node_name)
       with_lock do
-        node = find { |n| n.name == node_name }
+        node = find { |n| [n.name, n.ip].include? node_name }
         output = node.output.new
         raise Oxidized::NotSupported unless output.respond_to? :fetch
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`) (it has complaints, but not about this file)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Since b0b50e8bba592bf9c96c198087dc19b077044f51, most operations allow either node name or node IP as index. This is reflected in what oxidized-web accepts in URLs as well. However, for `/node/version` (and perhaps other endpoints), by-IP did not work yet because the change was made in one place instead of two. This PR makes the other change.

My use case: in LibreNMS, my switches are identified by IP instead of a host name. This means that in the LibreNMS/Oxidized integration, I can view details about the switches, but not versions, because that API endpoint did not take IPs.