### PR TITLE
feat: remove and enhance removal of secrets in nxos model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix 'wpa passphrase' hashed secret for SonicOS devices with built-in wireless #3036 (@lazynooblet)
 - Fix potential busy wait when retries and/or next_adds_job is enabled (@gs-kamnas)
 - Reverting PR #2498 as it broke old procurve models (2510G, 2610, 2824). Fixes #2833, #2871 (@robertcheramy)
+- Fixed regexp used to remove secrets in nxos model. Fixes #3080 (@desnoe)
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/model/nxos.rb
+++ b/lib/oxidized/model/nxos.rb
@@ -10,11 +10,12 @@ class NXOS < Oxidized::Model
   end
 
   cmd :secret do |cfg|
-    cfg.gsub! /^(snmp-server community).*/, '\\1 <configuration removed>'
-    cfg.gsub! /^(snmp-server user (\S+) (\S+) auth (\S+)) (\S+) (priv) (\S+)/, '\\1 <configuration removed> '
+    cfg.gsub! /^(snmp-server community).*/, '\\1 <secret hidden>'
+    cfg.gsub! /^(snmp-server user (\S+) (\S+) auth (\S+)) (\S+) (priv) (\S+)/, '\\1 <secret hidden> '
+    cfg.gsub! /^(snmp-server host.*? )\S+( udp-port \d+)?$/, '\\1<secret hidden>\\2'
     cfg.gsub! /(password \d+) (\S+)/, '\\1 <secret hidden>'
     cfg.gsub! /^(radius-server key).*/, '\\1 <secret hidden>'
-    cfg.gsub! /^(tacacs-server host .+ key(?: \d+)?) \S+/, '\\1 <secret hidden>'
+    cfg.gsub! /^(tacacs-server .*key(?: \d+)?) \S+/, '\\1 <secret hidden>'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Changes are in the **nxos** model only:
- always replace secret with the `<secret hidden>` string
- rework the tacacs-server regex so that is works with all known cases
- add a new regex to remove secret in `snmp-server host` commands

Closes issue #3080 