### PR TITLE
Added handling of more ios-xe and nxos secrets

### DIFF
--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -48,6 +48,8 @@ class IOS < Oxidized::Model
     cfg.gsub! /^( +dot1x username \S+ password \d) (.*)$/, '\\1 <secret hidden>'
     cfg.gsub! /^( +mgmtuser username \S+ password \d) (.*) (secret \d) (.*)$/, '\\1 <secret hidden> \\3 <secret hidden>'
     cfg.gsub! /^( +client \S+ server-key \d) (.*)$/, '\\1 <secret hidden>'
+    cfg.gsub! /^( +domain-password) \S+ ?(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^( +pre-shared-key).*/, '\\1 <configuration removed>'
     cfg
   end
 

--- a/lib/oxidized/model/nxos.rb
+++ b/lib/oxidized/model/nxos.rb
@@ -13,8 +13,9 @@ class NXOS < Oxidized::Model
     cfg.gsub! /^(snmp-server community).*/, '\\1 <secret hidden>'
     cfg.gsub! /^(snmp-server user (\S+) (\S+) auth (\S+)) (\S+) (priv) (\S+)/, '\\1 <secret hidden> '
     cfg.gsub! /^(snmp-server host.*? )\S+( udp-port \d+)?$/, '\\1<secret hidden>\\2'
+    cfg.gsub! /^(snmp-server mib community-map) \S+ ?(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /(password \d+) (\S+)/, '\\1 <secret hidden>'
-    cfg.gsub! /^(radius-server key).*/, '\\1 <secret hidden>'
+    cfg.gsub! /^(radius-server .*key(?: \d+)?) \S+/, '\\1 <secret hidden>'
     cfg.gsub! /^(tacacs-server .*key(?: \d+)?) \S+/, '\\1 <secret hidden>'
     cfg
   end


### PR DESCRIPTION
## Description
### **ios.rb changes:**
IS-IS domain passwords hidden (with or without extra options)
IPSEC PSKs hidden

For IPSEC PSKs the configuration lines have the same issues as here:
https://github.com/ytti/oxidized/blob/b1be800e6d3f66c4cae406d5eb4da7a75f9e250b/lib/oxidized/model/ios.rb#L29

Which means we need to hide everyhing after the first command, there is no part of the command that lets us know that the next word is the actual key.
  
  

### **nxos.rb changes:**
vrf-aware SNMP communities hidden
radius keys hidden (currently only global keys are hidden, this will hide both global and host-specific keys)




