### PR TITLE
Fix for slackdiff.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,7 +71,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - dlinknextgen removes user and snmp-server secrets (@tcrichton)
 - dnos: hide secrets in "ospf message-digest-key", "authentication-type" and "bsd-username" (@rybnico)
 - junos: Replace dynamic value in VMX-BANDWIDTH with count, hide ssh keys
-- Set default timeout to 60, since 20 is too short for larger configurations.
 
 ### Fixed
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)
@@ -96,7 +95,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix potential busy wait when retries and/or next_adds_job is enabled (@gs-kamnas)
 - Reverting PR #2498 as it broke old procurve models (2510G, 2610, 2824). Fixes #2833, #2871 (@robertcheramy)
 - Fixed regexp used to remove secrets in nxos model. Fixes #3080 (@desnoe)
-- Fixed incorrect slack api being used.
 
 ## [0.29.1 - 2023-04-24]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - dlinknextgen removes user and snmp-server secrets (@tcrichton)
 - dnos: hide secrets in "ospf message-digest-key", "authentication-type" and "bsd-username" (@rybnico)
 - junos: Replace dynamic value in VMX-BANDWIDTH with count, hide ssh keys
+- Set default timeout to 60, since 20 is too short for larger configurations.
 
 ### Fixed
 - fixed empty lines for ZyXEL GS1900 switches (@jluebbe)
@@ -92,6 +93,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix potential busy wait when retries and/or next_adds_job is enabled (@gs-kamnas)
 - Reverting PR #2498 as it broke old procurve models (2510G, 2610, 2824). Fixes #2833, #2871 (@robertcheramy)
 - Fixed regexp used to remove secrets in nxos model. Fixes #3080 (@desnoe)
+- Fixed incorrect slack api being used.
 
 ## [0.29.1 - 2023-04-24]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+- Updated slackdiff.rb to use slack_ruby_client instead of slack-api.
+- Updated default timeout from 20 to 60.
+
 ### Added
 - model for Siklu Multihaul TG radios (@bdg-robert)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-- Updated slackdiff.rb to use slack_ruby_client instead of slack-api.
-- Updated default timeout from 20 to 60.
-
 ### Added
 - model for Siklu Multihaul TG radios (@bdg-robert)
 
@@ -20,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fortios: Hide date in acme certifcate comments (@systeembeheerder)
 - dlink: added support for 'enable admin' before getting configuration, if enable=true (@as8net)
 - dlinknextgen: strip uptime and ntp update time from config
+- Updated slackdiff.rb to use slack_ruby_client instead of slack-api (@Punicaa)
 
 ### Fixed
 - fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -30,7 +30,7 @@ module Oxidized
       asetus.default.run_once      = false
       asetus.default.threads       = 30
       asetus.default.use_max_threads = false
-      asetus.default.timeout       = 20
+      asetus.default.timeout       = 60
       asetus.default.retries       = 3
       asetus.default.prompt        = /^([\w.@-]+[#>]\s?)$/
       asetus.default.rest          = '127.0.0.1:8888' # or false to disable

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -30,7 +30,7 @@ module Oxidized
       asetus.default.run_once      = false
       asetus.default.threads       = 30
       asetus.default.use_max_threads = false
-      asetus.default.timeout       = 60
+      asetus.default.timeout       = 20
       asetus.default.retries       = 3
       asetus.default.prompt        = /^([\w.@-]+[#>]\s?)$/
       asetus.default.rest          = '127.0.0.1:8888' # or false to disable

--- a/lib/oxidized/hook/slackdiff.rb
+++ b/lib/oxidized/hook/slackdiff.rb
@@ -1,4 +1,4 @@
-require 'slack'
+require 'slack_ruby_client'
 
 # defaults to posting a diff, if messageformat is supplied them a message will be posted too
 # diff defaults to true


### PR DESCRIPTION

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
- Updated slackdiff.rb to use slack_ruby_client instead of slack-api.
- Updated default timeout from 20 to 60. 

Fixes users experiencing the following error:

ERROR -- : Hook slack (#<SlackDiff:0x00005572c9621e20>) failed (#<NameError: uninitialized constant Slack::Client>) for event :post_store #2697 
