### PR TITLE
Exclude device dictionary from panos.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Collect VC info for juniper ex3400 (@ermuller)
 - adva: fix config content for recovery process, collect config delta instead of current (@MichiMeyer)
 - iosxr: include last config changed by in model (@electrocret)
+- panos: xclude device dictionary
 - Added support for Nokia SAR 7705 HMC in SROS model (@schouwenburg)
 
 ## Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Collect VC info for juniper ex3400 (@ermuller)
 - adva: fix config content for recovery process, collect config delta instead of current (@MichiMeyer)
 - iosxr: include last config changed by in model (@electrocret)
-- panos: xclude device dictionary
+- panos: exclude device dictionary
 - Added support for Nokia SAR 7705 HMC in SROS model (@schouwenburg)
 
 ## Fixed

--- a/lib/oxidized/model/panos.rb
+++ b/lib/oxidized/model/panos.rb
@@ -18,6 +18,8 @@ class PanOS < Oxidized::Model
     cfg.gsub! /^threat-.*?: .*$/, ''
     cfg.gsub! /^wildfire-.*?: .*$/, ''
     cfg.gsub! /^wf-private.*?: .*$/, ''
+    cfg.gsub! /^device-dictionary-version.*?: .*$/, ''
+    cfg.gsub! /^device-dictionary-release-date.*?: .*$/, ''
     cfg.gsub! /^url-filtering.*?: .*$/, ''
     cfg.gsub! /^global-.*?: .*$/, ''
     comment cfg


### PR DESCRIPTION
Need to exclude device dictionary values because they change with every update

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)
