### PR TITLE
Fix regex on Aruba 6400 switches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ios: removes secrets when config has multiple snmp-server host lines. Fixes #3239 (@robertcheramy)
 - ios: fixed device specs on ASR900 Series. Fixes #3297 (@robertcheramy, @roshnaraman)
 - netgear: prompt for gs752tpp. Fixes #3287 (@robertcheramy)
+- aoscx: fixed regex for 6400 switches to hide temperature and power (@steveneppler)
 
 ## [0.30.1 – 2024-04-12]
 

--- a/examples/device-simulation/cmdsets/aoscx
+++ b/examples/device-simulation/cmdsets/aoscx
@@ -5,6 +5,5 @@ show module
 show interface transceiver
 show system | exclude "Up Time" | exclude "CPU" | exclude "Memory" | exclude "Pkts .x" | exclude "Lowest" | exclude "Missed"
 show running-config
-# commands beyond the oxidized model
 show system
 exit

--- a/examples/device-simulation/yaml/6400s_10.10.x.yaml
+++ b/examples/device-simulation/yaml/6400s_10.10.x.yaml
@@ -1,0 +1,1171 @@
+---
+init_prompt: |-
+
+  Last login: 2024-11-08 20:52:56 from 1.2.3.4
+  User \"user\" has logged in 740 times in the past 30 days
+  Switch-cx#\x20
+commands:
+  no page: |-
+    no page
+    Switch-cx#\x20
+  show version: |-
+    show version
+    -----------------------------------------------------------------------------
+    ArubaOS-CX
+    (c) Copyright 2017-2023 Hewlett Packard Enterprise Development LP
+    -----------------------------------------------------------------------------
+    Version      : FL.10.10.1100                                                \x20
+    Build Date   : 2023-12-11 18:38:23 UTC                                      \x20
+    Build ID     : ArubaOS-CX:FL.10.10.1100:b4b52a6a46ff:202312111821           \x20
+    Build SHA    : b4b52a6a46ffe674f326481629c70082b24aeb95                     \x20
+    Active Image : secondary                    \x20
+
+    Service OS Version : FL.01.11.0001                \x20
+    BIOS Version       : FL.01.0002                   \x20
+    Switch-cx#\x20
+  show environment: |-
+    show environment
+    show environment fan
+
+    Fan tray information
+    ------------------------------------------------------------------------------
+    Name  Description                           Status        Serial Number  Fans
+    ------------------------------------------------------------------------------
+    1/1   R0X32A Aruba 6400 Fan Tray            ready         SG0AAAA00A     4 \x20
+    1/2   R0X32A Aruba 6400 Fan Tray            ready         SG0AAAA0A0     4 \x20
+    1/3   R0X32A Aruba 6400 Fan Tray            ready         SG0AAAA0AA     4 \x20
+    1/4   R0X32A Aruba 6400 Fan Tray            ready         SG0AAAA0AA     4 \x20
+
+    Fan information
+    ------------------------------------------------------------------------------
+    Location-      Product  Serial Number  Speed   Direction      Status  RPM
+    Mbr/Slot/Fan   Name
+    ------------------------------------------------------------------------------
+    Tray-1/1/1     N/A      N/A            slow    front-to-back  ok      3983  \x20
+    Tray-1/1/2     N/A      N/A            slow    front-to-back  ok      4032  \x20
+    Tray-1/1/3     N/A      N/A            slow    front-to-back  ok      4032  \x20
+    Tray-1/1/4     N/A      N/A            slow    front-to-back  ok      4037  \x20
+    Tray-1/2/1     N/A      N/A            slow    front-to-back  ok      4012  \x20
+    Tray-1/2/2     N/A      N/A            slow    front-to-back  ok      4024  \x20
+    Tray-1/2/3     N/A      N/A            slow    front-to-back  ok      4032  \x20
+    Tray-1/2/4     N/A      N/A            slow    front-to-back  ok      3996  \x20
+    Tray-1/3/1     N/A      N/A            slow    front-to-back  ok      3951  \x20
+    Tray-1/3/2     N/A      N/A            slow    front-to-back  ok      3947  \x20
+    Tray-1/3/3     N/A      N/A            slow    front-to-back  ok      4041  \x20
+    Tray-1/3/4     N/A      N/A            slow    front-to-back  ok      3975  \x20
+    Tray-1/4/1     N/A      N/A            slow    front-to-back  ok      3963  \x20
+    Tray-1/4/2     N/A      N/A            slow    front-to-back  ok      4016  \x20
+    Tray-1/4/3     N/A      N/A            slow    front-to-back  ok      3987  \x20
+    Tray-1/4/4     N/A      N/A            slow    front-to-back  ok      4020  \x20
+
+
+
+    show environment led
+    Mbr/Name       State        Status   \x20
+    ----------------------------------
+    1/locator      off          ok       \x20
+
+
+    show environment power-allocation
+    \x20    Product                                                Power
+    Name Number  Subsystem-Type       Request Priority Granted  Usage
+    -------------------------------------------------------------------
+    1    R0X25A  base-chassis-module  N/A     N/A      N/A      614 W
+    1/1  R0X25A  fabric-card-module   158     128      granted  61 W
+    1/2  R0X25A  fabric-card-module   158     128      granted  61 W
+    1/1  R0X32A  fan-tray-module      200     128      granted  0 W
+    1/2  R0X32A  fan-tray-module      200     128      granted  0 W
+    1/3  R0X32A  fan-tray-module      200     128      granted  0 W
+    1/4  R0X32A  fan-tray-module      200     128      granted  0 W
+    1/3  R0X45A  line-card-module     352     128      granted  124 W
+    1/4  R0X44A  line-card-module     424     128      granted  146 W
+    1/5  N/A     line-card-module     0       128      NA       0 W
+    1/6  R0X44A  line-card-module     424     128      granted  103 W
+    1/7  N/A     line-card-module     0       128      NA       0 W
+    1/8  N/A     line-card-module     0       128      NA       0 W
+    1/9  N/A     line-card-module     0       128      NA       0 W
+    1/10 N/A     line-card-module     0       128      NA       0 W
+    1/11 N/A     line-card-module     0       128      NA       0 W
+    1/12 R0X39B  line-card-module     121     128      granted  51 W
+    1/1  R0X31A  management-module    39      128      granted  19 W
+    1/2  R0X31A  management-module    39      128      granted  21 W
+
+    -------------------------------------------------------------------
+    Total Requested                   2515 W
+    Total Power Granted to Subsystems 2515 W
+    Power Granted for PoE             2813 W
+    Total Power Granted               5328 W
+    Maximum PSU Power Available       5328 W
+    Power Remaining                      0 W
+    -------------------------------------------------------------------
+
+
+    show environment power-redundancy
+    Configured  Operational
+    Redundancy  Redundancy
+    -------------------------
+    none        none
+
+
+    show environment power-supply
+    ------------------------------------------------------------------------------
+    \x20        Product  Serial            PSU            Input   Voltage    Wattage
+    Mbr/PSU  Number   Number            Status         Type    Range      Maximum
+    ------------------------------------------------------------------------------
+    1/1      R0X35A   CN0AAAA0AA        OK             AC      110V-240V  1800
+    1/2      R0X35A   CN0AAAA00A        OK             AC      110V-240V  1764
+    1/3      R0X35A   CN0AAAA0AA        OK             AC      110V-240V  1764
+    1/4      N/A      N/A               Absent         --      --         0
+
+
+
+    show environment temperature
+    Temperature information
+    ------------------------------------------------------------------------------
+    \x20                                                    Current
+    Mbr/Slot-Sensor                 Module Type        temperature  Status
+    ------------------------------------------------------------------------------
+    1/3-Board-front                 line-card-module     30.50 C    normal
+    1/3-Board-rear                  line-card-module     40.50 C    normal
+    1/3-CPU                         line-card-module     40.88 C    normal
+    1/3-DDR                         line-card-module     33.38 C    normal
+    1/3-Exhaust-left                line-card-module     34.00 C    normal
+    1/3-Exhaust-right               line-card-module     35.00 C    normal
+    1/3-IBC                         line-card-module     29.00 C    normal
+    1/3-Switch-ASIC                 line-card-module     51.31 C    normal
+    1/3-Switch-ASIC-Internal        line-card-module     54.25 C    normal
+    1/4-Board-front                 line-card-module     34.00 C    normal
+    1/4-Board-rear                  line-card-module     42.00 C    normal
+    1/4-CPU                         line-card-module     45.44 C    normal
+    1/4-DDR                         line-card-module     37.75 C    normal
+    1/4-Exhaust-left                line-card-module     35.00 C    normal
+    1/4-Exhaust-right               line-card-module     37.00 C    normal
+    1/4-IBC                         line-card-module     30.00 C    normal
+    1/4-Switch-ASIC                 line-card-module     53.12 C    normal
+    1/4-Switch-ASIC-Internal        line-card-module     54.50 C    normal
+    1/6-Board-front                 line-card-module     28.00 C    normal
+    1/6-Board-rear                  line-card-module     38.50 C    normal
+    1/6-CPU                         line-card-module     40.62 C    normal
+    1/6-DDR                         line-card-module     32.31 C    normal
+    1/6-Exhaust-left                line-card-module     32.00 C    normal
+    1/6-Exhaust-right               line-card-module     33.00 C    normal
+    1/6-IBC                         line-card-module     27.50 C    normal
+    1/6-Switch-ASIC                 line-card-module     48.94 C    normal
+    1/6-Switch-ASIC-Internal        line-card-module     52.25 C    normal
+    1/12-Board-front                line-card-module     27.00 C    normal
+    1/12-Board-rear                 line-card-module     33.50 C    normal
+    1/12-CPU                        line-card-module     38.25 C    normal
+    1/12-DDR                        line-card-module     33.56 C    normal
+    1/12-Exhaust-left               line-card-module     27.50 C    normal
+    1/12-Exhaust-right              line-card-module     27.00 C    normal
+    1/12-IBC                        line-card-module     29.00 C    normal
+    1/12-PHY-01-08                  line-card-module     42.00 C    normal
+    1/12-PHY-09-16                  line-card-module     38.00 C    normal
+    1/12-PHY-17-24                  line-card-module     37.00 C    normal
+    1/12-PHY-25-32                  line-card-module     37.00 C    normal
+    1/12-PHY-33-40                  line-card-module     40.00 C    normal
+    1/12-PHY-41-48                  line-card-module     40.00 C    normal
+    1/12-Switch-ASIC                line-card-module     39.75 C    normal
+    1/12-Switch-ASIC-Internal       line-card-module     39.50 C    normal
+
+    1/1-Board-Corner                management-module    26.62 C    normal
+    1/1-CPU                         management-module    40.44 C    normal
+    1/1-DDR                         management-module    29.50 C    normal
+    1/1-Exhaust-Air                 management-module    30.69 C    normal
+    1/1-Exhaust-board               management-module    30.44 C    normal
+    1/1-IBC                         management-module    32.00 C    normal
+    1/1-Inlet-Air                   management-module    20.50 C    normal
+    1/2-Board-Corner                management-module    26.50 C    normal
+    1/2-CPU                         management-module    37.81 C    normal
+    1/2-DDR                         management-module    29.50 C    normal
+    1/2-Exhaust-Air                 management-module    31.06 C    normal
+    1/2-Exhaust-board               management-module    30.12 C    normal
+    1/2-IBC                         management-module    33.12 C    normal
+    1/2-Inlet-Air                   management-module    21.00 C    normal
+
+    1-ASIC-DC-board                 chassis              31.81 C    normal
+    1-Board-NW                      chassis              33.06 C    normal
+    1-Board-W                       chassis              31.75 C    normal
+    1-DC-DC                         chassis              31.62 C    normal
+    1-Fabric-ASIC-1                 chassis              54.62 C    normal
+    1-Fabric-ASIC-2                 chassis              49.25 C    normal
+    1-Fabric-ASIC-Internal-1        chassis              52.88 C    normal
+    1-Fabric-ASIC-Internal-2        chassis              48.88 C    normal
+    1-IBC                           chassis              36.25 C    normal
+    1-PCIE-Management               chassis              51.94 C    normal
+    1-PCIE-Management-2             chassis              28.12 C    normal
+
+    Switch-cx#\x20
+  show module: |-
+    show module
+
+    Management Modules
+    ==================
+
+    \x20    Product                                        Serial
+    Name Number  Description                            Number     Status
+    ---- ------- -------------------------------------- ---------- ----------------
+    1/1  R0X31A  6400 Management Module                 SG0AAAA00A Active (local)
+    1/2  R0X31A  6400 Management Module                 SG00AAA00A Standby\x20
+
+
+    Line Modules
+    ============
+
+    \x20    Product                                        Serial
+    Name Number  Description                            Number     Status
+    ---- ------- -------------------------------------- ---------- ----------------
+    1/3  R0X45A  6400 12p 40G/100G QSFP28 Mod           SG00AAA000 Ready
+    1/4  R0X44A  6400 48p 10G/25G SFP28 Mod             SG00AAA000 Ready
+    1/6  R0X44A  6400 48p 10G/25G SFP28 Mod             SG00AAA00A Ready
+    1/12 R0X39B  6400 48p 1GbE CL4 PoE 4SFP56 Mod       SG00AA000A Ready
+
+
+    Switch-cx#\x20
+  show interface transceiver: |-
+    show interface transceiver
+    ------------------------------------------------------------------
+    Port      Type           Product      Serial          Part       \x20
+    \x20                        Number       Number          Number     \x20
+    ------------------------------------------------------------------
+    1/3/1     100G-DAC5      R0Z26A       CN00AAA00A      8121-1696  \x20
+    1/3/2     40G-LR4        JH232A       CN00AAA00A      1990-4676  \x20
+    1/3/3     40G-LR4        JH232A       CN00AAA00A      1990-4676  \x20
+    1/3/4     40G-LR4        JH232A       C0000000000     1990-4556  \x20
+    1/3/10    40G-LR4        JH232A       C0000000000     1990-4556  \x20
+    1/3/11    40G-BiDi       JL308A       MY00AA0AAA      1990-4679  \x20
+    1/3/12    100G-DAC5      R0Z26A       CN00AAA00A      8121-1696  \x20
+    1/4/7     10G-SR         J9150D       CN00AAA0A0      1990-4634  \x20
+    1/4/8     10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+    1/4/9     10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+    1/4/10    1G-SX          J4858C       PFA00A0         1990-3657  \x20
+    1/4/20    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/21    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/22    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/23    10G-LR         J9151D       C0000000000     1990-3883  \x20
+    1/4/24    10G-LR         J9151D       C0000000000     1990-3883  \x20
+    1/4/25    1G-SX          J4858D       MY00AA0AAA      1990-4395  \x20
+    1/4/26    10G-SR         J9150D       CN00AAA0AA      1990-4635  \x20
+    1/4/27    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/28    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/29    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/30    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/31    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/32    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+    1/4/33    10G-LR         J9151D       C0000000000     1990-3883  \x20
+    1/4/34    10G-LR         J9151D       C0000000000     1990-3883  \x20
+    1/4/35    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/36    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+    1/4/37    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/38    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/39    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/40    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/41    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/42    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+    1/4/43    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+    1/4/44    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/45    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+    1/4/46    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+    1/4/47    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+    1/4/48    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+    1/6/37    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+    1/6/38    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+    1/6/39    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+    1/6/40    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+    1/6/44    1G-LX          J4859C       CN00AAA0AA      1990-3677  \x20
+    1/6/47    1G-LX          J4859C       CN00AAA0AA      1990-4116  \x20
+    1/6/48    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+
+    Switch-cx#\x20
+  show system | exclude "Up Time" | exclude "CPU" | exclude "Memory" | exclude "Pkts .x" | exclude "Lowest" | exclude "Missed": |-
+    show system | exclude \"Up Time\" | exclude \"CPU\" | exclude \"Memor\rry\" | exclude \"Pkts .x\" | exclude \"Lowest\" | exclude \"Missed\"
+    Hostname               : Switch-cx              \x20
+    System Description     : FL.10.10.1100                \x20
+    System Contact         : SNMP Description
+    System Location        : SNMP Location                \x20
+
+    Vendor                 : Aruba                        \x20
+    Product Name           : R0X25A 6410 Chassis                 \x20
+    Chassis Serial Nbr     : SG0AAA0000                   \x20
+    Base MAC Address       : 100f00-000d00                \x20
+    ArubaOS-CX Version     : FL.10.10.1100                \x20
+
+    Time Zone              : America/Denver               \x20
+
+    Switch-cx#\x20
+  show running-config: |-
+    show running-config
+    Current configuration:
+    !
+    !Version ArubaOS-CX FL.10.10.1100
+    !export-password: default
+    hostname Switch-cx
+    alias  diff        checkpoint diff startup-config running-config \x20
+    alias  logout      exit \x20
+    user admin group administrators password ciphertext AQEcvdLHmJIRYNQhHzWsdg5r83vIUQyfNDReWcM3Kz7+o17kXuAAAMB93kW8Y29thkGl9AIkfApt/VowNDcU2BAaNmcgvS63go2CoMFW9KcN0AE+f/nKQrGRjY2LPqkf4VxntPXE5xKOAT9p8KbhO3gDkywU3rSvo1+mrqoeLQ8tCNHVJwztFTK
+    user user group administrators password ciphertext AQEfgTZ27jH5bp3e4uMv1qTGFOIYZr1vKzUDpSKdxgJyf7QrZgAAAQz48hyKMVG2YtkJ3axzQ0wjmVb38dKsWJa6RPACmZUfA7X93QoK7shVzBwGdnXBiJku73vyFsAoQ0SWlDq9xhpmFZ6pv83YJkQjVWOswRxNRMhzoeAOK6PTIyfGwqOJuZz3SQ9bP4LTCJ
+    module 1/3 product-number r0x45a
+    module 1/4 product-number r0x44a
+    module 1/6 product-number r0x44a
+    module 1/12 product-number r0x39b
+    clock timezone america/denver
+    logging filter no_restd
+    \x20   enable
+    \x20    20 deny event-id 4602,4605,4608,4655,4657
+    profile default
+    vrf KA
+    ntp server ntp1.example.com
+    ntp server ntp2.example.com
+    ntp server ntp3.example.com
+    ntp server pool.ntp.org minpoll 4 maxpoll 4 iburst
+    ntp enable
+    cli-session
+    \x20   timeout 1440
+    !
+    !
+    !
+    !
+    !
+    !
+    aruba-central
+    \x20   disable
+    logging 10.1.2.3
+    logging facility local0
+    ssh server vrf default
+    ssh server vrf mgmt
+    ssh key-exchange-algorithms curve25519-sha256 curve25519-sha256@libssh.org ecdh-sha2-nistp256 ecdh-sha2-nistp384 ecdh-sha2-nistp521 diffie-hellman-group-exchange-sha256 diffie-hellman-group16-sha512 diffie-hellman-group18-sha512 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1
+    vlan 1
+    vlan 2
+    \x20   name VLAN name
+    vlan 7
+    \x20   name VLAN name
+    \x20   vsx-sync
+    vlan 206
+    \x20   name VLAN name
+    \x20   vsx-sync
+    vlan 207
+    \x20   name VLAN name
+    \x20   vsx-sync
+    vlan 208
+    \x20   name VLAN name
+    \x20   vsx-sync
+    vlan 209
+    \x20   name VLAN name
+    \x20   vsx-sync
+    vlan 989
+    \x20   name VLAN name
+    \x20   vsx-sync
+    vlan 994
+    \x20   name VLAN name
+    \x20   vsx-sync
+    vlan 1630
+    \x20   name VLAN-name
+    \x20   vsx-sync
+    vlan 1640
+    \x20   name VLAN-name
+    \x20   vsx-sync
+    vlan 1650
+    \x20   name VLAN-name
+    \x20   vsx-sync
+    spanning-tree
+    spanning-tree priority 5
+    interface mgmt
+    \x20   no shutdown
+    \x20   ip dhcp
+    qos trust dscp
+    interface lag 7 multi-chassis static
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan trunk native 1
+    \x20   vlan trunk allowed 988,999
+    interface lag 8 multi-chassis static
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan trunk native 2
+    \x20   vlan trunk allowed all
+    interface lag 9 multi-chassis static
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan trunk native 1
+    \x20   vlan trunk allowed 1,2
+    interface lag 10 multi-chassis static
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan trunk native 2
+    \x20   vlan trunk allowed 1640
+    interface lag 247 multi-chassis
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan trunk native 2000
+    \x20   vlan trunk allowed all
+    \x20   lacp mode active
+    interface 1/3/1
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   lag 247
+    interface 1/3/2
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 247
+    interface 1/3/3
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 247
+    interface 1/3/4
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 247
+    interface 1/3/5
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/3/6
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/3/7
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/3/8
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/3/9
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/3/10
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 249
+    interface 1/3/11
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 247
+    interface 1/3/12
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   lag 8
+    interface 1/4/1
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   no routing
+    \x20   vlan trunk native 2
+    \x20   vlan trunk allowed 206,1640
+    interface 1/4/2
+    \x20   shutdown
+    \x20   mtu 9198
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/3
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/4
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/5
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/6
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/7
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   lag 7
+    interface 1/4/8
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   lag 8
+    interface 1/4/9
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   lag 9
+    interface 1/4/10
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   speed 1000-full
+    \x20   lag 10
+    interface 1/4/11
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/12
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/13
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/14
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/15
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/16
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/17
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/18
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/19
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/4/20
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 20
+    interface 1/4/21
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 21
+    interface 1/4/22
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 22
+    interface 1/4/23
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 23
+    interface 1/4/24
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 24
+    interface 1/4/25
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 25
+    interface 1/4/26
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 26
+    interface 1/4/27
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 27
+    interface 1/4/28
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 28
+    interface 1/4/29
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 29
+    interface 1/4/30
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 30
+    interface 1/4/31
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 31
+    interface 1/4/32
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 32
+    interface 1/4/33
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 33
+    interface 1/4/34
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 34
+    interface 1/4/35
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 35
+    interface 1/4/36
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 36
+    interface 1/4/37
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 37
+    interface 1/4/38
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 38
+    interface 1/4/39
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 39
+    interface 1/4/40
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 40
+    interface 1/4/41
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 41
+    interface 1/4/42
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 42
+    interface 1/4/43
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 43
+    interface 1/4/44
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 44
+    interface 1/4/45
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 45
+    interface 1/4/46
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 46
+    interface 1/4/47
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 47
+    interface 1/4/48
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/1
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/2
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/3
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/4
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/5
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/6
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/7
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/8
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/9
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/10
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/11
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/12
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/13
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/14
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/15
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/16
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/17
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/18
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/19
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/20
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/21
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/22
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/23
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/24
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/25
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/26
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/27
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/28
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/29
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/30
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/31
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/32
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/33
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/34
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/35
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/36
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/37
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 137
+    interface 1/6/38
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 138
+    interface 1/6/39
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 139
+    interface 1/6/40
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 140
+    interface 1/6/41
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/42
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/43
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/44
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   speed 1000-full
+    \x20   mtu 9198
+    \x20   no routing
+    \x20   vlan access 997
+    \x20   spanning-tree bpdu-filter
+    interface 1/6/45
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/46
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/6/47
+    \x20   description Description for interface)
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan trunk native 2000
+    \x20   vlan trunk allowed 2000
+    interface 1/6/48
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   lag 148
+    interface 1/12/1
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   mtu 9198
+    \x20   routing
+    \x20   vrf attach KA
+    \x20   ip address 192.168.0.0/31
+    interface 1/12/2
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 2
+    interface 1/12/3
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan trunk native 1
+    \x20   vlan trunk allowed 1,2,206
+    interface 1/12/4
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    \x20   spanning-tree port-type admin-edge
+    \x20   spanning-tree tcn-guard
+    interface 1/12/5
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/6
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/7
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/8
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/9
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/10
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/11
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/12
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/13
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/14
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/15
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/16
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/17
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/18
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/19
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/20
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/21
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/22
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/23
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/24
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/25
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/26
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/27
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/28
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/29
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/30
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/31
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/32
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/33
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/34
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/35
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/36
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/37
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/38
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/39
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/40
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/41
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/42
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/43
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/44
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/45
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/46
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/47
+    \x20   description Description for interface
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/48
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 2
+    interface 1/12/49
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/50
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/51
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface 1/12/52
+    \x20   no shutdown
+    \x20   no routing
+    \x20   vlan access 1
+    interface vlan 1
+    \x20   no ip dhcp
+    interface vlan 2
+    \x20   ip address 10.0.0.113/21
+    snmp-server vrf default
+    snmp-server trap-source interface vlan2 vrf default
+    snmp-server system-location SNMP Location
+    snmp-server system-contact SNMP Contact Information
+    snmp-server community readonlycom
+    snmp-server community rwsnmpcom
+    \x20   access-level rw
+    snmp-server host 10.7.32.31 trap version v2c community trapcomm\x20
+    snmp-server host 10.7.32.67 trap version v2c community trapcomm\x20
+    vsx
+    \x20   system-mac 02:02:00:00:02:00
+    \x20   inter-switch-link lag 256
+    \x20   role primary
+    \x20   keepalive peer 192.168.0.1 source 192.168.0.0 vrf KA
+    \x20   vsx-sync vsx-global
+    ip route 0.0.0.0/0 10.0.0.1
+    ip route 10.0.0.0/8 10.0.0.1
+    mirror session 1
+    \x20   destination tunnel 10.0.2.1 source 10.0.0.113
+    \x20   source interface lag45 rx
+    ip dns server-address 10.0.0.2
+    !
+    !
+    !
+    !
+    !
+    https-server vrf default
+    https-server vrf mgmt
+    nae-script configuration_change_email false ...
+    nae-script fault_finder_monitor false ...
+    Switch-cx#\x20
+  # commands beyond the oxidized model: |-
+    # commands beyond the oxidized model
+    Switch-cx#\x20
+  show system: |-
+    show system
+    Hostname               : Switch-cx              \x20
+    System Description     : FL.10.10.1100                \x20
+    System Contact         : SNMP Contact Info
+    System Location        : SNMP Location Info           \x20
+
+    Vendor                 : Aruba                        \x20
+    Product Name           : R0X25A 6410 Chassis                 \x20
+    Chassis Serial Nbr     : SG0AAA0000                   \x20
+    Base MAC Address       : 100b00-000d00                \x20
+    ArubaOS-CX Version     : FL.10.10.1100                \x20
+
+    Time Zone              : America/Denver               \x20
+
+    Up Time                : 45 weeks, 4 days, 1 hour, 11 minutes                       \x20
+    CPU Util (%)           : 30                           \x20
+    CPU Util (% avg 1 min) : 24                           \x20
+    CPU Util (% avg 5 min) : 25                           \x20
+    Memory Usage (%)       : 22                           \x20
+    Switch-cx#\x20
+  exit: |-
+    exit
+oxidized_output: |
+  !! needs to be written by hand or copy & paste from model output

