### PR TITLE
Solve IOS-XR admin mode deprecation on certain platforms

### DIFF
--- a/lib/oxidized/model/iosxr.rb
+++ b/lib/oxidized/model/iosxr.rb
@@ -16,7 +16,7 @@ class IOSXR < Oxidized::Model
     cfg
   end
 
-  cmd 'admin show inventory' do |cfg|
+  cmd 'show inventory all' do |cfg|
     comment cfg
   end
 


### PR DESCRIPTION


## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Admin mode is being deprecated on some IOS-XR flavors.
On others, `admin show` requires more permissions for the same (or similar) output.

I went for the `show inventory all` instead of `show inventory` according to [zagosch's comment](https://github.com/ytti/oxidized/issues/3166#issuecomment-2178030871) on the ASR9k platform, even though I did not see any output difference on NCS or C8000 series.

This PR :
* Solves #3166
* Reverts https://github.com/ytti/oxidized/pull/2915

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
