### PR TITLE
Add support for Fibrestore FSOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - added SCP input (@aeiodelic)
 - Added `linux/arm64` and `linux/amd64` platforms to Docker build/publish. (@disaac)
 - Added verion info for Vyatta (@systeembeheerder)
+- model for Fibrestore (fs.com) FSOS (@tcrichton)
 
 ## Changed
 - tp-link: fixed enable mode post login entrance (@mirackle-spb)

--- a/docs/Model-Notes/FSOS.md
+++ b/docs/Model-Notes/FSOS.md
@@ -1,0 +1,11 @@
+# Fiberstore (fs.com) FSOS notes
+
+This has been tested against the following models and OS versions
+
+|Model               |OS Version and Build          |
+|--------------------|------------------------------|
+|S3400-48T4SP        |Version 2.0.2J Build 81736    |
+|S3400-48T4SP        |Version 2.0.2J Build 95262    |
+|S3400-48T6SP        |Version 2.2.0F Build 109661   |
+
+Back to [Model-Notes](README.md)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -49,6 +49,7 @@
 |                    |CatOS                         |[catos](/lib/oxidized/model/catos.rb)
 |                    |Cisco Catalyst Express        |[ciscoce](/lib/oxidized/model/ciscoce.rb)
 |                    |FireLinuxOS                   |[firelinuxos](/lib/oxidized/model/firelinuxos.rb)
+|Fiberstore (fs.com) |FSOS                          |[fsos](/lib/oxidized/model/fsos.rb)              |                 |[FSOS](Model-Notes/FSOS.md)
 |                    |IOS                           |[ios](/lib/oxidized/model/ios.rb)                |@robertcheramy   |[IOS](Model-Notes/IOS.md)
 |                    |IOSXR                         |[iosxr](/lib/oxidized/model/iosxr.rb)
 |                    |NGA                           |[cisconga](/lib/oxidized/model/cisconga.rb)

--- a/lib/oxidized/model/fsos.rb
+++ b/lib/oxidized/model/fsos.rb
@@ -1,0 +1,43 @@
+class FSOS < Oxidized::Model
+  # Fiberstore / fs.com
+  using Refinements
+  comment '! '
+
+  # Handle paging
+  expect /^ --More--.*$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /(secret \w+) (\S+).*/, '\\1 <secret hidden>'
+    cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'
+    cfg.gsub! /(snmp-server community \d+) (\S+).*/, '\\1 <secret hidden>'
+    cfg
+  end
+
+  cmd 'show version' do |cfg|
+    # Remove uptime so the result doesn't change every time
+    cfg.gsub! /.*uptime is.*\n/, ''
+    comment cfg
+  end
+
+  cmd 'show running-config' do |cfg|
+    # Remove "Building configuration..." message
+    cfg.gsub! /^Building configuration.*\n/, ''
+    cfg.cut_head
+  end
+
+  cfg :telnet do
+    username /^Username:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    post_login 'enable'
+    post_login 'terminal length 0'
+    post_login 'terminal width 256'
+    pre_logout 'exit'
+    pre_logout 'exit'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added model Fibrestore FSOS