### PR TITLE
Remove secrets from IOS-XE WLCs (C9800)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - cnos: show information before config, remove secrets only when told to do so (@robje)
 - Updated slackdiff.rb to use new files.getUploadURLExternal slack file upload API instead of deprecated files.upload (@varesa)
 - Updated source/output files to reference a Source/Outputb module to avoid namespace duplication (@laf, @robertcheramy)
+- ios: Hide WLAN PSK, AP profile dot1x password, AP profile mgmtuser password/secret and radius COA server-key (@devon-mar)
 
 ### Fixed
 - fixed error for ibos when remove_secret is set (@dminuoso)

--- a/examples/device-simulation/yaml/iosxe_C9800-L-F-K9_17.06.05.yaml
+++ b/examples/device-simulation/yaml/iosxe_C9800-L-F-K9_17.06.05.yaml
@@ -233,6 +233,18 @@ commands:
     ^C
     !
     ! ...
+    wlan test 1 test
+     security wpa psk set-key ascii 0 WLANSECR3T
+    wlan test-spaces 2 test-spaces
+     security wpa psk set-key ascii 0 WLAN SECR3T
+    wlan hex 1000 hex
+     security wpa psk set-key hex 0 7df35f90c92ecff2a803e79577b85e978edc0a76404f6cfb534df8d9f9f67beb
+    ap profile default-ap-profile
+     dot1x username dot1x-username password 0 DOT1XPASSW0RD
+     mgmtuser username apmgmtuser password 0 MGMTPASSW0RD secret 0 MGMTSECR3T
+    ap profile \"spaces profile\"
+     dot1x username dot1x-username password 0 DOT1X PASSW0RD
+     mgmtuser username username password 0 MGMT PASSW0RD secret 0 MGMT SECR3T
     netconf-yang
     end
     
@@ -388,6 +400,18 @@ oxidized_output: |
   ^C
   !
   ! ...
+  wlan test 1 test
+   security wpa psk set-key ascii 0 WLANSECR3T
+  wlan test-spaces 2 test-spaces
+   security wpa psk set-key ascii 0 WLAN SECR3T
+  wlan hex 1000 hex
+   security wpa psk set-key hex 0 7df35f90c92ecff2a803e79577b85e978edc0a76404f6cfb534df8d9f9f67beb
+  ap profile default-ap-profile
+   dot1x username dot1x-username password 0 DOT1XPASSW0RD
+   mgmtuser username apmgmtuser password 0 MGMTPASSW0RD secret 0 MGMTSECR3T
+  ap profile \"spaces profile\"
+   dot1x username dot1x-username password 0 DOT1X PASSW0RD
+   mgmtuser username username password 0 MGMT PASSW0RD secret 0 MGMT SECR3T
   netconf-yang
   end\n
 # End of YAML file

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -44,6 +44,10 @@ class IOS < Oxidized::Model
     cfg.gsub! /^( +key-string) .+/, '\\1 <secret hidden>'
     cfg.gsub! /^((tacacs|radius) server [^\n]+\n( +[^\n]+\n)* +key) [^\n]+$/m, '\1 <secret hidden>'
     cfg.gsub! /^( +ppp (chap|pap) password \d) .+/, '\\1 <secret hidden>'
+    cfg.gsub! /^( +security wpa psk set-key (?:ascii|hex) \d) (.*)$/, '\\1 <secret hidden>'
+    cfg.gsub! /^( +dot1x username \S+ password \d) (.*)$/, '\\1 <secret hidden>'
+    cfg.gsub! /^( +mgmtuser username \S+ password \d) (.*) (secret \d) (.*)$/, '\\1 <secret hidden> \\3 <secret hidden>'
+    cfg.gsub! /^( +client \S+ server-key \d) (.*)$/, '\\1 <secret hidden>'
     cfg
   end
 

--- a/spec/model/ios_spec.rb
+++ b/spec/model/ios_spec.rb
@@ -45,4 +45,25 @@ describe 'model/IOS' do
     _(result.to_cfg).wont_match(/public/)
     _(result.to_cfg).wont_match(/AAAAAAAAAABBBBBBBBBB/)
   end
+
+  it 'removes secrets from IOS-XE WLCs' do
+    Oxidized.config.vars.remove_secret = true
+    mockmodel = MockSsh.new('examples/device-simulation/yaml/iosxe_C9800-L-F-K9_17.06.05.yaml')
+    Net::SSH.stubs(:start).returns mockmodel
+
+    status, result = @node.run
+
+    _(status).must_equal :success
+    _(result.to_cfg).wont_match(/SECRET_REMOVED/)
+    _(result.to_cfg).wont_match(/REMOVED_SECRET/)
+    _(result.to_cfg).wont_match(/WLANSECR3T/)
+    _(result.to_cfg).wont_match(/WLAN SECR3T/)
+    _(result.to_cfg).wont_match(/7df35f90c92ecff2a803e79577b85e978edc0a76404f6cfb534df8d9f9f67beb/)
+    _(result.to_cfg).wont_match(/DOT1XPASSW0RD/)
+    _(result.to_cfg).wont_match(/MGMTPASSW0RD/)
+    _(result.to_cfg).wont_match(/MGMTSECR3T/)
+    _(result.to_cfg).wont_match(/DOT1X PASSW0RD/)
+    _(result.to_cfg).wont_match(/MGMT PASSW0RD/)
+    _(result.to_cfg).wont_match(/MGMT SECR3T/)
+  end
 end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
This PR modifies the IOS model to hide secrets from IOS-XE WLCs (C9800). The secrets hidden are:
- WLAN PSK
- AP profile dot1x password
- AP profile mgmtuser password and secret
- RADIUS COA secret
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
