### PR TITLE
Clarify user permissions recommendation for running Oxidized

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ It is recommended practice to run Oxidized using its own username.  This usernam
 useradd -s /bin/bash -m oxidized
 ```
 
-> It is recommended __not__ to run Oxidized as root.
+> It is recommended __not__ to run Oxidized as root. After creating a dedicated user, switch to the oxidized user using su oxidized to ensure that Oxidized is run under the correct user context.
 
 To initialize a default configuration in your home directory `~/.config/oxidized/config`, simply run `oxidized` once. If you don't further configure anything from the output and source sections, it'll extend the examples on a subsequent `oxidized` execution. This is useful to see what options for a specific source or output backend are available.
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR updates the `README.md` to clarify the recommendation against running Oxidized as root. It now advises users to switch to the `oxidized` user with `su oxidized` to ensure proper permissions.

No additional tests were added, as this is a documentation change. The change does not require an update to the `CHANGELOG.md` as it does not affect the software's functionality.

