### PR TITLE
Correctly produce config in cmd :secret for ibos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - cnos: show information before config, remove secrets only when told to do so (@robje)
 
 ### Fixed
+- fixed error for ibos when remove_secret is set (@dminuoso)
 - fixed prompt for Watchguard FirewareOS not matching the regex when the node is managed and master (@benasse)
 - fixed prompt for vyos/vyatta to allow logins with non-priviliged accounts. Fixes #3111 (@h-lopez)
 - fixed power consumption included in ArubaOS-CX diffs starting with FL.10.13.xxx. Fixes #3142 (@terratalpi)

--- a/lib/oxidized/model/ibos.rb
+++ b/lib/oxidized/model/ibos.rb
@@ -22,6 +22,7 @@ class IBOS < Oxidized::Model
 
     # radius server 10.1.1.1 secret public
     cfg.gsub! /^radius server (\S+) secret (\S+)(.*)/, 'radius server \\1 secret <hidden> \\3'
+    cfg
   end
 
   cmd 'show version' do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

There's an oversight that does not pass the config back when remove_secret is enabled in IBOS, leading to a crash.

```
~
"10.15.0.3" 18L, 2006B                                                                                                                                             1,1           All
2024-10-16 06:24:52 UTC
undefined method `gsub!' for nil:NilClass

    cfg.gsub! /.*uptime is.*/, ''
       ^^^^^^ [NoMethodError]
--------------------------------------------------
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/model/ibos.rb:28:in `block in <class:IBOS>'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/model/model.rb:134:in `instance_exec'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/model/model.rb:134:in `cmd'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/model/model.rb:172:in `block in get'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/model/model.rb:171:in `each'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/model/model.rb:171:in `get'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/input/cli.rb:14:in `get'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/node.rb:70:in `run_input'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/node.rb:47:in `block in run'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/node.rb:41:in `each'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/node.rb:41:in `run'
/nix/store/dd3bcw4i4mnr33vr0csiksbd6k7yzyvh-ruby3.1-oxidized-0.29.1/lib/ruby/gems/3.1.0/gems/oxidized-0.29.1/lib/oxidized/job.rb:10:in `block in initialize'
```