### PR TITLE
aoscx: Expand `show system` command for compatibility

### DIFF
--- a/lib/oxidized/model/aoscx.rb
+++ b/lib/oxidized/model/aoscx.rb
@@ -70,7 +70,7 @@ class Aoscx < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show system | exclude "Up Time|CPU|Memory|Pkts .x|Lowest|Missed"' do |cfg|
+  cmd 'show system | exclude "Up Time" | exclude "CPU" | exclude "Memory" | exclude "Pkts .x" | exclude "Lowest" | exclude "Missed"' do |cfg|
     comment cfg
   end
 


### PR DESCRIPTION
Fixes `Command not supported` error on various Aruba CX 6xxx and 8xxx series

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

Changes to the aosxc.rb model in https://github.com/ytti/oxidized/pull/2933 cause a `Command not supported` error on various Aruba CX 6xxx and 8xxx series devices (and maybe others, but those are the ones that I've seen it on). I've expanded the command to make it compatible with those devices while keeping the functionality intended by the original commit.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
