### PR TITLE
Add JSON source class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - dlink: added support for 'enable admin' before getting configuration, if enable=true (@as8net)
 - dlinknextgen: strip uptime and ntp update time from config
 - Updated slackdiff.rb to use slack_ruby_client instead of slack-api (@Punicaa)
+- Add JSONFILE source (@sargon)
 
 ### Fixed
 - fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)

--- a/docs/Sources.md
+++ b/docs/Sources.md
@@ -55,6 +55,24 @@ and within: `~/.gnupg/gpg.conf`
 pinentry-mode loopback
 ```
 
+## Source: JSONFile
+
+One object per device. Supports GPG encryption like the CSV Source.
+
+```yaml
+source:
+  default: jsonfile
+  jsonfile: 
+    file: /var/lib/oxidized/router.json
+    map:
+      name: hostname
+      model: os
+      username: username
+      password: password
+    vars_map:
+      enable: enable
+```
+
 ## Source: SQL
 
  Oxidized uses the `sequel` ruby gem. You can use a variety of databases that aren't explicitly listed. For more information visit https://github.com/jeremyevans/sequel Make sure you have the correct adapter!

--- a/lib/oxidized/source/csv.rb
+++ b/lib/oxidized/source/csv.rb
@@ -45,17 +45,5 @@ module Oxidized
       end
       nodes
     end
-
-    private
-
-    def open_file
-      file = File.expand_path(@cfg.file)
-      if @cfg.gpg?
-        crypto = GPGME::Crypto.new password: @cfg.gpg_password
-        crypto.decrypt(File.open(file)).to_s
-      else
-        File.open(file)
-      end
-    end
   end
 end

--- a/lib/oxidized/source/jsonfile.rb
+++ b/lib/oxidized/source/jsonfile.rb
@@ -1,7 +1,5 @@
 module Oxidized
-  require "csv"
   class JSONFile < Source
-
     def initialize
       @cfg = Oxidized.config.source.jsonfile
       super
@@ -21,17 +19,17 @@ module Oxidized
 
     require "json"
 
-    def load(node_want = nil)
+    def load(*)
       nodes = []
       data = JSON.parse(open_file.read)
-      data = string_navigate(data, @cfg.hosts_location) if @cfg.hosts_location?
+      data = string_navigate_object(data, @cfg.hosts_location) if @cfg.hosts_location?
       data.each do |node|
         next if node.empty?
 
         # map node parameters
         keys = {}
         @cfg.map.each do |key, want_position|
-          keys[key.to_sym] = node_var_interpolate string_navigate(node, want_position)
+          keys[key.to_sym] = node_var_interpolate string_navigate_object(node, want_position)
         end
         keys[:model] = map_model keys[:model] if keys.has_key? :model
         keys[:group] = map_group keys[:group] if keys.has_key? :group
@@ -39,36 +37,13 @@ module Oxidized
         # map node specific vars
         vars = {}
         @cfg.vars_map.each do |key, want_position|
-          vars[key.to_sym] = node_var_interpolate string_navigate(node, want_position)
+          vars[key.to_sym] = node_var_interpolate string_navigate_object(node, want_position)
         end
         keys[:vars] = vars unless vars.empty?
 
         nodes << keys
       end
       nodes
-    end
-
-    private
-
-    def string_navigate(object, wants)
-      wants = wants.split(".").map do |want|
-        head, match, _tail = want.partition(/\[\d+\]/)
-        match.empty? ? head : [head, match[1..-2].to_i]
-      end
-      wants.flatten.each do |want|
-        object = object[want] if object.respond_to? :each
-      end
-      object
-    end
-
-    def open_file
-      file = File.expand_path(@cfg.file)
-      if @cfg.gpg?
-        crypto = GPGME::Crypto.new password: @cfg.gpg_password
-        crypto.decrypt(File.open(file)).to_s
-      else
-        File.open(file)
-      end
     end
   end
 end

--- a/lib/oxidized/source/jsonfile.rb
+++ b/lib/oxidized/source/jsonfile.rb
@@ -1,0 +1,74 @@
+module Oxidized
+  require "csv"
+  class JSONFile < Source
+
+    def initialize
+      @cfg = Oxidized.config.source.jsonfile
+      super
+    end
+
+    def setup
+      if @cfg.empty?
+        Oxidized.asetus.user.source.jsonfile.file      = File.join(Config::Root, 'router.json')
+        Oxidized.asetus.user.source.jsonfile.map.name  = "name"
+        Oxidized.asetus.user.source.jsonfile.map.model = "model"
+        Oxidized.asetus.user.source.jsonfile.gpg       = false
+        Oxidized.asetus.save :user
+        raise NoConfig, 'No source json config, edit ~/.config/oxidized/config'
+      end
+      require 'gpgme' if @cfg.gpg?
+    end
+
+    require "json"
+
+    def load(node_want = nil)
+      nodes = []
+      data = JSON.parse(open_file.read)
+      data = string_navigate(data, @cfg.hosts_location) if @cfg.hosts_location?
+      data.each do |node|
+        next if node.empty?
+
+        # map node parameters
+        keys = {}
+        @cfg.map.each do |key, want_position|
+          keys[key.to_sym] = node_var_interpolate string_navigate(node, want_position)
+        end
+        keys[:model] = map_model keys[:model] if keys.has_key? :model
+        keys[:group] = map_group keys[:group] if keys.has_key? :group
+
+        # map node specific vars
+        vars = {}
+        @cfg.vars_map.each do |key, want_position|
+          vars[key.to_sym] = node_var_interpolate string_navigate(node, want_position)
+        end
+        keys[:vars] = vars unless vars.empty?
+
+        nodes << keys
+      end
+      nodes
+    end
+
+    private
+
+    def string_navigate(object, wants)
+      wants = wants.split(".").map do |want|
+        head, match, _tail = want.partition(/\[\d+\]/)
+        match.empty? ? head : [head, match[1..-2].to_i]
+      end
+      wants.flatten.each do |want|
+        object = object[want] if object.respond_to? :each
+      end
+      object
+    end
+
+    def open_file
+      file = File.expand_path(@cfg.file)
+      if @cfg.gpg?
+        crypto = GPGME::Crypto.new password: @cfg.gpg_password
+        crypto.decrypt(File.open(file)).to_s
+      else
+        File.open(file)
+      end
+    end
+  end
+end

--- a/lib/oxidized/source/jsonfile.rb
+++ b/lib/oxidized/source/jsonfile.rb
@@ -1,5 +1,6 @@
 module Oxidized
   class JSONFile < Source
+    require "json"
     def initialize
       @cfg = Oxidized.config.source.jsonfile
       super
@@ -17,12 +18,17 @@ module Oxidized
       require 'gpgme' if @cfg.gpg?
     end
 
-    require "json"
-
     def load(*)
-      nodes = []
       data = JSON.parse(open_file.read)
       data = string_navigate_object(data, @cfg.hosts_location) if @cfg.hosts_location?
+
+      transform_json(data)
+    end
+
+    private
+
+    def transform_json(data)
+      nodes = []
       data.each do |node|
         next if node.empty?
 

--- a/lib/oxidized/source/source.rb
+++ b/lib/oxidized/source/source.rb
@@ -23,5 +23,28 @@ module Oxidized
       else var
       end
     end
+
+    private
+
+    def open_file
+      file = File.expand_path(@cfg.file)
+      if @cfg.gpg?
+        crypto = GPGME::Crypto.new password: @cfg.gpg_password
+        crypto.decrypt(File.open(file)).to_s
+      else
+        File.open(file)
+      end
+    end
+
+    def string_navigate_object(object, wants)
+      wants = wants.split(".").map do |want|
+        head, match, _tail = want.partition(/\[\d+\]/)
+        match.empty? ? head : [head, match[1..-2].to_i]
+      end
+      wants.flatten.each do |want|
+        object = object[want] if object.respond_to? :each
+      end
+      object
+    end
   end
 end

--- a/spec/source/http_spec.rb
+++ b/spec/source/http_spec.rb
@@ -7,26 +7,26 @@ describe Oxidized::HTTP do
     Oxidized.setup_logger
   end
 
-  describe "#string_navigate" do
+  describe "#string_navigate_object" do
     h1 = {}
     h1["inventory"] = [{ "ip" => "10.10.10.10" }]
     h1["jotain"] = { "2" => "jotain" }
     it "should be able to navigate multilevel-hash" do
       http = Oxidized::HTTP.new
       _(http.class).must_equal Oxidized::HTTP
-      _(http.send(:string_navigate, h1, "jotain.2")).must_equal "jotain"
+      _(http.send(:string_navigate_object, h1, "jotain.2")).must_equal "jotain"
     end
     it "should be able to navigate multilevel-hash" do
-      _(Oxidized::HTTP.new.send(:string_navigate, h1, "jotain.2")).must_equal "jotain"
+      _(Oxidized::HTTP.new.send(:string_navigate_object, h1, "jotain.2")).must_equal "jotain"
     end
     it "should be able to navigate hash/array combination" do
-      _(Oxidized::HTTP.new.send(:string_navigate, h1, "inventory[0].ip")).must_equal "10.10.10.10"
+      _(Oxidized::HTTP.new.send(:string_navigate_object, h1, "inventory[0].ip")).must_equal "10.10.10.10"
     end
     it "should return nil on non-existing string key" do
-      _(Oxidized::HTTP.new.send(:string_navigate, h1, "jotain.3")).must_be_nil
+      _(Oxidized::HTTP.new.send(:string_navigate_object, h1, "jotain.3")).must_be_nil
     end
     it "should return nil on non-existing array index" do
-      _(Oxidized::HTTP.new.send(:string_navigate, h1, "inventory[3]")).must_be_nil
+      _(Oxidized::HTTP.new.send(:string_navigate_object, h1, "inventory[3]")).must_be_nil
     end
   end
 end


### PR DESCRIPTION
With this class we can utilise JSON files directly without the redirection via a HTTP server. This massivly improved our configuration delivery process, because we are able to deliver cached configuration to oxidized without changes on the delivering service, which would have been much more complicated.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Adds an additional source class which is able to process JSON encoded files, like the HTTP source does.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
