### PR TITLE
Remove "<timestamp> by RouterOS" comment lines from ROS v7

### DIFF
--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -45,7 +45,9 @@ class RouterOS < Oxidized::Model
       cfg.gsub! "# poe-out status: short_circuit\r\n", '' # Remove intermittent POE short_circuit comment
       cfg.gsub! "# Firmware upgraded successfully, please reboot for changes to take effect!\r\n", '' # Remove transient firmware upgrade comment
       cfg.gsub! /# \S+ not ready\r\n/, '' # Remove intermittent $interface not ready comment
-      cfg = cfg.split("\n").reject { |line| line[/^#\s\w{3}\/\d{2}\/\d{4}\s\d{2}:\d{2}:\d{2}.*$/] || line[/^#\s\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}.*$/] } # Remove date time and 'by RouterOS' comment
+      cfg = cfg.split("\n")
+      cfg.reject! { |line| line[/^#\s\w{3}\/\d{2}\/\d{4}.*$/] } # Remove date time and 'by RouterOS' comment (v6)
+      cfg.reject! { |line| line[/^#\s\d{4}-\d{2}-\d{2}.*$/] }   # Remove date time and 'by RouterOS' comment (v7)
       cfg.join("\n") + "\n"
     end
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Update filter for timestamped "by RouterOS" lines to match v7 as well as v6

Closes issue #3021