--- a/examples/device-simulation/yaml/aoscx_R0X25A-6410_FL.10.10.1100.yaml
+++ b/examples/device-simulation/yaml/aoscx_R0X25A-6410_FL.10.10.1100.yaml
@@ -302,8 +302,8 @@ commands:
     hostname Switch-cx
     alias  diff        checkpoint diff startup-config running-config \x20
     alias  logout      exit \x20
-    user admin group administrators password ciphertext AQEcvdLHmJIRYNQhHzWsdg5r83vIUQyfNDReWcM3Kz7+o17kXuAAAMB93kW8Y29thkGl9AIkfApt/VowNDcU2BAaNmcgvS63go2CoMFW9KcN0AE+f/nKQrGRjY2LPqkf4VxntPXE5xKOAT9p8KbhO3gDkywU3rSvo1+mrqoeLQ8tCNHVJwztFTK
-    user user group administrators password ciphertext AQEfgTZ27jH5bp3e4uMv1qTGFOIYZr1vKzUDpSKdxgJyf7QrZgAAAQz48hyKMVG2YtkJ3axzQ0wjmVb38dKsWJa6RPACmZUfA7X93QoK7shVzBwGdnXBiJku73vyFsAoQ0SWlDq9xhpmFZ6pv83YJkQjVWOswRxNRMhzoeAOK6PTIyfGwqOJuZz3SQ9bP4LTCJ
+    user admin group administrators password ciphertext AQEcvdLHmJIRAAAAAAAAABBBBBBBBCCCCCCCC29thkGl9AIkfApt/VowNDcU2BAaNmcgvS63g2LPqkf4VxntPXE5xKOAT9p8KbhO3gDkywU3rSvo1+mrqoeLQ8tCNHVJwztFTK
+    user user group administrators password ciphertext AQEfgTZ27jH5bp3e4uMv1qTGAAAAAAAAAAABBBBBBBBCCCCCCCCAoQ0SWlDq9xhpmF/Z6pv83YJkQjVWOswRxNRMhzoeAOK6PTIyfGwqOJuZz3SQ9bP4LTCJ
     module 1/3 product-number r0x45a
     module 1/4 product-number r0x44a
     module 1/6 product-number r0x44a
