### PR TITLE
Edit h3c model prompt to support the square brackets in system-view.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - dlinknextgen removes user and snmp-server secrets (@tcrichton)
 - dnos: hide secrets in "ospf message-digest-key", "authentication-type" and "bsd-username" (@rybnico)
 - junos: Replace dynamic value in VMX-BANDWIDTH with count, hide ssh keys
+- h3c: change prompt to expect either angle (user-view) or square (system-view) brackets (@nl987)
 
 ### Fixed
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)

--- a/lib/oxidized/model/h3c.rb
+++ b/lib/oxidized/model/h3c.rb
@@ -3,7 +3,7 @@ class H3C < Oxidized::Model
 
   # H3C
 
-  prompt /^.*(<[\w.-]+>)$/
+  prompt /^.*([<\[][\w.-]+[>\]])$/
   comment '# '
 
   cmd :secret do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
If you enter system-view on a comware switch the prompt changes from <> to [].
This isn't an issue in oxidized as it doesn't enter system-view to get data, but it might be needed when using oxidized-script, depending on what you're doing.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->