### PR TITLE
Fix enable with password on TPLink

### DIFF
--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -58,6 +58,7 @@ class TPLink < Oxidized::Model
       if vars(:enable) == true
         cmd "enable"
       elsif vars(:enable)
+        send "enable\r"
         cmd vars(:enable)
       end
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Follow-Up to #2796 

This PR seems to have introduced a bug when enable is used WITH a password
In that case "enable" still needs to be sent before the actual password.

Current debug log when connecting:

```
switch>**sensitive enable password***
---------------^
Error: Bad command

switch>

switch>show system-info
---------------^
Error: Bad command

```