### PR TITLE
Example of running oxidized with podman-container

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Check out the [Oxidized TREX 2014 presentation](http://youtu.be/kBQ_CTUuqeU?t=3h
     * [FreeBSD](#freebsd)
     * [Build from Git](#build-from-git)
     * [Docker](#running-with-docker)
+    * [Podman-Compose](#running-with-podman-compose)
     * [Installing Ruby 2.3 using RVM](#installing-ruby-23-using-rvm)
 3. [Initial Configuration](#configuration)
 4. [Configuration](docs/Configuration.md)
@@ -255,6 +256,10 @@ If you need to use an internal CA (e.g. to connect to an private github instance
 ```shell
 docker run -v /etc/oxidized:/home/oxidized/.config/oxidized -v /path/to/MY-CA.crt:/usr/local/share/ca-certificates/MY-CA.crt -p 8888:8888/tcp -e UPDATE_CA_CERTIFICATES=true -t oxidized/oxidized:latest
 ```
+
+### Running with podman-compose
+Under [examples/podman-compose](examples/podman-compose), you will find a complete
+example of how to integrate the container into a docker-compose.yml file.
 
 ### Installing Ruby 2.3 using RVM
 

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -64,3 +64,19 @@ Compare the output to the partial output collected by Oxidized, focusing on the 
 Adapt the prompt regexp to be more conservative if necessary in a local model override file.
 
 *We encourage you to submit a PR for any prompt issues you encounter.*
+
+## Oxidized does not push to a remote Git repository (hook githubrepo)
+See Issue #2753
+
+You need to store the public SSH keys of the remote Git server to the ~/.ssh/known_hosts
+of the user running oxidized.
+
+This can be done with
+```shell
+ssh-keyscan gitserver.git.com >> ~/.ssh/known_hosts
+```
+
+If you are running oxidized in a container, you need to map /home/oxidized/.ssh in the
+container to a local repository and save the known_hosts in the local repository. You can
+find an example how to do this under [examples/podman-compose](/examples/podman-compose/)
+

--- a/examples/podman-compose/Makefile
+++ b/examples/podman-compose/Makefile
@@ -1,0 +1,61 @@
+# Make sure these targets always run
+.PHONY: help rights clean-rights
+
+help:
+	@: $(info $(HELP))
+
+rights:
+	podman unshare chown -R 30000:30000 oxidized-config oxidized-ssh
+
+clean-rights:
+	podman unshare chown -R 0:0 *
+
+start: rights model-image
+	podman-compose -p oxidized up
+
+run: start
+
+stop:
+	podman-compose -p oxidized down
+	$(MAKE) clean-rights
+
+start-local:
+	if [ -f oxidized-config/config.local ]; then \
+	  cp oxidized-config/config.local oxidized-config/config; \
+	else \
+	  echo "oxidized-config/config.local does not exist"; \
+	fi
+	$(MAKE) start
+
+stop-local: stop
+	if [ -f oxidized-config/config.local ]; then \
+	  git checkout -- oxidized-config/config; \
+	else \
+	  echo "oxidized-config/config.local does not exist"; \
+	fi
+
+model-image:
+	podman image exists localhost/local/model || \
+	  podman build -t local/model -f model-simulation/Dockerfile-model .
+
+model-clean:
+	podman rmi local/model
+
+clean: stop-local model-clean
+
+define HELP
+make help           - This help
+make rights         - Change the rights of mapped folders for user oxidized
+                      in the container
+make clean-rights   - Revert the rights of mapped folders to the local user
+make start          - Start the containter
+                      You can interrupt with Ctrl-C, but make sure you run
+                      make stop to realy stop the container
+make run            - Same as make start
+make stop           - Stop the containter
+make start-local    - Starts the container with the local configuration config.local
+make stop-local     - Stops the container and restores oxidized-config/config from git
+make model-image    - Creates a local OCI-Image to run simulated devices
+make model-clean    - Removes the local OCI-Image to run simulated devices
+make clean          - make stop-local + model-clean
+endef

--- a/examples/podman-compose/README.md
+++ b/examples/podman-compose/README.md
@@ -1,0 +1,58 @@
+# Running oxidized with podman-compose
+This is an example of Oxidized running within an OCI container, provided by
+podman and podman-compose.
+
+In order to have the example work out of the box, a network device is simulated.
+The model asternos has been chosen because there were not too many commands to
+implement.
+
+To run the example, just run `make start`. You should be sure to have installed the
+[dependencies](#dependencies) before.
+
+To exit, press `CTRL-C` or run `make stop` in a separate shell. If you exit
+with `CTRL-C`, make sure to run `make stop` after it, in order to clean up the
+running environment.
+
+## Running Environment
+This example of oxidized with podman-compose has been run on Debian
+Bookworm (Version 12), but should work with few adaptations on any Linux
+box running podman, and maybe also with docker.
+
+## Dependencies
+You need to install some packages on your debian system:
+```shell
+sudo apt install podman containers-storage podman-compose make
+```
+
+You also want to make sure that podman uses the overlay driver for storing its images.
+If not, it will save every layer of the container to disk (and not only the delta),
+so it will fill your disk very fast.
+
+This happens if you run podman without having installed the package `container-storage`
+before.
+
+```shell
+podman info | grep graphDriverName
+```
+
+You should get this reply
+```shell
+  graphDriverName: overlay
+```
+
+If not, the quick way I found to solve it is to delete `~/.local/share/containers/`.
+Beware - this will delete **all** your containers!
+
+## I want to adapt this to my needs
+Feel free and have fun. You probably want to edit docker-compose.yml in order to remove the
+simulated model.
+
+## Use your own oxidized configuration within the git repository
+When developing oxidized and testing the container, you may want to use your
+own configuration. This can be done by saving it under `oxidized-config/config.local`
+
+`make start-local` will recognize the local configuration and copy it to
+`oxidized-config/config` before starting the container.
+
+You shoud stop the container with `make stop-local` in order to restore the original
+configuration from git.

--- a/examples/podman-compose/docker-compose.yml
+++ b/examples/podman-compose/docker-compose.yml
@@ -1,0 +1,21 @@
+services:
+  oxidized:
+    # Choose the image that you want to test
+    # image: docker.io/oxidized/oxidized:0.29.1
+    image: docker.io/oxidized/oxidized:latest
+    ports:
+      - 127.0.0.1:8042:8888/tcp
+    environment:
+      # Reload hosts list once per day
+      CONFIG_RELOAD_INTERVAL: 86400
+      # Needed when you push to a remote git repository
+      OXIDIZED_SSH_PASSPHRASE: xxxxPassphasexxxx
+    volumes:
+       - ./oxidized-config:/home/oxidized/.config/oxidized
+       - ./oxidized-ssh:/home/oxidized/.ssh
+  # This is a simulated network device for the example to work out of the box
+  asternos-device:
+    image: localhost/local/model
+    volumes:
+      - ./model-simulation/asternos.sh:/home/oxidized/.profile
+      - ./model-simulation/asternos.sh:/home/admin/.profile

--- a/examples/podman-compose/model-simulation/Dockerfile-model
+++ b/examples/podman-compose/model-simulation/Dockerfile-model
@@ -1,0 +1,13 @@
+FROM docker.io/phusion/baseimage:jammy-1.0.2
+
+# Use baseimage-docker's init system.
+CMD ["/sbin/my_init"]
+
+# enable ssh
+RUN rm -f /etc/service/sshd/down
+RUN /etc/my_init.d/00_regen_ssh_host_keys.sh
+
+# Add users to login. The password is "oxidized"
+RUN useradd -m oxidized -p '$y$j9T$UoDYxDiE.8iBGmoaD/acn1$kVvYvoEIJdKUmIKFVBRYKLIVzmEBP1RKrCM6Vfx.V55' -s /bin/bash
+RUN useradd -m admin -p '$y$j9T$UoDYxDiE.8iBGmoaD/acn1$kVvYvoEIJdKUmIKFVBRYKLIVzmEBP1RKrCM6Vfx.V55' -s /bin/bash
+

--- a/examples/podman-compose/model-simulation/asternos.sh
+++ b/examples/podman-compose/model-simulation/asternos.sh
@@ -1,0 +1,34 @@
+# if running bash
+if [ -n "$BASH_VERSION" ]; then
+    # include .bashrc if it exists
+    if [ -f "$HOME/.bashrc" ]; then
+        . "$HOME/.bashrc"
+    fi
+fi
+
+# Display a MOTD
+cat << EOF
+This is the welcome message of this device
+it is muliline
+End of the MOTD
+EOF
+
+function show() {
+  if [ "$*" == "version" ]; then
+    echo "Version 1.2.3"
+  elif [ "$*" == "runningconfiguration all" ]; then
+          cat << EOF
+! begin of the configuration
+! this is the running config
+!
+I have no idea how a configuration in asternos looks like ;-)
+!
+! End of the Configuration
+EOF
+  else
+    echo "command 'show $*' not implemented"
+  fi
+}
+
+PS1="asternos$"
+

--- a/examples/podman-compose/oxidized-config/.gitignore
+++ b/examples/podman-compose/oxidized-config/.gitignore
@@ -1,0 +1,8 @@
+# Ignore local configurations, which will override the git config
+config.local
+router.db.local
+
+# Ignore logs, retrieved configs...
+configs/
+crash
+logs/

--- a/examples/podman-compose/oxidized-config/config
+++ b/examples/podman-compose/oxidized-config/config
@@ -1,0 +1,46 @@
+---
+username: oxidized
+password: oxidized
+resolve_dns: true
+interval: 3600
+use_syslog: false
+debug: false
+threads: 30
+use_max_threads: true
+timeout: 20
+retries: 3
+prompt: !ruby/regexp /^([\w.@-]+[#>]\s?)$/
+rest: 127.0.0.1:8888
+next_adds_job: false
+vars: {}
+groups: {}
+group_map: {}
+models: {}
+pid: "~/.config/oxidized/pid"
+crash:
+  directory: "~/.config/oxidized/crashes"
+  hostnames: false
+stats:
+  history_size: 10
+input:
+  default: ssh
+  debug: false
+  ssh:
+    secure: false
+  ftp:
+    passive: true
+  utf8_encoded: true
+output:
+  default: file
+  file:
+    directory: "~/.config/oxidized/configs/"
+source:
+  default: csv
+  csv:
+    file: "~/.config/oxidized/router.db"
+    delimiter: !ruby/regexp /:/
+    map:
+      name: 0
+      model: 1
+      ip: 2
+    gpg: false

--- a/examples/podman-compose/oxidized-config/router.db
+++ b/examples/podman-compose/oxidized-config/router.db
@@ -1,0 +1,1 @@
+asternos-device:asternos

--- a/examples/podman-compose/oxidized-ssh/README.md
+++ b/examples/podman-compose/oxidized-ssh/README.md
@@ -1,0 +1,14 @@
+This is `~/.ssh/` of the user oxidized inside the oxidized container.
+
+## What you need here for the hook githubrepo
+You can store the SSH key needed to access a remote Git repository here. Here is
+an example how to generate this key.
+```shell
+ssh-keygen -q -t ed25519 -C "Oxidized Push Key@`hostname`" -N "YOURPASSPHRASE" -m PEM -f oxidized-key
+```
+
+You also need to store the public keys of the remote git server in known_hosts. If you do not,
+oxidized will refuse to push to the remote Git with the error `#<Rugged::SshError: invalid or unknown remote ssh hostkey>`, see Issue #2753.
+```shell
+ssh-keyscan git-server.example.com > known_hosts
+```


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added an example how to run oxidized within a podman container with podman-container.

This PR also documents an closes Issue #2753
