### PR TITLE
save navigation for http-header

### DIFF
--- a/lib/oxidized/input/http.rb
+++ b/lib/oxidized/input/http.rb
@@ -56,7 +56,7 @@ module Oxidized
     
       res = make_request(uri, ssl_verify)
     
-      if res.code == '401' && res['www-authenticate'].include?('Digest')
+      if res.code == '401' && res['www-authenticate']&.include?('Digest')
         uri.user = @username
         uri.password = @password
         Oxidized.logger.debug "Server requires Digest authentication"


### PR DESCRIPTION
## Description
Adds safe navigation for res['www-authenticate'] because it can be nil in basic auth