### PR TITLE
eos string is enable password now

### DIFF
--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -15,7 +15,7 @@ class EOS < Oxidized::Model
     cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
     cfg.gsub! /(secret \w+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'
-    cfg.gsub! /^(enable secret).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(enable (?:secret|password)).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(service unsupported-transceiver).*/, '\\1 <license key removed>'
     cfg.gsub! /^(tacacs-server key \d+).*/, '\\1 <configuration removed>'
     cfg.gsub! /( {6}key) (\h+ 7) (\h+).*/, '\\1 <secret hidden>'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Arista EOS (not sure when) started using "enable password" instead of "enable secret".  Updating the regex for those of us who use secrets redaction.

