### PR TITLE
Remove constantly updating value from custom SNMP OID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Updated slackdiff.rb to use new files.getUploadURLExternal slack file upload API instead of deprecated files.upload (@varesa)
 - Updated source/output files to reference a Source/Outputb module to avoid namespace duplication (@laf, @robertcheramy)
 - ios: Hide WLAN PSK, AP profile dot1x password, AP profile mgmtuser password/secret and radius COA server-key (@devon-mar)
+- ios: remove values from custom SNMP OID's, set by an EEM script (@syn-bit)
 
 ### Fixed
 - fixed error for ibos when remove_secret is set (@dminuoso)

--- a/examples/device-simulation/yaml/iosxe_C9200L-24P-4G_17.09.04a.yaml
+++ b/examples/device-simulation/yaml/iosxe_C9200L-24P-4G_17.09.04a.yaml
@@ -281,6 +281,10 @@ commands:
     snmp-server host 10.42.0.35 vrf Mgmt-vrf informs version 2c AAAAAAAAAABBBBBBBBBB  tty vtp
     snmp-server host 10.42.0.36 vrf Mgmt-vrf informs version 3 auth oxidized  bfd bridge transceiver
     !
+    snmp mib expression owner nat name 1
+      expression 42
+    snmp mib expression owner oxidized name rocks
+      expression 42
     !
     !
     !
@@ -485,6 +489,10 @@ oxidized_output: |
   snmp-server host 10.42.0.35 vrf Mgmt-vrf informs version 2c AAAAAAAAAABBBBBBBBBB  tty vtp
   snmp-server host 10.42.0.36 vrf Mgmt-vrf informs version 3 auth oxidized  bfd bridge transceiver
   !
+  snmp mib expression owner nat name 1
+    expression <value removed>
+  snmp mib expression owner oxidized name rocks
+    expression <value removed>
   !
   !
   !

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -124,6 +124,8 @@ class IOS < Oxidized::Model
       cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]*\n*(
                     (?: [^\n]*\n*)*
                     tunnel mpls traffic-eng auto-bw)/mx, '\1'
+      # get rid of values of custom SNMP OID's
+      cfg.gsub! /^(\s+expression) \d+$/, '\\1 <value removed>'
       cfg
     end
   end


### PR DESCRIPTION
Adding a custom SNMP OID means having a different "expression <value>" line each time the config is pulled. Add a rule to remove the expression value.

EEM code to generate the custom SNMP OID is:

event manager applet TotalNatTranslations
 event timer watchdog time 300 maxrun 60
 action 010 cli command "enable"
 action 020 cli command "configure terminal"
 action 030 cli command "do-exec show ip nat translations total"
 action 040 regexp "^.+\s([0-9]+)" "$_cli_result" match total_translations
 action 050 cli command "snmp mib expression owner nat name 1"
 action 060 if $_regexp_result eq "1"
 action 070  cli command "expression $total_translations"
 action 080 else
 action 090  cli command "expression 0"
 action 100  cli command "exit"
 action 110 end

The resulting configuration block is:

snmp mib expression owner nat name 1
  description Total active translations
  value type integer32
  expression 1234
!

After this commit the resulting configuration block is:

snmp mib expression owner nat name 1
  description Total active translations
  value type integer32
  expression <value removed>
!

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
