### PR TITLE
Hide radius and snmp secrets for Arista EOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - h3c: change prompt to expect either angle (user-view) or square (system-view) brackets (@nl987)
 - xos: Hide radius and user secrets for XOS (@iriseden)
+- eos: Hide radius and snmp secrets for Arista EOS (@iriseden)
 
 ### Fixed
 - fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -18,6 +18,7 @@ class EOS < Oxidized::Model
     cfg.gsub! /^(enable (?:secret|password)).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(service unsupported-transceiver).*/, '\\1 <license key removed>'
     cfg.gsub! /^(tacacs-server key \d+).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^((radius-server host) (([0-9]{1,3}.){3}[0-9]{1,3}) (vrf \S+) (key \d)).*/, '\\1 <secret hidden>'
     cfg.gsub! /( {6}key) (\h+ 7) (\h+).*/, '\\1 <secret hidden>'
     cfg
   end

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -18,8 +18,9 @@ class EOS < Oxidized::Model
     cfg.gsub! /^(enable (?:secret|password)).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(service unsupported-transceiver).*/, '\\1 <license key removed>'
     cfg.gsub! /^(tacacs-server key \d+).*/, '\\1 <configuration removed>'
-    cfg.gsub! /^((radius-server host) (([0-9]{1,3}.){3}[0-9]{1,3}) (vrf \S+) (key \d)).*/, '\\1 <secret hidden>'
+    cfg.gsub! /^(radius-server .+ key \d) \S+/, '\\1 <radius secret hidden>'
     cfg.gsub! /( {6}key) (\h+ 7) (\h+).*/, '\\1 <secret hidden>'
+    cfg.gsub! /(localized|auth (md5|sha\d{0,3})|priv (des|aes\d{0,3})) \S+/, '\\1 <secret hidden>'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Hide radius and snmp secrets for Arista EOS
