### PR TITLE
Fix issue #3163 

### DIFF
--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -69,7 +69,7 @@ module Oxidized
 
     # @param node [String] name of the node moved into the head of array
     def next(node, opt = {})
-      return unless waiting.find_node_index(node)
+      return if running.find_index(node)
 
       with_lock do
         n = del node
@@ -116,6 +116,10 @@ module Oxidized
       end
     end
 
+    def find_index(node)
+      index { |e| [e.name, e.ip].include? node }
+    end
+
     private
 
     def initialize(opts = {})
@@ -131,10 +135,6 @@ module Oxidized
 
     def with_lock(...)
       @mutex.synchronize(...)
-    end
-
-    def find_index(node)
-      index { |e| [e.name, e.ip].include? node }
     end
 
     # @param node node which is removed from nodes list


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests ran successful (try `rake test`)
- [ ] ~~Changes are reflected in the documentation~~
- [ ] ~~User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)~~

## Description
#### Current code:
If the node is running while `next(node)` is called, `waiting.find_node_index(node)` will throw an exception because the running node is not in this waiting list.
The indented behavior is a direct return from the next function.

#### My changes
I changed to code so that it uses the `find_index()` function instead, because if the node is not found there, it will simply return nil.
I also switched `return unless waiting.find_index(node)` to `return if running.find_index(node)`.  The running list is just the inverse of the waiting list, but it should be much shorter.
To be able to call `find_index()` on the running/waiting list, the function had to be moved from the private scope to the public scope.

I ran the tests and rubocop without any problems. I also tested it directly in our oxidized installation and it fixed the [Web API /next returns status 500 if node is waiting to poll](https://github.com/ytti/oxidized/issues/3163) issue.

Closes issue #3163 
