### PR TITLE
firewareos: fix prompt not matching when the node is managed and master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - container-image: use ubuntu-packages instead of gems in order to reduce container image size (@robertcheramy)
 
 ### Fixed
+- fixed prompt for Watchguard FirewareOS not matching the regex when the node is managed and master (@benasse)
 - fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)
 - fixed power consumption included in ArubaOS-CX diffs starting with FL.10.13.xxx. Fixes #3142 (@terratalpi)
 - fixed oxidized-web getting "version not found" when fetching a version from git and no group is defined. Fixes #2222 (@robertcheramy)

--- a/lib/oxidized/model/firewareos.rb
+++ b/lib/oxidized/model/firewareos.rb
@@ -1,7 +1,16 @@
 class FirewareOS < Oxidized::Model
   using Refinements
 
-  prompt /^\[?\w*\]?\w*?(<[\w-]*>)?(#|>)\s*$/
+  # matched prompts:
+  # [FAULT]WG<managed-by-wsm><master>>
+  # WG<managed-by-wsm><master>>
+  # WG<managed-by-wsm>>
+  # [FAULT]WG<non-master>>
+  # [FAULT]WG>
+  # WG>
+
+  prompt /^\[?\w*\]?\w*?(?:<[\w-]+>)*(#|>)\s*$/
+
   comment  '-- '
 
   cmd :all do |cfg|

--- a/spec/model/firewareos_spec.rb
+++ b/spec/model/firewareos_spec.rb
@@ -1,0 +1,25 @@
+require_relative '../spec_helper'
+
+describe 'Model firewareos' do
+  before(:each) do
+    Oxidized.asetus = Asetus.new
+    Oxidized.asetus.cfg.debug = false
+    Oxidized.setup_logger
+
+    Oxidized::Node.any_instance.stubs(:resolve_repo)
+    Oxidized::Node.any_instance.stubs(:resolve_output)
+
+    @node = Oxidized::Node.new(name:  'example.com',
+                               input: 'ssh',
+                               model: 'firewareos')
+  end
+
+  it "matches different prompts" do
+    _('[FAULT]WG<managed-by-wsm><master>>').must_match FirewareOS.prompt
+    _('WG<managed-by-wsm><master>>').must_match FirewareOS.prompt
+    _('WG<managed-by-wsm>>').must_match FirewareOS.prompt
+    _('[FAULT]WG<non-master>>').must_match FirewareOS.prompt
+    _('[FAULT]WG>').must_match FirewareOS.prompt
+    _('WG>').must_match FirewareOS.prompt
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
fix prompt not matching when the node is managed and master

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
