### PR TITLE
Fix wrong regexp to get ride of \r

### DIFF
--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -45,7 +45,7 @@ module Oxidized
       cmd_output = if @exec
                      @ssh.exec! cmd
                    else
-                     cmd_shell(cmd, expect).gsub("/\r\n/", "\n")
+                     cmd_shell(cmd, expect).gsub("\r\n", "\n")
                    end
       # Make sure we return a String
       cmd_output.to_s


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Closes #2997 