### PR TITLE
Updated slackdiff document to highlight channel id is required

### DIFF
--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -259,7 +259,7 @@ gem install slack-ruby-client
 
 ### slackdiff hook configuration example
 
-> Please note that channel needs to be your Slack channel ID.
+> Please note that the channel needs to be your Slack channel ID.
 
 ```yaml
 hooks:
@@ -284,8 +284,6 @@ hooks:
     diff: false
     message: "%{node} %{group} %{model} updated https://git.intranet/network-changes/commit/%{commitref}"
 ```
-
-Note the channel ID must be in quotes.
 
 A proxy can optionally be specified if needed to reach the Slack API endpoint.
 

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -259,13 +259,15 @@ gem install slack-ruby-client
 
 ### slackdiff hook configuration example
 
+> Please note that channel needs to be your Slack channel ID.
+
 ```yaml
 hooks:
   slack:
     type: slackdiff
     events: [post_store]
     token: SLACK_BOT_TOKEN
-    channel: "#network-changes"
+    channel: "CHANNEL_ID"
 ```
 
 The token parameter is a Slack API token that can be generated following [this tutorial](https://api.slack.com/tutorials/tracks/getting-a-token).  Until Slack stops supporting them, legacy tokens can also be used.
@@ -278,12 +280,12 @@ hooks:
     type: slackdiff
     events: [post_store]
     token: SLACK_BOT_TOKEN
-    channel: "#network-changes"
+    channel: "CHANNEL_ID"
     diff: false
     message: "%{node} %{group} %{model} updated https://git.intranet/network-changes/commit/%{commitref}"
 ```
 
-Note the channel name must be in quotes.
+Note the channel ID must be in quotes.
 
 A proxy can optionally be specified if needed to reach the Slack API endpoint.
 
@@ -293,7 +295,7 @@ hooks:
     type: slackdiff
     events: [post_store]
     token: SLACK_BOT_TOKEN
-    channel: "#network-changes"
+    channel: "#CHANNEL_ID"
     proxy: http://myproxy:8080
 ```
 


### PR DESCRIPTION
## Pre-Request Checklist

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Updated the slackdiff documentation to use the slack channel id.

Fixes #3349 