@@ -1141,9 +1141,6 @@ commands:
     nae-script configuration_change_email false ...
     nae-script fault_finder_monitor false ...
     Switch-cx#\x20
-  # commands beyond the oxidized model: |-
-    # commands beyond the oxidized model
-    Switch-cx#\x20
   show system: |-
     show system
     Hostname               : Switch-cx              \x20
@@ -1168,4 +1165,1117 @@ commands:
   exit: |-
     exit
 oxidized_output: |
-  !! needs to be written by hand or copy & paste from model output
+  ! -----------------------------------------------------------------------------
+  ! ArubaOS-CX
+  ! (c) Copyright 2017-2023 Hewlett Packard Enterprise Development LP
+  ! -----------------------------------------------------------------------------
+  ! Version      : FL.10.10.1100                                                \x20
+  ! Build Date   : 2023-12-11 18:38:23 UTC                                      \x20
+  ! Build ID     : ArubaOS-CX:FL.10.10.1100:b4b52a6a46ff:202312111821           \x20
+  ! Build SHA    : b4b52a6a46ffe674f326481629c70082b24aeb95                     \x20
+  ! Active Image : secondary                    \x20
+  !\x20
+  ! Service OS Version : FL.01.11.0001                \x20
+  ! BIOS Version       : FL.01.0002                   \x20
+  ! show environment fan
+  !\x20
+  ! Fan tray information
+  ! ------------------------------------------------------------------------------
+  ! Name  Description                           Status        Serial Number  Fans
+  ! ------------------------------------------------------------------------------
+  ! 1/1   R0X32A Aruba 6400 Fan Tray            ready         SG0AAAA00A     4 \x20
+  ! 1/2   R0X32A Aruba 6400 Fan Tray            ready         SG0AAAA0A0     4 \x20
+  ! 1/3   R0X32A Aruba 6400 Fan Tray            ready         SG0AAAA0AA     4 \x20
+  ! 1/4   R0X32A Aruba 6400 Fan Tray            ready         SG0AAAA0AA     4 \x20
+  !\x20
+  ! Fan information
+  ! ------------------------------------------------------------------------------
+  ! Location-      Product  Serial Number  Speed   Direction      Status  RPM
+  ! Mbr/Slot/Fan   Name
+  ! ------------------------------------------------------------------------------
+  ! Tray-1/1/1     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/1/2     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/1/3     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/1/4     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/2/1     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/2/2     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/2/3     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/2/4     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/3/1     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/3/2     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/3/3     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/3/4     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/4/1     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/4/2     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/4/3     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  ! Tray-1/4/4     N/A      N/A            <speed> front-to-back  ok      <rpm>
+  !\x20
+  !\x20
+  !\x20
+  ! show environment led
+  ! Mbr/Name       State        Status   \x20
+  ! ----------------------------------
+  ! 1/locator      off          ok       \x20
+  !\x20
+  !\x20
+  ! show environment power-allocation
+  !      Product                                                Power
+  ! Name Number  Subsystem-Type       Request Priority Granted  Usage
+  ! -------------------------------------------------------------------
+  ! 1    R0X25A  base-chassis-module  N/A     N/A      N/A     <power>
+  ! 1/1  R0X25A  fabric-card-module   158     128      granted <power>
+  ! 1/2  R0X25A  fabric-card-module   158     128      granted <power>
+  ! 1/1  R0X32A  fan-tray-module      200     128      granted <power>
+  ! 1/2  R0X32A  fan-tray-module      200     128      granted <power>
+  ! 1/3  R0X32A  fan-tray-module      200     128      granted <power>
+  ! 1/4  R0X32A  fan-tray-module      200     128      granted <power>
+  ! 1/3  R0X45A  line-card-module     352     128      granted <power>
+  ! 1/4  R0X44A  line-card-module     424     128      granted <power>
+  ! 1/5  N/A     line-card-module     0       128      NA      <power>
+  ! 1/6  R0X44A  line-card-module     424     128      granted <power>
+  ! 1/7  N/A     line-card-module     0       128      NA      <power>
+  ! 1/8  N/A     line-card-module     0       128      NA      <power>
+  ! 1/9  N/A     line-card-module     0       128      NA      <power>
+  ! 1/10 N/A     line-card-module     0       128      NA      <power>
+  ! 1/11 N/A     line-card-module     0       128      NA      <power>
+  ! 1/12 R0X39B  line-card-module     121     128      granted <power>
+  ! 1/1  R0X31A  management-module    39      128      granted <power>
+  ! 1/2  R0X31A  management-module    39      128      granted <power>
+  ! -------------------------------------------------------------------
+  ! Total Requested                   2515 W
+  ! Total Power Granted to Subsystems 2515 W
+  ! Power Granted for PoE             2813 W
+  ! Total Power Granted               5328 W
+  ! Maximum PSU Power Available       5328 W
+  ! Power Remaining                      0 W
+  ! -------------------------------------------------------------------
+  !\x20
+  !\x20
+  ! show environment power-redundancy
+  ! Configured  Operational
+  ! Redundancy  Redundancy
+  ! -------------------------
+  ! none        none
+  !\x20
+  !\x20
+  ! show environment power-supply
+  ! ------------------------------------------------------------------------------
+  !          Product  Serial            PSU            Input   Voltage    Wattage
+  ! Mbr/PSU  Number   Number            Status         Type    Range      Maximum
+  ! ------------------------------------------------------------------------------
+  ! 1/1      R0X35A   CN0AAAA0AA        OK             AC      110V-240V  1800
+  ! 1/2      R0X35A   CN0AAAA00A        OK             AC      110V-240V  1764
+  ! 1/3      R0X35A   CN0AAAA0AA        OK             AC      110V-240V  1764
+  ! 1/4      N/A      N/A               Absent         --      --         0
+  !\x20
+  !\x20
+  !\x20
+  ! show environment temperature
+  ! Temperature information
+  ! ------------------------------------------------------------------------------
+  !                                                      Current
+  ! Mbr/Slot-Sensor                 Module Type        temperature  Status
+  ! ------------------------------------------------------------------------------
+  ! 1/3-Board-front                 line-card-module     <hidden>   normal
+  ! 1/3-Board-rear                  line-card-module     <hidden>   normal
+  ! 1/3-CPU                         line-card-module     <hidden>   normal
+  ! 1/3-DDR                         line-card-module     <hidden>   normal
+  ! 1/3-Exhaust-left                line-card-module     <hidden>   normal
+  ! 1/3-Exhaust-right               line-card-module     <hidden>   normal
+  ! 1/3-IBC                         line-card-module     <hidden>   normal
+  ! 1/3-Switch-ASIC                 line-card-module     <hidden>   normal
+  ! 1/3-Switch-ASIC-Internal        line-card-module     <hidden>   normal
+  ! 1/4-Board-front                 line-card-module     <hidden>   normal
+  ! 1/4-Board-rear                  line-card-module     <hidden>   normal
+  ! 1/4-CPU                         line-card-module     <hidden>   normal
+  ! 1/4-DDR                         line-card-module     <hidden>   normal
+  ! 1/4-Exhaust-left                line-card-module     <hidden>   normal
+  ! 1/4-Exhaust-right               line-card-module     <hidden>   normal
+  ! 1/4-IBC                         line-card-module     <hidden>   normal
+  ! 1/4-Switch-ASIC                 line-card-module     <hidden>   normal
+  ! 1/4-Switch-ASIC-Internal        line-card-module     <hidden>   normal
+  ! 1/6-Board-front                 line-card-module     <hidden>   normal
+  ! 1/6-Board-rear                  line-card-module     <hidden>   normal
+  ! 1/6-CPU                         line-card-module     <hidden>   normal
+  ! 1/6-DDR                         line-card-module     <hidden>   normal
+  ! 1/6-Exhaust-left                line-card-module     <hidden>   normal
+  ! 1/6-Exhaust-right               line-card-module     <hidden>   normal
+  ! 1/6-IBC                         line-card-module     <hidden>   normal
+  ! 1/6-Switch-ASIC                 line-card-module     <hidden>   normal
+  ! 1/6-Switch-ASIC-Internal        line-card-module     <hidden>   normal
+  ! 1/12-Board-front                line-card-module     <hidden>   normal
+  ! 1/12-Board-rear                 line-card-module     <hidden>   normal
+  ! 1/12-CPU                        line-card-module     <hidden>   normal
+  ! 1/12-DDR                        line-card-module     <hidden>   normal
+  ! 1/12-Exhaust-left               line-card-module     <hidden>   normal
+  ! 1/12-Exhaust-right              line-card-module     <hidden>   normal
+  ! 1/12-IBC                        line-card-module     <hidden>   normal
+  ! 1/12-PHY-01-08                  line-card-module     <hidden>   normal
+  ! 1/12-PHY-09-16                  line-card-module     <hidden>   normal
+  ! 1/12-PHY-17-24                  line-card-module     <hidden>   normal
+  ! 1/12-PHY-25-32                  line-card-module     <hidden>   normal
+  ! 1/12-PHY-33-40                  line-card-module     <hidden>   normal
+  ! 1/12-PHY-41-48                  line-card-module     <hidden>   normal
+  ! 1/12-Switch-ASIC                line-card-module     <hidden>   normal
+  ! 1/12-Switch-ASIC-Internal       line-card-module     <hidden>   normal
+  !\x20
+  ! 1/1-Board-Corner                management-module    <hidden>   normal
+  ! 1/1-CPU                         management-module    <hidden>   normal
+  ! 1/1-DDR                         management-module    <hidden>   normal
+  ! 1/1-Exhaust-Air                 management-module    <hidden>   normal
+  ! 1/1-Exhaust-board               management-module    <hidden>   normal
+  ! 1/1-IBC                         management-module    <hidden>   normal
+  ! 1/1-Inlet-Air                   management-module    <hidden>   normal
+  ! 1/2-Board-Corner                management-module    <hidden>   normal
+  ! 1/2-CPU                         management-module    <hidden>   normal
+  ! 1/2-DDR                         management-module    <hidden>   normal
+  ! 1/2-Exhaust-Air                 management-module    <hidden>   normal
+  ! 1/2-Exhaust-board               management-module    <hidden>   normal
+  ! 1/2-IBC                         management-module    <hidden>   normal
+  ! 1/2-Inlet-Air                   management-module    <hidden>   normal
+  !\x20
+  ! 1-ASIC-DC-board                 chassis              <hidden>   normal
+  ! 1-Board-NW                      chassis              <hidden>   normal
+  ! 1-Board-W                       chassis              <hidden>   normal
+  ! 1-DC-DC                         chassis              <hidden>   normal
+  ! 1-Fabric-ASIC-1                 chassis              <hidden>   normal
+  ! 1-Fabric-ASIC-2                 chassis              <hidden>   normal
+  ! 1-Fabric-ASIC-Internal-1        chassis              <hidden>   normal
+  ! 1-Fabric-ASIC-Internal-2        chassis              <hidden>   normal
+  ! 1-IBC                           chassis              <hidden>   normal
+  ! 1-PCIE-Management               chassis              <hidden>   normal
+  ! 1-PCIE-Management-2             chassis              <hidden>   normal
+  !\x20
+  !\x20
+  ! Management Modules
+  ! ==================
+  !\x20
+  !      Product                                        Serial
+  ! Name Number  Description                            Number     Status
+  ! ---- ------- -------------------------------------- ---------- ----------------
+  ! 1/1  R0X31A  6400 Management Module                 SG0AAAA00A Active (local)
+  ! 1/2  R0X31A  6400 Management Module                 SG00AAA00A Standby\x20
+  !\x20
+  !\x20
+  ! Line Modules
+  ! ============
+  !\x20
+  !      Product                                        Serial
+  ! Name Number  Description                            Number     Status
+  ! ---- ------- -------------------------------------- ---------- ----------------
+  ! 1/3  R0X45A  6400 12p 40G/100G QSFP28 Mod           SG00AAA000 Ready
+  ! 1/4  R0X44A  6400 48p 10G/25G SFP28 Mod             SG00AAA000 Ready
+  ! 1/6  R0X44A  6400 48p 10G/25G SFP28 Mod             SG00AAA00A Ready
+  ! 1/12 R0X39B  6400 48p 1GbE CL4 PoE 4SFP56 Mod       SG00AA000A Ready
+  !\x20
+  !\x20
+  ! ------------------------------------------------------------------
+  ! Port      Type           Product      Serial          Part       \x20
+  !                          Number       Number          Number     \x20
+  ! ------------------------------------------------------------------
+  ! 1/3/1     100G-DAC5      R0Z26A       CN00AAA00A      8121-1696  \x20
+  ! 1/3/2     40G-LR4        JH232A       CN00AAA00A      1990-4676  \x20
+  ! 1/3/3     40G-LR4        JH232A       CN00AAA00A      1990-4676  \x20
+  ! 1/3/4     40G-LR4        JH232A       C0000000000     1990-4556  \x20
+  ! 1/3/10    40G-LR4        JH232A       C0000000000     1990-4556  \x20
+  ! 1/3/11    40G-BiDi       JL308A       MY00AA0AAA      1990-4679  \x20
+  ! 1/3/12    100G-DAC5      R0Z26A       CN00AAA00A      8121-1696  \x20
+  ! 1/4/7     10G-SR         J9150D       CN00AAA0A0      1990-4634  \x20
+  ! 1/4/8     10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+  ! 1/4/9     10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+  ! 1/4/10    1G-SX          J4858C       PFA00A0         1990-3657  \x20
+  ! 1/4/20    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/21    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/22    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/23    10G-LR         J9151D       C0000000000     1990-3883  \x20
+  ! 1/4/24    10G-LR         J9151D       C0000000000     1990-3883  \x20
+  ! 1/4/25    1G-SX          J4858D       MY00AA0AAA      1990-4395  \x20
+  ! 1/4/26    10G-SR         J9150D       CN00AAA0AA      1990-4635  \x20
+  ! 1/4/27    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/28    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/29    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/30    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/31    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/32    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+  ! 1/4/33    10G-LR         J9151D       C0000000000     1990-3883  \x20
+  ! 1/4/34    10G-LR         J9151D       C0000000000     1990-3883  \x20
+  ! 1/4/35    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/36    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+  ! 1/4/37    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/38    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/39    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/40    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/41    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/42    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+  ! 1/4/43    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+  ! 1/4/44    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/45    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+  ! 1/4/46    10G-LR         J9151E       CN00AAA0AA      1990-4727  \x20
+  ! 1/4/47    10G-LR         J9151E       CN00AAA0AA      1990-4694  \x20
+  ! 1/4/48    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+  ! 1/6/37    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+  ! 1/6/38    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+  ! 1/6/39    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+  ! 1/6/40    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+  ! 1/6/44    1G-LX          J4859C       CN00AAA0AA      1990-3677  \x20
+  ! 1/6/47    1G-LX          J4859C       CN00AAA0AA      1990-4116  \x20
+  ! 1/6/48    10G-SR         J9150D       CN00AAA0AA      1990-4634  \x20
+  !\x20
+  ! Hostname               : Switch-cx              \x20
+  ! System Description     : FL.10.10.1100                \x20
+  ! System Contact         : SNMP Description
+  ! System Location        : SNMP Location                \x20
+  !\x20
+  ! Vendor                 : Aruba                        \x20
+  ! Product Name           : R0X25A 6410 Chassis                 \x20
+  ! Chassis Serial Nbr     : SG0AAA0000                   \x20
+  ! Base MAC Address       : 100f00-000d00                \x20
+  ! ArubaOS-CX Version     : FL.10.10.1100                \x20
+  !\x20
+  ! Time Zone              : America/Denver               \x20
+  !\x20
+  Current configuration:
+  !
+  !Version ArubaOS-CX FL.10.10.1100
+  !export-password: default
+  hostname Switch-cx
+  alias  diff        checkpoint diff startup-config running-config \x20
+  alias  logout      exit \x20
+  user admin group administrators password ciphertext AQEcvdLHmJIRAAAAAAAAABBBBBBBBCCCCCCCC29thkGl9AIkfApt/VowNDcU2BAaNmcgvS63g2LPqkf4VxntPXE5xKOAT9p8KbhO3gDkywU3rSvo1+mrqoeLQ8tCNHVJwztFTK
+  user user group administrators password ciphertext AQEfgTZ27jH5bp3e4uMv1qTGAAAAAAAAAAABBBBBBBBCCCCCCCCAoQ0SWlDq9xhpmF/Z6pv83YJkQjVWOswRxNRMhzoeAOK6PTIyfGwqOJuZz3SQ9bP4LTCJ
+  module 1/3 product-number r0x45a
+  module 1/4 product-number r0x44a
+  module 1/6 product-number r0x44a
+  module 1/12 product-number r0x39b
+  clock timezone america/denver
+  logging filter no_restd
+      enable
+       20 deny event-id 4602,4605,4608,4655,4657
+  profile default
+  vrf KA
+  ntp server ntp1.example.com
+  ntp server ntp2.example.com
+  ntp server ntp3.example.com
+  ntp server pool.ntp.org minpoll 4 maxpoll 4 iburst
+  ntp enable
+  cli-session
+      timeout 1440
+  !
+  !
+  !
+  !
+  !
+  !
+  aruba-central
+      disable
+  logging 10.1.2.3
+  logging facility local0
+  ssh server vrf default
+  ssh server vrf mgmt
+  ssh key-exchange-algorithms curve25519-sha256 curve25519-sha256@libssh.org ecdh-sha2-nistp256 ecdh-sha2-nistp384 ecdh-sha2-nistp521 diffie-hellman-group-exchange-sha256 diffie-hellman-group16-sha512 diffie-hellman-group18-sha512 diffie-hellman-group14-sha256 diffie-hellman-group14-sha1
+  vlan 1
+  vlan 2
+      name VLAN name
+  vlan 7
+      name VLAN name
+      vsx-sync
+  vlan 206
+      name VLAN name
+      vsx-sync
+  vlan 207
+      name VLAN name
+      vsx-sync
+  vlan 208
+      name VLAN name
+      vsx-sync
+  vlan 209
+      name VLAN name
+      vsx-sync
+  vlan 989
+      name VLAN name
+      vsx-sync
+  vlan 994
+      name VLAN name
+      vsx-sync
+  vlan 1630
+      name VLAN-name
+      vsx-sync
+  vlan 1640
+      name VLAN-name
+      vsx-sync
+  vlan 1650
+      name VLAN-name
+      vsx-sync
+  spanning-tree
+  spanning-tree priority 5
+  interface mgmt
+      no shutdown
+      ip dhcp
+  qos trust dscp
+  interface lag 7 multi-chassis static
+      description Description for interface
+      no shutdown
+      no routing
+      vlan trunk native 1
+      vlan trunk allowed 988,999
+  interface lag 8 multi-chassis static
+      description Description for interface
+      no shutdown
+      no routing
+      vlan trunk native 2
+      vlan trunk allowed all
+  interface lag 9 multi-chassis static
+      description Description for interface
+      no shutdown
+      no routing
+      vlan trunk native 1
+      vlan trunk allowed 1,2
+  interface lag 10 multi-chassis static
+      description Description for interface
+      no shutdown
+      no routing
+      vlan trunk native 2
+      vlan trunk allowed 1640
+  interface lag 247 multi-chassis
+      description Description for interface
+      no shutdown
+      no routing
+      vlan trunk native 2000
+      vlan trunk allowed all
+      lacp mode active
+  interface 1/3/1
+      description Description for interface
+      no shutdown
+      lag 247
+  interface 1/3/2
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 247
+  interface 1/3/3
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 247
+  interface 1/3/4
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 247
+  interface 1/3/5
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/3/6
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/3/7
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/3/8
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/3/9
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/3/10
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 249
+  interface 1/3/11
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 247
+  interface 1/3/12
+      description Description for interface
+      no shutdown
+      lag 8
+  interface 1/4/1
+      description Description for interface
+      no shutdown
+      mtu 9198
+      no routing
+      vlan trunk native 2
+      vlan trunk allowed 206,1640
+  interface 1/4/2
+      shutdown
+      mtu 9198
+      no routing
+      vlan access 1
+  interface 1/4/3
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/4
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/5
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/6
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/7
+      description Description for interface
+      no shutdown
+      lag 7
+  interface 1/4/8
+      description Description for interface
+      no shutdown
+      lag 8
+  interface 1/4/9
+      description Description for interface
+      no shutdown
+      lag 9
+  interface 1/4/10
+      description Description for interface
+      no shutdown
+      speed 1000-full
+      lag 10
+  interface 1/4/11
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/12
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/13
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/14
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/15
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/16
+      description Description for interface
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/17
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/18
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/19
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/4/20
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 20
+  interface 1/4/21
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 21
+  interface 1/4/22
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 22
+  interface 1/4/23
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 23
+  interface 1/4/24
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 24
+  interface 1/4/25
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 25
+  interface 1/4/26
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 26
+  interface 1/4/27
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 27
+  interface 1/4/28
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 28
+  interface 1/4/29
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 29
+  interface 1/4/30
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 30
+  interface 1/4/31
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 31
+  interface 1/4/32
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 32
+  interface 1/4/33
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 33
+  interface 1/4/34
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 34
+  interface 1/4/35
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 35
+  interface 1/4/36
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 36
+  interface 1/4/37
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 37
+  interface 1/4/38
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 38
+  interface 1/4/39
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 39
+  interface 1/4/40
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 40
+  interface 1/4/41
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 41
+  interface 1/4/42
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 42
+  interface 1/4/43
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 43
+  interface 1/4/44
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 44
+  interface 1/4/45
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 45
+  interface 1/4/46
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 46
+  interface 1/4/47
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 47
+  interface 1/4/48
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/1
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/2
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/3
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/4
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/5
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/6
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/7
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/8
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/9
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/10
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/11
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/12
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/13
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/14
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/15
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/16
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/17
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/18
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/19
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/20
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/21
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/22
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/23
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/24
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/25
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/26
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/27
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/28
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/29
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/30
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/31
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/32
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/33
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/34
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/35
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/36
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/37
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 137
+  interface 1/6/38
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 138
+  interface 1/6/39
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 139
+  interface 1/6/40
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 140
+  interface 1/6/41
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/42
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/43
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/44
+      description Description for interface
+      no shutdown
+      speed 1000-full
+      mtu 9198
+      no routing
+      vlan access 997
+      spanning-tree bpdu-filter
+  interface 1/6/45
+      description Description for interface
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/46
+      description Description for interface
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/6/47
+      description Description for interface)
+      no shutdown
+      no routing
+      vlan trunk native 2000
+      vlan trunk allowed 2000
+  interface 1/6/48
+      description Description for interface
+      no shutdown
+      mtu 9198
+      lag 148
+  interface 1/12/1
+      description Description for interface
+      no shutdown
+      mtu 9198
+      routing
+      vrf attach KA
+      ip address 192.168.0.0/31
+  interface 1/12/2
+      no shutdown
+      no routing
+      vlan access 2
+  interface 1/12/3
+      description Description for interface
+      no shutdown
+      no routing
+      vlan trunk native 1
+      vlan trunk allowed 1,2,206
+  interface 1/12/4
+      description Description for interface
+      no shutdown
+      no routing
+      vlan access 1
+      spanning-tree port-type admin-edge
+      spanning-tree tcn-guard
+  interface 1/12/5
+      description Description for interface
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/6
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/7
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/8
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/9
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/10
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/11
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/12
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/13
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/14
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/15
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/16
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/17
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/18
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/19
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/20
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/21
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/22
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/23
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/24
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/25
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/26
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/27
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/28
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/29
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/30
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/31
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/32
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/33
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/34
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/35
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/36
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/37
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/38
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/39
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/40
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/41
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/42
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/43
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/44
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/45
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/46
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/47
+      description Description for interface
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/48
+      no shutdown
+      no routing
+      vlan access 2
+  interface 1/12/49
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/50
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/51
+      no shutdown
+      no routing
+      vlan access 1
+  interface 1/12/52
+      no shutdown
+      no routing
+      vlan access 1
+  interface vlan 1
+      no ip dhcp
+  interface vlan 2
+      ip address 10.0.0.113/21
+  snmp-server vrf default
+  snmp-server trap-source interface vlan2 vrf default
+  snmp-server system-location SNMP Location
+  snmp-server system-contact SNMP Contact Information
+  snmp-server community readonlycom
+  snmp-server community rwsnmpcom
+      access-level rw
+  snmp-server host 10.7.32.31 trap version v2c community trapcomm\x20
+  snmp-server host 10.7.32.67 trap version v2c community trapcomm\x20
+  vsx
+      system-mac 02:02:00:00:02:00
+      inter-switch-link lag 256
+      role primary
+      keepalive peer 192.168.0.1 source 192.168.0.0 vrf KA
+      vsx-sync vsx-global
+  ip route 0.0.0.0/0 10.0.0.1
+  ip route 10.0.0.0/8 10.0.0.1
+  mirror session 1
+      destination tunnel 10.0.2.1 source 10.0.0.113
+      source interface lag45 rx
+  ip dns server-address 10.0.0.2
+  !
+  !
+  !
+  !
+  !
+  https-server vrf default
+  https-server vrf mgmt
+  nae-script configuration_change_email false ...
+  nae-script fault_finder_monitor false ...

