### PR TITLE
Update nagios_check_failing_nodes.rb

### DIFF
--- a/extra/nagios_check_failing_nodes.rb
+++ b/extra/nagios_check_failing_nodes.rb
@@ -10,7 +10,7 @@ pending = false
 critical_nodes = []
 pending_nodes = []
 
-json = JSON.parse(open("http://localhost:8888/nodes.json").read)
+json = JSON.parse(URI("http://localhost:8888/nodes.json").open(&:read))
 json.each do |node|
   next if !ARGV.empty? && (ARGV[0] != node['name'])
 


### PR DESCRIPTION
Fixes:
No such file or directory @ rb_sysopen - http://localhost:8888/nodes.json (Errno::ENOENT)

See discussion in: https://github.com/ytti/oxidized/issues/67

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
