### PR TITLE
fix for Aruba remove extra info

### DIFF
--- a/lib/oxidized/model/aoscx.rb
+++ b/lib/oxidized/model/aoscx.rb
@@ -70,7 +70,7 @@ class Aoscx < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show system | exclude "Up Time" | exclude "CPU" | exclude "Memory"' do |cfg|
+  cmd 'show system | exclude "Up Time|CPU|Memory|Pkts .x|Lowest|Missed"' do |cfg|
     comment cfg
   end
 

--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -27,7 +27,7 @@ class VRP < Oxidized::Model
   end
 
   cmd 'display version' do |cfg|
-    cfg = cfg.each_line.reject { |l| l.match /uptime|^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)? ?(+\d\d:\d\d)?$/ }.join
+    cfg = cfg.each_line.reject { |l| l.match /uptime|^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)? ?(\+\d\d:\d\d)?$/ }.join
     comment cfg
   end
 

--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -32,10 +32,12 @@ class VRP < Oxidized::Model
   end
 
   cmd 'display device' do |cfg|
+    cfg = cfg.each_line.reject { |l| l.match /^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)? ?(\+\d\d:\d\d)?$/ }.join
     comment cfg
   end
 
   cmd 'display current-configuration all' do |cfg|
+    cfg = cfg.each_line.reject { |l| l.match /^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)? ?(\+\d\d:\d\d)?$/ }.join
     cfg
   end
 end

--- a/lib/oxidized/model/vrp.rb
+++ b/lib/oxidized/model/vrp.rb
@@ -27,7 +27,7 @@ class VRP < Oxidized::Model
   end
 
   cmd 'display version' do |cfg|
-    cfg = cfg.each_line.reject { |l| l.match /uptime/ }.join
+    cfg = cfg.each_line.reject { |l| l.match /uptime|^\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d(\.\d\d\d)? ?(+\d\d:\d\d)?$/ }.join
     comment cfg
   end
 


### PR DESCRIPTION
## Description

two changes here:

**Firs one:** removes extra information from `show system` output on Aruba CX switches

```
Aruba1184-2540-UP# show system

 Status and Counters - General System Information

  System Name        : Aruba1184-2540-UP
  System Contact     : ict@mail.com
  System Location    :

  MAC Age Time (sec) : 300

  Time Zone          : 180
  Daylight Time Rule : None

  Software revision  : YC.16.11.0002        Base MAC Addr      : 8030e0-946060
  ROM Version        : YC.16.01.0002        Serial Number      : CN8AJYH0J4

  Up Time            : 95 days              Memory   - Total   : 359,035,392
  CPU Util (%)       : 5                               Free    : 258,128,676

  IP Mgmt  - Pkts Rx : 5,028,126            Packet   - Total   : 6600
             Pkts Tx : 5,030,762            Buffers    Free    : 4794
                                                       Lowest  : 4729
                                                       Missed  : 0

Aruba1184-2540-UP#
```
fix will remove IP Mgmt interface stats from the output so oxidized doesn't have to push change every time.


**Second one:**

Some versions of VRP software (especially on Huawei USG) print right before output current date and time
which again forces oxidized to push changes every time it collects config.
```
<FW1184>display version
2023-09-07 12:40:38.430 +09:00
Huawei Versatile Routing Platform Software
VRP (R) Software, Version 5.170 (USG6300 V500R005C20SPC500)
Copyright (C) 2014-2020 Huawei Technologies Co., Ltd.
USG6330 uptime is 1 week, 6 days, 21 hours, 40 minutes
....
```

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
