### PR TITLE
Add support to Dell EMS OS6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- os6: Added support to Dell EMC Networking OS6
 
 ### Changed
 - h3c: change prompt to expect either angle (user-view) or square (system-view) brackets (@nl987)

--- a/docs/Model-Notes/OS6.md
+++ b/docs/Model-Notes/OS6.md
@@ -1,0 +1,11 @@
+# OS6 Configuration
+
+The commands Oxidized executes are:
+
+1. terminal length 0
+2. show version
+3. show system | exclude "Up Time"
+4. show interfaces transceiver properties
+5. show running-config
+
+Back to [Model-Notes](README.md)

--- a/docs/Model-Notes/OS6.md
+++ b/docs/Model-Notes/OS6.md
@@ -4,8 +4,7 @@ The commands Oxidized executes are:
 
 1. terminal length 0
 2. show version
-3. show system | exclude "Up Time"
-4. show interfaces transceiver properties
-5. show running-config
+3. show interfaces transceiver properties
+4. show running-config
 
 Back to [Model-Notes](README.md)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -70,6 +70,7 @@
 |DELL                |PowerConnect                  |[powerconnect](/lib/oxidized/model/powerconnect.rb)
 |                    |AOSW                          |[aosw](/lib/oxidized/model/aosw.rb)              |                 |Same model as Aruba Wireless
 |                    |DellX                         |[dellx](/lib/oxidized/model/dellx.rb)
+|                    |Dell EMC Networking OS6      |[os6](/lib/oxidized/model/os6.rb)              |                 |[Dell EMC Networking OS6](Model-Notes/OS6.md)
 |                    |Dell EMC Networking OS10      |[os10](/lib/oxidized/model/os10.rb)              |                 |[Dell EMC Networking OS10](Model-Notes/OS10.md)
 |D-Link              |D-Link                        |[dlink](/lib/oxidized/model/dlink.rb)
 |                    |D-Link cisco like CLI         |[dlinknextgen](/lib/oxidized/model/dlinknextgen.rb)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -70,7 +70,7 @@
 |DELL                |PowerConnect                  |[powerconnect](/lib/oxidized/model/powerconnect.rb)
 |                    |AOSW                          |[aosw](/lib/oxidized/model/aosw.rb)              |                 |Same model as Aruba Wireless
 |                    |DellX                         |[dellx](/lib/oxidized/model/dellx.rb)
-|                    |Dell EMC Networking OS6      |[os6](/lib/oxidized/model/os6.rb)              |                 |[Dell EMC Networking OS6](Model-Notes/OS6.md)
+|                    |Dell EMC Networking OS6       |[os6](/lib/oxidized/model/os6.rb)              |                 |[Dell EMC Networking OS6](Model-Notes/OS6.md)
 |                    |Dell EMC Networking OS10      |[os10](/lib/oxidized/model/os10.rb)              |                 |[Dell EMC Networking OS10](Model-Notes/OS10.md)
 |D-Link              |D-Link                        |[dlink](/lib/oxidized/model/dlink.rb)
 |                    |D-Link cisco like CLI         |[dlinknextgen](/lib/oxidized/model/dlinknextgen.rb)

--- a/lib/oxidized/model/os6.rb
+++ b/lib/oxidized/model/os6.rb
@@ -25,7 +25,7 @@ class OS6 < Oxidized::Model
     comment cfg
   end
 
-    cmd 'show interfaces transceiver properties' do |cfg|
+  cmd 'show interfaces transceiver properties' do |cfg|
     comment cfg
   end
 

--- a/lib/oxidized/model/os6.rb
+++ b/lib/oxidized/model/os6.rb
@@ -1,0 +1,52 @@
+class OS6 < Oxidized::Model
+  using Refinements
+
+  # For switches running Dell EMC Networking OS10 #
+  #
+  # Tested with : Dell PowerSwitch S4148U-ON
+
+  comment  '! '
+
+  cmd :all do |cfg|
+    cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
+    cfg.each_line.to_a[2..-2].join
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /(password )(\S+)/, '\1<secret hidden>'
+    cfg
+  end
+
+  cmd 'show version' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show system | exclude "Up Time"' do |cfg|
+    comment cfg
+  end
+
+    cmd 'show interfaces transceiver properties' do |cfg|
+    comment cfg
+  end
+
+  cmd 'show running-config' do |cfg|
+    cfg.each_line.to_a[3..-1].join
+  end
+
+  cfg :telnet do
+    username /^Login:/
+    password /^Password:/
+  end
+
+  cfg :telnet, :ssh do
+    if vars :enable
+      post_login do
+        send "enable\n"
+        cmd vars(:enable)
+      end
+    end
+    post_login 'terminal length 0'
+    pre_logout 'exit'
+    pre_logout 'exit'
+  end
+end

--- a/lib/oxidized/model/os6.rb
+++ b/lib/oxidized/model/os6.rb
@@ -21,10 +21,6 @@ class OS6 < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show system | exclude "Up Time"' do |cfg|
-    comment cfg
-  end
-
   cmd 'show interfaces transceiver properties' do |cfg|
     comment cfg
   end

--- a/lib/oxidized/model/os6.rb
+++ b/lib/oxidized/model/os6.rb
@@ -1,9 +1,9 @@
 class OS6 < Oxidized::Model
   using Refinements
 
-  # For switches running Dell EMC Networking OS10 #
+  # For switches running Dell EMC Networking OS6 #
   #
-  # Tested with : Dell PowerSwitch S4148U-ON
+  # Tested with : Dell PowerSwitch N2048
 
   comment  '! '
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added support to Dell EMC OS6, tested on Dell N2048 with OS 6.5.4.4
