### PR TITLE
ciscosmb: fix backup when no enable password is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fixed digest authentication when using http input (@spike77453)
 - fixed aosw prompt; now working with ArubaOS 8 (@mabezi, @robertcheramy)
 - routeros: fix system info for CHR. Fixes #3180 (@systeembeheerder)
+- ciscosmb: fix backup when no enable password is set. Fixes #3044 (@benasse)
 
 ## [0.30.1 – 2024-04-12]
 

--- a/lib/oxidized/model/ciscosmb.rb
+++ b/lib/oxidized/model/ciscosmb.rb
@@ -57,12 +57,14 @@ class CiscoSMB < Oxidized::Model
     username /User ?[nN]ame:/
     password /^\r?Password:/
 
-    post_login do
-      if vars(:enable) == true
-        cmd 'enable'
-      elsif vars(:enable)
-        cmd 'enable', /^\r?Password:$/
-        cmd vars(:enable)
+    if !vars(:enable).nil? && !vars(:enable).empty?
+      post_login do
+        if vars(:enable) == true
+          cmd 'enable'
+        elsif vars(:enable)
+          cmd 'enable', /^\r?Password:$/
+          cmd vars(:enable)
+        end
       end
     end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
ciscosmb: fix backup when no enable password is set. Fixes #3044
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Closes issue #3044