### PR TITLE
Fix version not found in oxidized-web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)
 - fixed power consumption included in ArubaOS-CX diffs starting with FL.10.13.xxx. Fixes #3142 (@terratalpi)
+- fixed oxidized-web getting "version not found" when fetching a version from git and no group is defined. Fixes #2222 (@robertcheramy)
 
 ## [0.30.1 – 2024-04-12]
 

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -139,7 +139,7 @@ module Oxidized
     def yield_repo_and_path(node, group)
       repo, path = node.repo, node.name
 
-      path = "#{group}/#{node.name}" if group && @cfg.single_repo?
+      path = "#{group}/#{node.name}" if group && !group.empty? && @cfg.single_repo?
 
       [repo, path]
     end

--- a/spec/output/git_spec.rb
+++ b/spec/output/git_spec.rb
@@ -1,0 +1,42 @@
+require_relative '../spec_helper'
+require 'oxidized/output/git'
+
+describe Oxidized::Git do
+  describe '#yield_repo_and_path' do
+    # Note that #yield_repo_and_path is private, so we can not call it directy
+    # we use @git.send(:yield_repo_and_path, ...) to bypass the protection
+    before do
+      # Default value in most tests
+      Oxidized.config.output.git.single_repo = true
+
+      @mock_node = Minitest::Mock.new
+      @mock_node.expect(:repo, '/tmp/oxidized.git')
+      @mock_node.expect(:name, 'switch-42')
+
+      @git = Oxidized::Git.new
+    end
+
+    it 'accepts group = nil' do
+      result = @git.send(:yield_repo_and_path, @mock_node, nil)
+      _(result).must_equal ['/tmp/oxidized.git', 'switch-42']
+    end
+
+    it 'ignores an empty group' do
+      result = @git.send(:yield_repo_and_path, @mock_node, nil)
+      _(result).must_equal ['/tmp/oxidized.git', 'switch-42']
+    end
+
+    it 'takes the group into accout when simple_repo=true' do
+      # node.name will be needed a second time
+      @mock_node.expect(:name, 'switch-42')
+      result = @git.send(:yield_repo_and_path, @mock_node, 'testgroup')
+      _(result).must_equal ['/tmp/oxidized.git', 'testgroup/switch-42']
+    end
+
+    it 'ignores the group when simple_repo=false' do
+      Oxidized.config.output.git.single_repo = false
+      result = @git.send(:yield_repo_and_path, @mock_node, 'testgroup')
+      _(result).must_equal ['/tmp/oxidized.git', 'switch-42']
+    end
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
oxidized-web was getting "version not found" when fetching a version from git and no group was defined. The issue was that group was an empty string. As oxidized-web produces group=nil AND group='', we handle both in oxidized.

Added a minitest to validate the correct behaviour.

Closes #2222
