### PR TITLE
Fix rake test

### DIFF
--- a/spec/input/ssh_spec.rb
+++ b/spec/input/ssh_spec.rb
@@ -79,8 +79,8 @@ describe Oxidized::SSH do
         number_of_password_prompts:      0,
         auth_methods:                    %w[none publickey password],
         proxy:                           proxy
-        }
-      Net::SSH.expects(:start).with('example.com', 'alma',  ssh_options)
+      }
+      Net::SSH.expects(:start).with('example.com', 'alma', ssh_options)
 
       ssh.instance_variable_set("@exec", true)
       ssh.connect(@node)

--- a/spec/input/ssh_spec.rb
+++ b/spec/input/ssh_spec.rb
@@ -4,6 +4,7 @@ require 'oxidized/input/ssh'
 describe Oxidized::SSH do
   before(:each) do
     Oxidized.asetus = Asetus.new
+    Oxidized.asetus.cfg.debug = false
     Oxidized.setup_logger
     Oxidized.config.timeout = 30
     Oxidized.config.input.ssh.secure = true
@@ -31,16 +32,19 @@ describe Oxidized::SSH do
 
       proxy = mock
       Net::SSH::Proxy::Command.expects(:new).with("ssh test.com -W [%h]:%p").returns(proxy)
-      Net::SSH.expects(:start).with('93.184.216.34', 'alma',  port:                            22,
-                                                              verify_host_key:                 Oxidized.config.input.ssh.secure ? :always : :never,
-                                                              append_all_supported_algorithms: true,
-                                                              keepalive:                       true,
-                                                              forward_agent:                   false,
-                                                              password:                        'armud',
-                                                              timeout:                         Oxidized.config.timeout,
-                                                              number_of_password_prompts:      0,
-                                                              auth_methods:                    %w[none publickey password],
-                                                              proxy:                           proxy)
+      ssh_options = {
+        port:                            22,
+        verify_host_key:                 Oxidized.config.input.ssh.secure ? :always : :never,
+        append_all_supported_algorithms: true,
+        keepalive:                       true,
+        forward_agent:                   false,
+        password:                        'armud',
+        timeout:                         Oxidized.config.timeout,
+        number_of_password_prompts:      0,
+        auth_methods:                    %w[none publickey password],
+        proxy:                           proxy
+      }
+      Net::SSH.expects(:start).with('93.184.216.34', 'alma', ssh_options)
 
       ssh.instance_variable_set("@exec", true)
       ssh.connect(@node)
@@ -64,16 +68,19 @@ describe Oxidized::SSH do
 
       proxy = mock
       Net::SSH::Proxy::Command.expects(:new).with("ssh test.com -W [%h]:%p").returns(proxy)
-      Net::SSH.expects(:start).with('example.com', 'alma',  port:                            22,
-                                                            verify_host_key:                 Oxidized.config.input.ssh.secure ? :always : :never,
-                                                            append_all_supported_algorithms: true,
-                                                            keepalive:                       true,
-                                                            forward_agent:                   false,
-                                                            password:                        'armud',
-                                                            timeout:                         Oxidized.config.timeout,
-                                                            number_of_password_prompts:      0,
-                                                            auth_methods:                    %w[none publickey password],
-                                                            proxy:                           proxy)
+      ssh_options = {
+        port:                            22,
+        verify_host_key:                 Oxidized.config.input.ssh.secure ? :always : :never,
+        append_all_supported_algorithms: true,
+        keepalive:                       true,
+        forward_agent:                   false,
+        password:                        'armud',
+        timeout:                         Oxidized.config.timeout,
+        number_of_password_prompts:      0,
+        auth_methods:                    %w[none publickey password],
+        proxy:                           proxy
+        }
+      Net::SSH.expects(:start).with('example.com', 'alma',  ssh_options)
 
       ssh.instance_variable_set("@exec", true)
       ssh.connect(@node)

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -3,6 +3,7 @@ require_relative 'spec_helper'
 describe Oxidized::Node do
   before(:each) do
     Oxidized.asetus = Asetus.new
+    Oxidized.asetus.cfg.debug = false
     Oxidized.setup_logger
 
     Oxidized::Node.any_instance.stubs(:resolve_repo)

--- a/spec/nodes_spec.rb
+++ b/spec/nodes_spec.rb
@@ -4,6 +4,7 @@ describe Oxidized::Nodes do
   before(:each) do
     Resolv.any_instance.stubs(:getaddress)
     Oxidized.asetus = Asetus.new
+    Oxidized.asetus.cfg.debug = false
     Oxidized.setup_logger
 
     opts = {

--- a/spec/refinements_spec.rb
+++ b/spec/refinements_spec.rb
@@ -117,7 +117,9 @@ describe Refinements do
 
       _(str2.instance_variable_get(:@cmd)).must_equal str1.instance_variable_get(:@cmd)
       _(str2.instance_variable_get(:@name)).must_equal str1.instance_variable_get(:@name)
-      _(str2.instance_variable_get(:@type)).must_equal str1.instance_variable_get(:@type)
+      # :@type is always nil
+      _(str2.instance_variable_get(:@type)).must_be_nil
+      _(str1.instance_variable_get(:@type)).must_be_nil
     end
   end
 end

--- a/spec/source/http_spec.rb
+++ b/spec/source/http_spec.rb
@@ -23,10 +23,10 @@ describe Oxidized::HTTP do
       _(Oxidized::HTTP.new.send(:string_navigate, h1, "inventory[0].ip")).must_equal "10.10.10.10"
     end
     it "should return nil on non-existing string key" do
-      _(Oxidized::HTTP.new.send(:string_navigate, h1, "jotain.3")).must_equal nil
+      _(Oxidized::HTTP.new.send(:string_navigate, h1, "jotain.3")).must_be_nil
     end
     it "should return nil on non-existing array index" do
-      _(Oxidized::HTTP.new.send(:string_navigate, h1, "inventory[3]")).must_equal nil
+      _(Oxidized::HTTP.new.send(:string_navigate, h1, "inventory[3]")).must_be_nil
     end
   end
 end


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
- debug needs explicity to be set to "false" in order to avoid DEBUG messages
- Net::SSH.start needs a Hash for its options
- use asset_nil and not assert_equal
