### PR TITLE
rgos: Also strip system uptime from module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed telnet to disconnect gracefully even if it throws IOError while disconnect. Fixes #3212 (@ytti)
 - docs: run Git garbage collection to address performance issues. Fixes #3121 (@robertcheramy)
 - saos: fixed handling of 'unsaved configuration' indicator in prompt (@grbeneke)
+- rgos: also strip "System uptime" for installed modules (@spike77453)
 
 
 ## [0.30.1 – 2024-04-12]

--- a/lib/oxidized/model/rgos.rb
+++ b/lib/oxidized/model/rgos.rb
@@ -12,7 +12,7 @@ class RGOS < Oxidized::Model
 
   cmd 'show version' do |cfg|
     cfg = cfg.each_line.reject { |line| line.match /^System start time/ }.join
-    cfg = cfg.each_line.reject { |line| line.match /^System uptime/ }.join
+    cfg = cfg.each_line.reject { |line| line.match /^\s*System uptime/ }.join
     comment "#{cfg.cut_both}\n"
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Starting with RGOS/FSOS 12 `show version` also reports `System uptime` for any installed module, e.g.:

```
#show version 
System description      : FS Data Center Switch(N5860-48SC) By FS.COM Inc
System start time       : 2024-07-04 05:43:25
System uptime           : 0:06:26:14
System hardware version : 1.00
System software version : N5860_FSOS 12.5(1)B0506
System patch number     : NA
System serial number    : <redacted>
System boot version     : 1.3.36(Master) 1.3.36(Slave)
System rboot version    : 1.2.8
Module information:
  Slot 0 : N5860-48SC
    System uptime       : 0:06:26:14
    Hardware version    : 1.00
    Boot version        : 1.3.36(Master) 1.3.36(Slave)
    Rboot version       : 1.2.8
    Software version    : N5860_FSOS 12.5(1)B0506
    Serial number       : <redacted>
```

This change ensures all all lines starting with `System uptime` are rejected, no matter how many spaces (if any) there are between `SOL` and `System uptime`.