### PR TITLE
Added CeraOS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - model for D-Link cisco like CLI (@mirackle-spb)
 - model for Ruijie Networks RGOS devices (@spike77453)
 - pagination for http source (@davama)
-
+- model for CeraOS (Ceragon OS)
 + Added ability to send mail with the Docker container
 + Documentation to send mail with hooks
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -64,6 +64,8 @@
   * [Casa](/lib/oxidized/model/casa.rb)
 * Centec Networks
   * [CNOS](/lib/oxidized/model/cnos.rb)
+* Ceragon
+  * [CeraOS](/lib/oxidized/model/ceros.rb)
 * Check Point
   * [GaiaOS](/lib/oxidized/model/gaiaos.rb)
 * Ciena

--- a/lib/oxidized/model/ceraos.rb
+++ b/lib/oxidized/model/ceraos.rb
@@ -1,0 +1,25 @@
+class Ceraos < Oxidized::Model
+  prompt /root\>/
+
+  expect /(END)/ do |data, re|
+    send 'q'
+    data.sub re, ''
+  end
+
+  expect /^:/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
+  cmd 'platform configuration configuration-file show'
+
+  cmd 'platform software show versions all'
+
+  cmd :all do |cfg|
+    cfg.gsub! /\e.*/, ''
+  end
+
+  cfg :ssh do
+    pre_logout 'quit'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)
- [X] I have no dev environment where I can run the rubocon and rake test, although I tested the fix

## Description
Added support for Ceragon LOS equipment running on CeraOS.