### PR TITLE
Update net-ssh to 7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - unit tests framework for models with ssh input (@robertcheramy)
 - container-image: install x25519 gem package to support more ssh kex. Fixes #3070 (@benasse)
 - os6: Added support to Dell EMC Networking OS6 (@anubisg1)
+- Update net-ssh to 7.3 to enable support for aes(128|256)gcm. Fixes #3168 (@jacobw)
 
 ### Changed
 - h3c: change prompt to expect either angle (user-view) or square (system-view) brackets (@nl987)

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-ftp',              '~> 0.2'
   s.add_dependency 'net-http-digest_auth', '~> 1.4'
   s.add_dependency 'net-scp',              '~> 4.0'
-  s.add_dependency 'net-ssh',              '~> 7.1'
+  s.add_dependency 'net-ssh',              '~> 7.3'
   s.add_dependency 'net-telnet',           '~> 0.2'
   s.add_dependency 'psych',                '~> 5.0'
   s.add_dependency 'rugged',               '~> 1.6'


### PR DESCRIPTION
Enable support for aes(128|256)gcm.
Fixes #3168.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [-] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Update net-ssh to 7.3.
Enable support for aes(128|256)gcm.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Fixes #3168.