### PR TITLE
Better/more unified precedence for options that can be defined global, per model, group or per node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - dlinknextgen removes user and snmp-server secrets (@tcrichton)
 - dnos: hide secrets in "ospf message-digest-key", "authentication-type" and "bsd-username" (@rybnico)
 - junos: Replace dynamic value in VMX-BANDWIDTH with count, hide ssh keys
+- oxidized: options (such as credentials, etc.) now use the same resolution logic as variables and can also be defined per model in a group 
 
 ### Fixed
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -242,13 +242,15 @@ groups:
     password: ubnt
 ```
 
-Model specific variables within groups
+Model specific variables/credentials within groups
 
 ```yaml
 groups:
   foo:
     models:
       arista:
+        username: admin
+        password: password
         vars:
           ssh_keys: "~/.ssh/id_rsa_foo_arista"
       vyatta:
@@ -260,6 +262,8 @@ groups:
         vars:
           ssh_keys: "~/.ssh/id_rsa_bar_routeros"
       vyatta:
+        username: admin
+        password: pass
         vars:
           ssh_keys: "~/.ssh/id_rsa_bar_vyatta"
 ```
@@ -310,6 +314,17 @@ models:
     username: nil
     password: pass
 ```
+
+### Options (credentials, vars, etc.) precedence:  
+From least to most important:
+- global options
+- model specific options
+- group specific options
+- model specific options in groups
+- options defined on single nodes
+
+more important options overwrite less important ones if they are set
+
 
 ## RESTful API and Web Interface
 

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -211,17 +211,17 @@ module Oxidized
         Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '#{value}' from node"
 
       # Group specific model
-      elsif Oxidized.config.groups.has_key?(@group) && Oxidized.config.groups[@group].models.has_key?(model_name) && Oxidized.config.groups[@group].models[model_name].has_key?(key_str)
+      elsif Oxidized.config.groups&.has_key?(@group) && Oxidized.config.groups[@group]&.models&.has_key?(model_name) && Oxidized.config.groups[@group].models[model_name]&.has_key?(key_str)
         value = Oxidized.config.groups[@group].models[model_name][key_str]
         Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '#{value}' from model in group"
 
       # Group
-      elsif Oxidized.config.groups.has_key?(@group) && Oxidized.config.groups[@group].has_key?(key_str)
+      elsif Oxidized.config.groups&.has_key?(@group) && Oxidized.config.groups[@group]&.has_key?(key_str)
         value = Oxidized.config.groups[@group][key_str]
         Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '#{value}' from group"
 
       # Model
-      elsif Oxidized.config.models.has_key?(model_name) && Oxidized.config.models[model_name].has_key?(key_str)
+      elsif Oxidized.config.models&.has_key?(model_name) && Oxidized.config.models[model_name]&.has_key?(key_str)
         value = Oxidized.config.models[model_name][key_str]
         Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '#{value}' from model"
 

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -211,17 +211,17 @@ module Oxidized
         Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '#{value}' from node"
 
       # Group specific model
-      elsif Oxidized.config.groups&.has_key?(@group) && Oxidized.config.groups[@group]&.models&.has_key?(model_name) && Oxidized.config.groups[@group].models[model_name]&.has_key?(key_str)
+      elsif Oxidized.config.groups.has_key?(@group) && Oxidized.config.groups[@group].models.has_key?(model_name) && Oxidized.config.groups[@group].models[model_name].has_key?(key_str)
         value = Oxidized.config.groups[@group].models[model_name][key_str]
         Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '#{value}' from model in group"
 
       # Group
-      elsif Oxidized.config.groups&.has_key?(@group) && Oxidized.config.groups[@group]&.has_key?(key_str)
+      elsif Oxidized.config.groups.has_key?(@group) && Oxidized.config.groups[@group].has_key?(key_str)
         value = Oxidized.config.groups[@group][key_str]
         Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '#{value}' from group"
 
       # Model
-      elsif Oxidized.config.models&.has_key?(model_name) && Oxidized.config.models[model_name]&.has_key?(key_str)
+      elsif Oxidized.config.models.has_key?(model_name) && Oxidized.config.models[model_name].has_key?(key_str)
         value = Oxidized.config.models[model_name][key_str]
         Oxidized.logger.debug "node.rb: setting node key '#{key}' to value '#{value}' from model"
 

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -116,4 +116,47 @@ describe Oxidized::Node do
       end
     end
   end
+
+  describe '#resolve_key test hierarchy' do
+    let(:group) { 'test_group' }
+    let(:model) { 'junos' }
+    let(:node) do
+      Oxidized::Node.new(
+        ip: '127.0.0.1', group: group, model: model
+      )
+    end
+
+    describe 'create node with different usernames defined on each level' do
+      it 'should use global username if set' do
+        Oxidized.config.username = "global_username"
+        _(node.auth[:username]).must_equal "global_username"
+      end
+      it 'should prefer model username over global one' do
+        Oxidized.config.username = "global_username"
+        Oxidized.config.models[model].username = "model_username"
+        _(node.auth[:username]).must_equal "model_username"
+      end
+      it 'should prefer group username over model one' do
+        Oxidized.config.username = "global_username"
+        Oxidized.config.models[model].username = "model_username"
+        Oxidized.config.groups[group].username = "group_username"
+        _(node.auth[:username]).must_equal "group_username"
+      end
+      it 'should prefer model username group setting over normal group one' do
+        Oxidized.config.username = "global_username"
+        Oxidized.config.models[model].username = "model_username"
+        Oxidized.config.groups[group].username = "group_username"
+        Oxidized.config.groups[group].models[model].username = "group_model_username"
+        _(node.auth[:username]).must_equal "group_model_username"
+      end
+      it 'should prefer node username over everything else' do
+        Oxidized.config.username = "global_username"
+        Oxidized.config.models[model].username = "model_username"
+        Oxidized.config.groups[group].username = "group_username"
+        Oxidized.config.groups[group].models[model].username = "group_model_username"
+        node = Oxidized::Node.new(ip: '127.0.0.1', group: group, model: model, username: "node_username")
+        _(node.auth[:username]).must_equal "node_username"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Hey,

with this PR options that are resolved when creating the node (like credentials, etc.) behave the same way as variables (`lib/oxidized/config/vars`), which means that group options are now preferred over model options and there's now also the possibility to define these options model specific in a group, which is already possible with [variables](https://github.com/ytti/oxidized/blob/master/docs/Configuration.md#advanced-group-configuration).

This would help with my scenario in which nearly all devices with the same model have identical credentials, but a small group of those have different ones. First I thought that this would be possible with groups, but in the current state I didn't find a way to achieve this.

This PR also adds a section in the documentation in which I try to explain this hierarchy for options, which should make this behavior easier to understand. 

also fixes #3058