### PR TITLE
models/dlink.rb Add privileged mode (enable)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - eos: Hide radius and snmp secrets for Arista EOS (@iriseden)
 - docker/podman: baseimage updated to phusion/baseimage:jammy-1.0.4
 - fortios: Hide date in acme certifcate comments (@systeembeheerder)
+- dlink: added support for 'enable admin' before getting configuration, if enable=true (@as8net)
 
 ### Fixed
 - fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)

--- a/lib/oxidized/model/dlink.rb
+++ b/lib/oxidized/model/dlink.rb
@@ -37,6 +37,7 @@ class Dlink < Oxidized::Model
 
   cfg :telnet, :ssh do
     post_login 'disable clipaging'
+    post_login 'enable admin' if vars(:enable) == true
     pre_logout 'logout'
   end
 end


### PR DESCRIPTION
Added function to start privileged mode before pulling the configuration. Tested on DGS-3120-24SC.