### PR TITLE
model vyatta: hide wireguard private-key and preshared-key

### DIFF
--- a/lib/oxidized/model/vyatta.rb
+++ b/lib/oxidized/model/vyatta.rb
@@ -15,6 +15,8 @@ class Vyatta < Oxidized::Model
     cfg.gsub! /password (\S+).*/, 'password <secret removed>'
     cfg.gsub! /pre-shared-secret (\S+).*/, 'pre-shared-secret <secret removed>'
     cfg.gsub! /community (\S+) {/, 'community <hidden> {'
+    cfg.gsub! /private-key (\S+).*/, 'private-key <secret removed>'
+    cfg.gsub! /preshared-key (\S+).*/, 'preshared-key <secret removed>'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

The patch hide secrets of WireGuard interfaces in vyatta / vyos :

I was not able to try Rubocop and rake test. I'm not used to these tools and didn't manage to use them.

I tried this patch on our instance of Oxidized and the patch produce this change on VyOS 1.5 :

```diff
-set interfaces wireguard wg0 peer mypeer preshared-key 'DFpH6vrTlXczS/eHFUt+rddmE7zRaeQ1oCiprVGwzXs='
+set interfaces wireguard wg0 peer mypeer preshared-key <secret removed>
set interfaces wireguard wg0 peer mypeer public-key 'qu3a1Dus/jaE4QM6qIUWaF/Jdktg8+FyMssicDMsu1Y='
set interfaces wireguard wg0 port '43521'
-set interfaces wireguard wg0 private-key 'SCcDxY9eldGfQKlncqtPifGw0JHtedszS89V5BpTQWM='
+set interfaces wireguard wg0 private-key <secret removed>
```