### PR TITLE
Opengear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - iosxr: include last config changed by in model (@electrocret)
 - panos: exclude device dictionary
 - Added support for Nokia SAR 7705 HMC in SROS model (@schouwenburg)
+- opengear: support newer Opengear CM* and OM* models (@matej_v)
 
 ## Fixed
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)

--- a/lib/oxidized/model/opengear.rb
+++ b/lib/oxidized/model/opengear.rb
@@ -15,20 +15,15 @@ class OpenGear < Oxidized::Model
     cfg
   end
 
-  cmd 'cat /etc/version' do |cfg|
-      cfg.gsub! /^/, 'OS Version: '
-      comment cfg
-  end
+  cmd('cat /etc/version') { |cfg| comment cfg }
 
   # newer opengear firmware versions
   cmd 'ogdeviceinfo -r' do |cfg|
-    if not cfg.include? "ogdeviceinfo: command not found"
-      comment cfg
-    end
+    comment cfg unless cfg.include? "ogdeviceinfo: command not found"
   end
 
   cmd 'config export' do |cfg|
-    if not cfg.include? "usage: config"
+    unless cfg.include? "usage: config"
       out = ''
       cfg.each_line do |line|
         out << line
@@ -39,14 +34,14 @@ class OpenGear < Oxidized::Model
 
   # older opengear firmware versions
   cmd 'showserial' do |cfg|
-    if not cfg.include? "showserial: command not found"
+    unless cfg.include? "showserial: command not found"
       cfg.gsub! /^/, 'Serial Number: '
       comment cfg
     end
   end
 
   cmd 'config -g config' do |cfg|
-    if not cfg.include? "config: error: argument"
+    unless cfg.include? "config: error: argument"
       out = ''
       cfg.each_line do |line|
         out << line

--- a/lib/oxidized/model/opengear.rb
+++ b/lib/oxidized/model/opengear.rb
@@ -8,22 +8,51 @@ class OpenGear < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub!(/password (\S+)/, 'password <secret removed>')
     cfg.gsub!(/community (\S+)/, 'community <secret removed>')
+    cfg.gsub!(/community=(\S+)/, 'community=<secret removed>')
+    cfg.gsub!(/private_key=(\S+)/, 'private_key=<secret removed>')
+    cfg.gsub!(/ key=(\S+)/, ' key=<secret removed>')
+    cfg.gsub!(/hashed_password=(\S+)/, 'hashed_password=<secret removed>')
     cfg
   end
 
-  cmd('cat /etc/version') { |cfg| comment cfg }
+  cmd 'cat /etc/version' do |cfg|
+      cfg.gsub! /^/, 'OS Version: '
+      comment cfg
+  end
 
+  # newer opengear firmware versions
+  cmd 'ogdeviceinfo -r' do |cfg|
+    if not cfg.include? "ogdeviceinfo: command not found"
+      comment cfg
+    end
+  end
+
+  cmd 'config export' do |cfg|
+    if not cfg.include? "usage: config"
+      out = ''
+      cfg.each_line do |line|
+        out << line
+      end
+      out
+    end
+  end
+
+  # older opengear firmware versions
   cmd 'showserial' do |cfg|
-    cfg.gsub! /^/, 'Serial Number: '
-    comment cfg
+    if not cfg.include? "showserial: command not found"
+      cfg.gsub! /^/, 'Serial Number: '
+      comment cfg
+    end
   end
 
   cmd 'config -g config' do |cfg|
-    out = ''
-    cfg.each_line do |line|
-      out << line
+    if not cfg.include? "config: error: argument"
+      out = ''
+      cfg.each_line do |line|
+        out << line
+      end
+      out
     end
-    out
   end
 
   cfg :ssh do


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Opengear changed their firmware (possibly somewhere around 2018). Old oxidized model didn't call correct commands for new firmware. I've updated the model so old and new commands are called. This way the model supports both old and new firmware version.
