### PR TITLE
no error, if the default config is created

### DIFF
--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -69,8 +69,10 @@ module Oxidized
 
       if asetus.create
         puts "Configuration file created at #{@configfile}. Please edit it."
+      elsif !File.exist?(@configfile)
+        raise NoConfig, "Configuration file #{@configfile} is missing and could not be created."
       else
-        raise NoConfig, "Configuration file #{@configfile} is missing."
+        puts "Configuration file #{@configfile} already exists."
       end
 
       # override if comand line flag given

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -68,13 +68,14 @@ module Oxidized
       end
 
       if asetus.create
-        puts "Configuration file created at #{@configfile}. Please edit it."
+        Oxidized.logger.info "Configuration file created at #{@configfile}. Please edit it."
       elsif !File.exist?(@configfile)
+        Oxidized.logger.error "Configuration file #{@configfile} is missing and could not be created."
         raise NoConfig, "Configuration file #{@configfile} is missing and could not be created."
       else
-        puts "Configuration file #{@configfile} already exists."
+        Oxidized.logger.info "Configuration file #{@configfile} already exists."
       end
-
+      
       # override if comand line flag given
       asetus.cfg.debug = cmd_opts[:debug] if cmd_opts[:debug]
 

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -67,7 +67,11 @@ module Oxidized
         raise InvalidConfig, "Error loading config: #{e.message}"
       end
 
-      raise NoConfig, "edit #{@configfile}" if asetus.create
+      if asetus.create
+        puts "Configuration file created at #{@configfile}. Please edit it."
+      else
+        raise NoConfig, "Configuration file #{@configfile} is missing."
+      end
 
       # override if comand line flag given
       asetus.cfg.debug = cmd_opts[:debug] if cmd_opts[:debug]


### PR DESCRIPTION
## Pre-Request Checklist
- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
If you use saltstack for example, on init oxidized, you will get an error, because it writes to _stderr_, if there is no configfile and if there is none, it creates one. It just tries to create the file, and if it doesn't work, it will write to _stderr_. Otherwise it will inform you about the new config file via _stdout_, and that you should edit it.
