### PR TITLE
[Fix]Add missing NewLine Characters for Audiocodes config

### DIFF
--- a/lib/oxidized/model/audiocodes.rb
+++ b/lib/oxidized/model/audiocodes.rb
@@ -12,14 +12,14 @@ class AudioCodes < Oxidized::Model
     data.sub re, ''
   end
 
-  cmd 'show running-config' do |cfg|
+  cmd "show running-config\r\n" do |cfg|
     cfg
   end
 
   cfg :ssh do
     username /^login as:\s$/
     password /^.+password:\s$/
-    pre_logout 'exit'
+    pre_logout "exit\r\n"
   end
 
   cfg :telnet do


### PR DESCRIPTION
## Description

Added missing NewLine characters. Without it the commands do not work.
Tested with Audiocodes SBC.

Closes issue #2006 
