### PR TITLE
Update slackdiff.rb to use new slack file API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - saos: add inventory and software status collection (@grbeneke)
 - container-image: update to phusion/baseimage:noble-1.0.0 and include security upgrades at build time (@robertcheramy)
 - container-image: use ubuntu-packages instead of gems in order to reduce container image size (@robertcheramy)
+- Updated slackdiff.rb to use new files.getUploadURLExternal slack file upload API instead of deprecated files.upload (@varesa)
 
 ### Fixed
 - fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)

--- a/lib/oxidized/hook/slackdiff.rb
+++ b/lib/oxidized/hook/slackdiff.rb
@@ -1,4 +1,6 @@
 require 'slack_ruby_client'
+require 'uri'
+require 'net/http'
 
 # defaults to posting a diff, if messageformat is supplied them a message will be posted too
 # diff defaults to true
@@ -7,6 +9,30 @@ class SlackDiff < Oxidized::Hook
   def validate_cfg!
     raise KeyError, 'hook.token is required' unless cfg.has_key?('token')
     raise KeyError, 'hook.channel is required' unless cfg.has_key?('channel')
+  end
+
+  def slack_upload(client, title, content, channel)
+    log "Posting diff as snippet to #{channel}"
+    upload_dest = client.files_getUploadURLExternal(filename:     "change",
+                                                    length:       content.length,
+                                                    snippet_type: "diff")
+    file_uri = URI.parse(upload_dest[:upload_url])
+
+    http = Net::HTTP.new(file_uri.host, file_uri.port)
+    http.use_ssl = true
+
+    request = Net::HTTP::Post.new(file_uri.request_uri, { Host: file_uri.host })
+    request.body = content
+    response = http.request(request)
+
+    raise 'Slack file upload failed' unless response.is_a? Net::HTTPSuccess
+
+    files = [{
+      id:    upload_dest[:file_id],
+      title: title
+    }]
+    client.files_completeUploadExternal(channel_id: channel,
+                                        files:      files.to_json)
   end
 
   def run_hook(ctx)
@@ -26,12 +52,8 @@ class SlackDiff < Oxidized::Hook
       diff = gitoutput.get_diff ctx.node, ctx.node.group, ctx.commitref, nil
       unless diff == "no diffs"
         title = "#{ctx.node.name} #{ctx.node.group} #{ctx.node.model.class.name.to_s.downcase}"
-        log "Posting diff as snippet to #{cfg.channel}"
-        client.files_upload(channels: cfg.channel, as_user: true,
-                            content: diff[:patch].lines.to_a[4..-1].join,
-                            filetype: "diff",
-                            title: title,
-                            filename: "change")
+        content = diff[:patch].lines.to_a[4..-1].join
+        slack_upload(client, title, content, cfg.channel)
       end
     end
     # message custom formatted - optional


### PR DESCRIPTION
Use new files.getUploadURLExternal API call to initiate the update instead of deprecated files.upload which is no longer available for newly created API tokens

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

The existing API method used for uploading diffs to slack is deprecated, and also not available for newly created API tokens: https://api.slack.com/methods/files.upload

> files.upload is deprecated and will stop functioning on March 11, 2025. Use [files.getUploadURLExternal](https://api.slack.com/methods/files.getUploadURLExternal) and [files.completeUploadExternal](https://api.slack.com/methods/files.completeUploadExternal) to upload files instead. Newly created apps will be unable to use files.upload beginning May 8, 2024. See [Uploading files](https://api.slack.com/messaging/files#uploading_files) for more details on the process and [this changelog](https://api.slack.com/changelog/2024-04-a-better-way-to-upload-files-is-here-to-stay) for more on the deprecation.

The used 'slack_ruby_client' library implements the `files_getUploadURLExternal` and `files_completeUploadExternal` methods but as far as I can see, it does not include a method to actually upload the file. Replaced the deprecated call with these new functions and a simple HTTP POST to upload the actual bytes.

I am not sure if this upload functionality should be added to oxidized or slack_ruby_client. Or if it would be smarter to use something else than `net/http` (faraday?). Honestly, oxidized being my only exposure to the Ruby ecosystem, I'm trying to limit the area which I have to work with but I understand if this is not the approach the project wants to take. 

The solution has been tested to work in practice:
```
I, [2024-09-13T17:09:22.953412 #397765]  INFO -- : Configuration updated for /fwtest.xxx.fi
I, [2024-09-13T17:09:22.953595 #397765]  INFO -- : SlackDiff: Connecting to slack
I, [2024-09-13T17:09:23.207599 #397765]  INFO -- : SlackDiff: Connected
I, [2024-09-13T17:09:23.230153 #397765]  INFO -- : SlackDiff: Posting diff as snippet to GM3HZPVTP
I, [2024-09-13T17:09:25.789587 #397765]  INFO -- : SlackDiff: Finished
```

![screenshot_2024-09-13-171324](https://github.com/user-attachments/assets/c2b69c5f-6156-41d4-b4b9-9a7d70894b2c)


<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->

Closes issue #3189