### PR TITLE
Feature/remote branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - dlink: added support for 'enable admin' before getting configuration, if enable=true (@as8net)
 - dlinknextgen: strip uptime and ntp update time from config
 - Updated slackdiff.rb to use slack_ruby_client instead of slack-api (@Punicaa)
+- remote_repo: Add ability to specify remote branch name (@ianbarrere)
 
 ### Fixed
 - fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -184,6 +184,17 @@ hooks:
     privatekey: /root/.ssh/id_rsa
 ```
 
+A remote branch can be given if different from the default of "master" like so:
+
+```yaml
+hooks:
+  push_to_remote:
+    type: githubrepo
+    events: [post_store]
+    remote_repo: git@git.intranet:oxidized/test.git
+    remote_branch: main
+```
+
 ## Hook type: awssns
 
 The `awssns` hook publishes messages to AWS SNS topics. This allows you to notify other systems of device configuration changes, for example a config orchestration pipeline. Multiple services can subscribe to the same AWS topic.

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -36,7 +36,12 @@ class GithubRepo < Oxidized::Hook
       cleanup = true
       ref = repo.references.create("refs/heads/" + remote_branch, repo.head.target_id)
     end
-    remote.push([ref.name], credentials: creds)
+    pushed = remote.push([ref.name], credentials: creds)
+    if pushed == {}
+      log("Push successful", :debug)
+    else
+      log("Unexpected response from remote repo: #{pushed}", :warn)
+    end
     repo.references.delete(ref.name) if cleanup == true
   end
 

--- a/spec/hook/githubrepo_spec.rb
+++ b/spec/hook/githubrepo_spec.rb
@@ -40,7 +40,7 @@ describe GithubRepo do
       repo.expects(:fetch).with('origin', ['refs/heads/master'], credentials: credentials).returns(Hash.new(0))
       repo.expects(:branches).never
       repo.expects(:head).returns(repo_head)
-      _(gr.fetch_and_merge_remote(repo, credentials)).must_be_nil
+      _(gr.fetch_and_merge_remote(repo, credentials, 'master')).must_be_nil
     end
 
     describe "when there is update considering conflicts" do
@@ -60,7 +60,7 @@ describe GithubRepo do
         their_branch.expects(:name).returns("origin/master")
         merge_index.expects(:conflicts?).returns(true)
         Rugged::Commit.expects(:create).never
-        _(gr.fetch_and_merge_remote(repo, credentials)).must_be_nil
+        _(gr.fetch_and_merge_remote(repo, credentials, 'master')).must_be_nil
       end
 
       it "should merge when there is no conflict" do
@@ -75,7 +75,7 @@ describe GithubRepo do
                                              tree:       "tree",
                                              message:    "Merge remote-tracking branch 'origin/master'",
                                              update_ref: "HEAD").returns(1)
-        _(gr.fetch_and_merge_remote(repo, credentials)).must_equal 1
+        _(gr.fetch_and_merge_remote(repo, credentials, 'master')).must_equal 1
       end
     end
   end


### PR DESCRIPTION

## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
My organization has strict branch naming rules in our GitLab instance, and so I could not create a branch called "master". This adds functionality to specify a remote branch name with "remote_branch" key under githubrepo hook. The default is master, but can be overridden with this.

It also adds a bit more complete logging for pushes. It was failing silently for me before so it took a long time to track down the issue. Now it should be quite clear if the push fails or succeeds.

I'm not at all a ruby developer either, I did my best to follow best practices but feel free to let me know if something could be improved.

### Background

To document my process in case somebody needs to do something similar...

I was also trying to add a .gitlab-ci.yml file to define pipeline steps for our GitLab repo. This file was getting overwritten by Oxidized when it would run. What I needed to do was clone the devices.git repo from Oxidized locally, add the .gitlab-ci.yml file to that repo, push to origin, then copy the .git/index file from the working directory over to devices.git/index. This allowed Oxidized to know where it was, I suppose, and subsequent pushes worked and preserved the changes made to the repo outside of the standard Oxidized run.