### PR TITLE
vyatta/vyos: update prompt matcher to account for non-privileged users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix potential busy wait when retries and/or next_adds_job is enabled (@gs-kamnas)
 - Reverting PR #2498 as it broke old procurve models (2510G, 2610, 2824). Fixes #2833, #2871 (@robertcheramy)
 - Fixed regexp used to remove secrets in nxos model. Fixes #3080 (@desnoe)
+- fixed prompt for vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez) 
 
 ## [0.29.1 - 2023-04-24]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - h3c: change prompt to expect either angle (user-view) or square (system-view) brackets (@nl987)
 
 ### Fixed
+- fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)
 
 
 ## [0.30.1 – 2024-04-12]
@@ -82,7 +83,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix potential busy wait when retries and/or next_adds_job is enabled (@gs-kamnas)
 - Reverting PR #2498 as it broke old procurve models (2510G, 2610, 2824). Fixes #2833, #2871 (@robertcheramy)
 - Fixed regexp used to remove secrets in nxos model. Fixes #3080 (@desnoe)
-- fixed prompt for vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez) 
 
 ## [0.29.1 - 2023-04-24]
 

--- a/lib/oxidized/model/vyatta.rb
+++ b/lib/oxidized/model/vyatta.rb
@@ -3,7 +3,7 @@ class Vyatta < Oxidized::Model
 
   # Brocade Vyatta / VyOS model #
 
-  prompt /@.*(:~\$|>)/
+  prompt /@.*(:~\$|>)\s/
 
   cmd :all do |cfg|
     cfg.lines.to_a[1..-2].join

--- a/lib/oxidized/model/vyatta.rb
+++ b/lib/oxidized/model/vyatta.rb
@@ -3,7 +3,7 @@ class Vyatta < Oxidized::Model
 
   # Brocade Vyatta / VyOS model #
 
-  prompt /@.*?:~\$\s/
+  prompt /@.*(:~\$|>)/
 
   cmd :all do |cfg|
     cfg.lines.to_a[1..-2].join


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
matches prompt ending with '>' which corresponds to non-privileged accounts. 
allows oxidized to use a non or low-privileged account to login to a VyOS device.
see related issue for detail

Closes issue #3111