### PR TITLE
Update ip of example.com in ssh-test

### DIFF
--- a/spec/input/ssh_spec.rb
+++ b/spec/input/ssh_spec.rb
@@ -15,6 +15,8 @@ describe Oxidized::SSH do
 
   describe "#connect" do
     it "should use proxy command when proxy host given and connect by ip if resolve_dns is true" do
+      # If this test fails, check it exemple.com stil resolves to 93.184.215.14
+      # If not, update Net::SSH.expects(:start).with('93.184.215.14'... below
       Oxidized.config.resolve_dns = true
       @node = Oxidized::Node.new(name:     'example.com',
                                  input:    'ssh',
@@ -44,7 +46,7 @@ describe Oxidized::SSH do
         auth_methods:                    %w[none publickey password],
         proxy:                           proxy
       }
-      Net::SSH.expects(:start).with('93.184.216.34', 'alma', ssh_options)
+      Net::SSH.expects(:start).with('93.184.215.14', 'alma', ssh_options)
 
       ssh.instance_variable_set("@exec", true)
       ssh.connect(@node)


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Close #3145
The A-record of example.com was changed from 93.184.216.34 to 93.184.215.14, so our test failed.
I updated the IP-Adress in the ssh-test.
I could have added an automatic resolution in the test, but I don't think the IP of example.com will change too often, so I kept it simple. A comment should help to find the problem quickly next time.
I'm not documenting this in CHANGELOG.md as it is only relevant for developpers and not for our users.