--- a/lib/oxidized/model/aoscx.rb
+++ b/lib/oxidized/model/aoscx.rb
@@ -56,13 +56,13 @@ class Aoscx < Oxidized::Model
   cmd 'show environment' do |cfg|
     cfg.gsub! /^(LC.*\s+)\d+\s+$/, '\\1<hidden>'
     cfg.gsub! /^(\d\/\d\/\d.*\s+)\d+\s+$/, '\\1<hidden>'
-    cfg.gsub! /^(\d+\/\S+\s+\S+\s+)\d+\.\d+\s+C\s+(.*)/, '\\1<hidden>   \\2'
+    cfg.gsub! /^(\d+\/?\S+\s+\S+\s+)\d+\.\d+\s+C\s+(.*)/, '\\1<hidden>   \\2'
     cfg.gsub! /^(LC.*\s+)\d+\.\d+\s+(C.*)$/, '\\1 <hidden> \\2'
     cfg.gsub! /^(\S+\s+\S+\s+\s+\S+\s+)(slow|normal|medium|fast|max)\s+(\S+\s+\S+\s+)\d+[[:blank:]]+/, '\\1<speed> \\3<rpm>'
     # match show environment power-consumption on VSF or standadlone, non-chassis and non-6400 switch, e.g. "2    6300M 48G 4SFP56 Swch                 156.00      155.94"
     cfg.gsub! /^(\d+\s+.+\s+)(\s{2}\d{2}\.\d{2}|\s{1}\d{3}\.\d{2}|\d{4}\.\d{2})(\s+)(\s{2}\d{2}\.\d{2}|\s{1}\d{3}\.\d{2}|\d{4}\.\d{2})$/, '\\1<power>\\3<power>'
     # match show environment power-consumption on 6400 or chassis switches, e.g. "1/4    line-card-module    R0X39A 6400 48p 1GbE CL4 PoE 4SFP56 Mod     54 W"
