### PR TITLE
make snmp community detection work

### DIFF
--- a/lib/oxidized/model/vyatta.rb
+++ b/lib/oxidized/model/vyatta.rb
@@ -14,7 +14,7 @@ class Vyatta < Oxidized::Model
     cfg.gsub! /plaintext-password (\S+).*/, 'plaintext-password <secret removed>'
     cfg.gsub! /password (\S+).*/, 'password <secret removed>'
     cfg.gsub! /pre-shared-secret (\S+).*/, 'pre-shared-secret <secret removed>'
-    cfg.gsub! /community (\S+) {/, 'community <hidden> {'
+    cfg.gsub! /community (\S+)/, 'community <hidden>'
     cfg.gsub! /private-key (\S+).*/, 'private-key <secret removed>'
     cfg.gsub! /preshared-key (\S+).*/, 'preshared-key <secret removed>'
     cfg


### PR DESCRIPTION
## Description
We request the configuration in its "command" form.

e.g. the 
snmp configuration will be 

`set service snmp community SuperSecretCommunity authorization 'ro'`

The secret detection expected a `{` which does not exist in this form


Closes issue #3153