### PR TITLE
Reverting PR #2498 as it broke old procurve models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fixed pre_logout for BDCOM switches
 - Fix 'wpa passphrase' hashed secret for SonicOS devices with built-in wireless #3036 (@lazynooblet)
 - Fix potential busy wait when retries and/or next_adds_job is enabled (@gs-kamnas)
+- Reverting PR #2498 as it broke old procurve models (2510G, 2610, 2824). Fixes #2833, #2871 (@robertcheramy)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -20,7 +20,7 @@
 |Arbor Networks      |ArbOS                         |[arbos](/lib/oxidized/model/arbos.rb)            |                 |[ArbOS](Model-Notes/ArbOS.md)
 |Arista              |EOS                           |[eos](/lib/oxidized/model/eos.rb)                |                 |[EOS](Model-Notes/EOS.md)
 |Arris               |C4CMTS                        |[c4cmts](/lib/oxidized/model/c4cmts.rb)
-|Aruba               |AOS-CX                        |[aoscx](/lib/oxidized/model/aoscx.rb)
+|Aruba               |AOS-CX                        |[aoscx](/lib/oxidized/model/aoscx.rb)            |@robertcheramy
 |                    |AOSW                          |[Aaosw](/lib/oxidized/model/aosw.rb)
 |Asterfusion         |AsterNOS                      |[asternos](/lib/oxidized/model/asternos.rb)
 |AudioCodes          |AudioCodes                    |[audiocodes](/lib/oxidized/model/audiocodes.rb)
@@ -99,8 +99,8 @@
 |Hillstone Networks  |StoneOS                       |[stoneos](/lib/oxidized/model/stoneos.rb)
 |Hirschmann          |Classic                       |[hirschmann](/lib/oxidized/model/hirschmann.rb)
 |                    |HiOS                          |[hios](/lib/oxidized/model/hios.rb)
-|HP                  |Comware (HP A-series, H3C, 3Com)|[comware](/lib/oxidized/model/comware.rb)      |                 |[Comware](Model-Notes/Comware.md)
-|                    |Procurve                      |[procurve](/lib/oxidized/model/procurve.rb)
+|HP                  |Comware (HP A-series, H3C, 3Com)|[comware](/lib/oxidized/model/comware.rb)      |@robertcheramy   |[Comware](Model-Notes/Comware.md)
+|                    |Procurve                      |[procurve](/lib/oxidized/model/procurve.rb)      |@robertcheramy
 |                    |BladeSystem (Onboard Administrator)|[hpebladesystem](/lib/oxidized/model/hpebladesystem.rb)
 |                    |MSA                           |[hpemsa](/lib/oxidized/model/hpemsa.rb)
 |                    |MSM (Wireless Controller)     |[hpmsm](/lib/oxidized/model/hpmsm.rb)

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -5,7 +5,7 @@ class Procurve < Oxidized::Model
   # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+[#>] ), which ends the line
   # telnet switches may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), followed by the prompt, followed
   # by at least 3 other vt100 characters
-  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+(\((config|vlan-[0-9]{1,4}|y\/n)\)|\(o\)nce)?[#>:?\]] {1,2})($|(\e\[24;[0-9][0-9]?[hH]){3})/
+  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
 
   comment '! '
 
@@ -36,6 +36,8 @@ class Procurve < Oxidized::Model
     cfg.gsub! /\e\[\??\d+(;\d+)*[A-Za-z]/, ''
     # Additional filtering for power usage reporting which obviously changes over time
     cfg.gsub! /^(.*AC [0-9]{3}V\/?([0-9]{3}V)?) *([0-9]{1,3}) (.*)/, '\\1 <removed> \\4'
+    # Remove failed commands that are not supported on all models
+    cfg.gsub! /^Invalid input: [A-Za-z-]+\n/, ''
     cfg
   end
 


### PR DESCRIPTION


## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
- Reverting PR #2498 as it broke old procurve models (2510G, 2610, 2824).
- Closes issue #2833
- Closes issue #2871
- Removed "Invalid input" on unsupported commands
- Adding myself as model maintainter for HP/Aruba devices I have access to. Multiple model maintainters per model are welcome, just add yourself :-)