### PR TITLE
Update dependency of psych version

### DIFF
--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'net-scp',      '~> 4.0'
   s.add_runtime_dependency 'net-ssh',      '~> 7.1'
   s.add_runtime_dependency 'net-telnet',   '~> 0.2'
-  s.add_runtime_dependency 'psych',        '~> 3.3.2'
+  s.add_runtime_dependency 'psych',        '> 3.3.2'
   s.add_runtime_dependency 'rugged',       '~> 1.6'
   s.add_runtime_dependency 'slop',         '~> 4.6'
 


### PR DESCRIPTION
We do not need to lock psych to an old version.
There is no need either to enforce a high version, so changing ~> to >.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
