### PR TITLE
Removed enable, Cisco SMB Switches do not have the enable switch

### DIFF
--- a/lib/oxidized/model/ciscocbs.rb
+++ b/lib/oxidized/model/ciscocbs.rb
@@ -1,11 +1,12 @@
-class CiscoSMB < Oxidized::Model
+class CiscoCBS < Oxidized::Model
 using Refinements
 
 #Cisco Small Business CBS220 Switches
 #https://www.cisco.com/c/en/us/support/switches/business-220-series-smart-switches/series.html
 # Tested with 2.0.2.12 Firmware with Password Auth enabled
 
-prompt /^\r?([\w.@()-]+[#>]\s?)$/
+prompt /^[^\r\n]+[#>]/
+
 comment '! '
 
 cmd :all do |cfg|

--- a/lib/oxidized/model/ciscocbs.rb
+++ b/lib/oxidized/model/ciscocbs.rb
@@ -1,0 +1,62 @@
+class CiscoSMB < Oxidized::Model
+using Refinements
+
+#Cisco Small Business CBS220 Switches
+#https://www.cisco.com/c/en/us/support/switches/business-220-series-smart-switches/series.html
+# Tested with 2.0.2.12 Firmware with Password Auth enabled
+
+prompt /^\r?([\w.@()-]+[#>]\s?)$/
+comment '! '
+
+cmd :all do |cfg|
+lines = cfg.each_line.to_a[1..-2]
+# Remove \r from beginning of response
+lines[0].gsub!(/^\r.*?/, '') unless lines.empty?
+lines.join
+end
+
+cmd :secret do |cfg|
+cfg.gsub! /^(snmp-server community)./, '\1 '
+cfg.gsub! /username (\S+) privilege (\d+) (\S+)./, ''
+cfg.gsub! /^(username \S+ password encrypted) \S+(.)/, '\1 \2'
+cfg.gsub! /^(enable password level \d+ encrypted) \S+/, '\1 '
+cfg.gsub! /^(encrypted radius-server key)./, '\1 '
+cfg.gsub! /^(encrypted radius-server host .+ key) \S+(.)/, '\1 \2'
+cfg.gsub! /^(encrypted tacacs-server key)./, '\1 '
+cfg.gsub! /^(encrypted tacacs-server host .+ key) \S+(.)/, '\1 \2'
+cfg.gsub! /^(encrypted sntp authentication-key \d+ md5) ./, '\1 '
+cfg
+end
+
+cmd 'show version' do |cfg|
+cfg.gsub! /.Uptime for this control./, ''
+cfg.gsub! /.System restarted./, ''
+cfg.gsub! /uptime is\ .+/, ''
+comment cfg
+end
+
+cmd 'show bootvar' do |cfg|
+comment cfg
+end
+
+cmd 'show running-config' do |cfg|
+cfg = cfg.each_line.to_a[0..-1].join
+cfg.gsub! /^Current configuration : [^\n]\n/, ''
+cfg.sub! /^(ntp clock-period)./, '! \1'
+cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]\n(
+(?: [^\n]\n)*
+tunnel mpls traffic-eng auto-bw)/mx, '\1'
+cfg
+end
+
+cfg :telnet, :ssh do
+username /User ?[nN]ame:/
+password /^\r?Password:/
+
+post_login 'terminal datadump' # Disable pager
+post_login 'terminal width 0'
+post_login 'terminal len 0'
+pre_logout 'exit' # exit returns to previous priv level, no way to quit from exec(#)
+pre_logout 'exit'
+end
+end

--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -1,7 +1,7 @@
 class CiscoSMB < Oxidized::Model
   using Refinements
 
-  # Cisco Small Business 300, 500, and ESW2 series switches
+  # Cisco Small Business 3x0, 5x0, and ESW2 series switches, Cisco CBS 250, Cisco CBS 350
   # http://www.cisco.com/c/en/us/support/switches/small-business-300-series-managed-switches/products-release-notes-list.html
 
   prompt /^\r?([\w.@()-]+[#>]\s?)$/
@@ -52,13 +52,7 @@ class CiscoSMB < Oxidized::Model
     username /User ?[nN]ame:/
     password /^\r?Password:/
 
-    post_login do
-      if vars(:enable) == true
-        cmd 'enable'
-      elsif vars(:enable)
-        cmd 'enable', /^\r?Password:$/
-        cmd vars(:enable)
-      end
+    
     end
 
     post_login 'terminal datadump' # Disable pager


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x ] Tests added or adapted (try `rake test`)
- [x ] Changes are reflected in the documentation
- [x ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Cisco SG Switches do not work because the commands are not right. Removed and tested with Cisco SG250, Cisco SG350 CBS250 with Password Authentification 
