### PR TITLE
Add post_login command to prevent terminal paging for TP-Link TL-SG3452X and TL-SG2210P

### DIFF
--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -60,6 +60,8 @@ class TPLink < Oxidized::Model
       elsif vars(:enable)
         cmd vars(:enable)
       end
+      cmd "terminal length 0"
+    end
     end
 
     pre_logout do

--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -62,7 +62,6 @@ class TPLink < Oxidized::Model
       end
       cmd "terminal length 0"
     end
-    end
 
     pre_logout do
       send "exit\r"


### PR DESCRIPTION
## Description
<!-- Describe your changes here. -->
The pull request is to add a post_login command to prevent terminal paging for TP-Link TL-SG3452X and TL-SG2210P.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