-    cfg.gsub! /^(\d+\/\d+\s+.+\s+)(\s{3}\d{1}|\s{2}\d{2}|\s{1}\d{3}|\d{4})\sW\s*$/, '\\1<power>'
+    cfg.gsub! /^(\d+\/?\d*\s+.+\s+)(\s{1,4}\d{1,3})\sW\s*$/, '\\1<power>'
     # match show environment power-consumption on 6400 or chassis switches, e.g. "Module Total Power Usage      13000 W", match up to a 5-digit number and keep table formatting.
     cfg.gsub! /^(Module|Chassis)\s(Total\sPower\sUsage)(\s+)\s(\s{4}\d{1}|\s{3}\d{2}|\s{2}\d{3}|\s{1}\d{4}|\d{5})\sW\s*$/, '\\1 <power>'
     # match show environment power-consumption on 6400 or chassis switches, e.g. "Chassis Total Power Usage     13000 W", match up to a 5-digit number and keep table formatting.

--- a/spec/model/aoscx_spec.rb
+++ b/spec/model/aoscx_spec.rb
@@ -21,4 +21,14 @@ describe 'model/Aoscx' do
     _(status).must_equal :success
     _(result.to_cfg).must_equal mockmodel.oxidized_output
   end
+
+  it 'runs on R8N85A (C6000-48G-CL4) with PL.10.08.1010' do
+    mockmodel = MockSsh.new('examples/device-simulation/yaml/aoscx_R0X25A-6410_FL.10.10.1100.yaml')
+    Net::SSH.stubs(:start).returns mockmodel
+
+    status, result = @node.run
+
+    _(status).must_equal :success
+    _(result.to_cfg).must_equal mockmodel.oxidized_output
+  end
 end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Modified aoscx.rb model to hide changing values such as power and temperature in 6400 switches in firmware 10.10.x


