### PR TITLE
Correct accidental regression in scheduler introduced in PR3060

### DIFF
--- a/lib/oxidized/jobs.rb
+++ b/lib/oxidized/jobs.rb
@@ -49,7 +49,7 @@ module Oxidized
       # a) less threads running than the total amount of nodes
       # b) we want less than the max specified number of threads
 
-      want = [(@want + 1), @nodes.size, @max].min
+      @want = [(@want + 1), @nodes.size, @max].min
     end
 
     def work


### PR DESCRIPTION

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Correct accidental regression in scheduler introduced in https://github.com/ytti/oxidized/pull/3060

Apologies for not catching this pre-merge @ytti 