### PR TITLE
Update the prompt detection RegEx to support Netgear M4250-10G2XF-PoE+ and M4300-28G-PoE+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Remove constantly updating dates from backup of Adtran config (@davesbell)
 - fixed prompt for Cumulus to allow usernames with dots and dashes (@ktims)
 - fixed source http when source is librenms (@davama)
+- fixed prompt detection for Netgear M4250-10G2XF-PoE+ and M4300-28G-PoE+ (@rexhaugen)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -2,7 +2,7 @@ class Netgear < Oxidized::Model
   using Refinements
 
   comment '!'
-  prompt /^(\([\w\s\-.]+\)\s[#>])$/
+  prompt /^(\([\w\s\-\+.]+\)\s?[#>])$/
 
   cmd :secret do |cfg|
     cfg.gsub!(/password (\S+)/, 'password <hidden>')


### PR DESCRIPTION
## Description
<!-- Describe your changes here. -->
The pull request is to update the prompt detection RegEx to support Netgear M4250-10G2XF-PoE+ and M4300-28G-PoE+.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
