### PR TITLE
Fixed devices not retriving config after refinement change (openwrt, opnsense, pfsense)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Added support for Nokia SAR 7705 HMC in SROS model (@schouwenburg)
 
 ## Fixed
-
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)
 - fixed prompt for Watchguard FirewareOS not matching the regex when the node is non-master (@netdiver)
 - defined 'psych' runtime dependency to resolve 'unsafe_load' error during startup (@MattKobayashi)
@@ -42,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed prompt for Cumulus to allow usernames with dots and dashes (@ktims)
 - fixed source http when source is librenms (@davama)
 - fixed prompt detection for Netgear M4250-10G2XF-PoE+ and M4300-28G-PoE+ (@rexhaugen)
+- fixed pfsense and opnsense not retriving config after refinement change #2771 (@robertcheramy)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed prompt for Cumulus to allow usernames with dots and dashes (@ktims)
 - fixed source http when source is librenms (@davama)
 - fixed prompt detection for Netgear M4250-10G2XF-PoE+ and M4300-28G-PoE+ (@rexhaugen)
-- fixed pfsense and opnsense not retriving config after refinement change #2771 (@robertcheramy)
+- fixed devices (pfsense, opnsense, openwrt) not retriving config after refinement change #2771 #2968 (@robertcheramy)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -42,11 +42,13 @@ module Oxidized
 
     def cmd(cmd, expect = node.prompt)
       Oxidized.logger.debug "lib/oxidized/input/ssh.rb #{cmd} @ #{node.name} with expect: #{expect.inspect}"
-      if @exec
-        @ssh.exec! cmd
-      else
-        cmd_shell(cmd, expect).gsub(/\r\n/, "\n")
-      end
+      cmd_output = if @exec
+                     @ssh.exec! cmd
+                   else
+                     cmd_shell(cmd, expect).gsub(/\r\n/, "\n")
+                   end
+      # Make sure we return a String
+      cmd_output.to_s
     end
 
     def send(data)

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -45,7 +45,7 @@ module Oxidized
       cmd_output = if @exec
                      @ssh.exec! cmd
                    else
-                     cmd_shell(cmd, expect).gsub(/\r\n/, "\n")
+                     cmd_shell(cmd, expect).gsub("/\r\n/", "\n")
                    end
       # Make sure we return a String
       cmd_output.to_s


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (for changed files)
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

With the refinement change in e47d719aff64950f8cd7313f27d85846915db837,  the output from ssh is not packed in an Oxidized::String anymore. The refinement change trusts that the output would be a String.
But in the case of pfsense and opnsense, `cmd 'cat /conf/config.xml'` the output is a `Net::SSH::Connection::Session::StringWithExitstatus`, which causes `process_cmd_output` to wipe it out (`output = String.new('') unless output.instance_of?(String)`).

This PR ensures that input/ssh.rb returns a String

Closes issues #2771 #2968