### PR TITLE
Update iosxr.rb with admin keyword for show inventory command

### DIFF
--- a/lib/oxidized/model/iosxr.rb
+++ b/lib/oxidized/model/iosxr.rb
@@ -16,7 +16,7 @@ class IOSXR < Oxidized::Model
     cfg
   end
 
-  cmd 'show inventory' do |cfg|
+  cmd 'admin show inventory' do |cfg|
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [] Passes rubocop code analysis (try `rubocop --auto-correct`)
The core code didn't change. Only specific model
- [ ] Tests added or adapted (try `rake test`)
The core code didn't change. Only specific model
- [ ] Changes are reflected in the documentation
Particular Model didn't have the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)
N/A

## Description
"show inventory" command without admin keyword is not showing some useful inventory information, such as FAN, PSU and Chassis serial and part numbers

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
