### PR TITLE
Fixed login into Fortigate when post-login-baner ist enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed source http when source is librenms (@davama)
 - fixed prompt detection for Netgear M4250-10G2XF-PoE+ and M4300-28G-PoE+ (@rexhaugen)
 - fixed devices (pfsense, opnsense, openwrt) not retriving config after refinement change #2771 #2968 (@robertcheramy)
+- Fixed login into Fortigate when post-login-baned ist enabled. Fixes #2021 (@chrisr0880, @sahdan, @dangoscomb and @robertcheramy)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -5,6 +5,12 @@ class FortiOS < Oxidized::Model
 
   prompt /^([-\w.~]+(\s[(\w\-.)]+)?~?\s?[#>$]\s?)$/
 
+  # When a post-login-banner is enabled, you have to press "a" to log in
+  expect /^\(Press\s'a'\sto\saccept\):/ do |data, re|
+    send 'a'
+    data.sub re, ''
+  end
+
   expect /^--More--\s$/ do |data, re|
     send ' '
     data.sub re, ''


### PR DESCRIPTION
Fixes #2021 (@chrisr0880, @sahdan, @dangoscomb and @robertcheramy)

## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`) - only for fortios.rb - other warnings have to be fixed, see PR #2991
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
When post-login-baner is enabled, the fortigate requires pressind "a" to accept the message.

This PR has been tested agains Fortigate v7.0.13, with and without following configuration:
```
config system global
    set post-login-banner enable
end
```
Closes issue #2021 .
