### PR TITLE
feat(fsos): Hiding AAA and SNMP secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - asyncos: fix prompt for hostnames containing "-" . Fixes #3327 (@robertcheramy)
 - sonicos: fix prompt for hostnames containing "-" . Fixes #3333 (@robertcheramy)
 - xos: Hide radius accounting secret
-- fsos: Hide AAA secrets
+- fsos: Hide AAA and SNMP secrets (@RayaneB35)
 
 ## [0.31.0 – 2024-11-29]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - asyncos: fix prompt for hostnames containing "-" . Fixes #3327 (@robertcheramy)
 - sonicos: fix prompt for hostnames containing "-" . Fixes #3333 (@robertcheramy)
 - xos: Hide radius accounting secret
+- fsos: Hide AAA secrets
 
 ## [0.31.0 – 2024-11-29]
 

--- a/docs/Model-Notes/FSOS.md
+++ b/docs/Model-Notes/FSOS.md
@@ -7,6 +7,7 @@ This has been tested against the following models and OS versions
 |S3400-48T4SP        |Version 2.0.2J Build 81736    |
 |S3400-48T4SP        |Version 2.0.2J Build 95262    |
 |S3400-48T6SP        |Version 2.2.0F Build 109661   |
+|S3400-48T4SP        |Version 2.0.2J Build 120538   |
 |S3410-24TS-P        |S3410_FSOS 11.4(1)B74S5       |
 |S5850-48T4Q         |Version 7.0.4.34              |
 |S5800-48MBQ         |Version 7.0.4.21              |

--- a/examples/device-simulation/cmdsets/fsos
+++ b/examples/device-simulation/cmdsets/fsos
@@ -1,0 +1,7 @@
+enable
+terminal length 0
+terminal width 256
+show version
+show running-config
+exit
+exit

--- a/examples/device-simulation/yaml/fsos_S3400-48T4SP_2.0.2J-120538.yaml
+++ b/examples/device-simulation/yaml/fsos_S3400-48T4SP_2.0.2J-120538.yaml
@@ -1,0 +1,1551 @@
+---
+init_prompt: |-
+  FS-LAB-OXI#
+commands:
+  show version: |-
+    show version
+    Fiberstore Co., Limited Internetwork Operating System Software
+    S3400-48T4SP Software, Version 2.0.2J Build 120538, RELEASE SOFTWARE
+    Copyright (c) 2019 by FS.COM All Rights Reserved
+    Compiled: 2023-11-21 15:39:8 by SYS, Image text-base: 0x80010000
+    ROM: System Bootstrap, Version 0.1.3,hardware version:A
+    Serial num:CG2XXXXXX, ID num:2000000
+    System image file is \"Switch.bin\"
+    FS S3400-48T4SP RISC
+    262144K bytes of memory,16384K bytes of flash
+    Base ethernet MAC Address: 64:9d:99:23:25:04
+    snmp info:
+      vend_ID:52642   product_ID:445   system_ID:1.3.6.1.4.1.52642.1.445.0
+    FS-LAB-OXI uptime is 4:04:14:10, The current time: 2024-12-25 22:18:44
+     Reboot history information:
+      No. 1: System is rebooted by power-on
+      No. 2: System is rebooted by command at 2000-1-1 0:7:30, uptime 0:00:07:12
+      No. 3: System is rebooted by command at 2000-1-1 2:50:33, uptime 0:02:50:16
+    FS-LAB-OXI#
+  show running-config: |-
+    show running-config
+    Building configuration...
+
+
+
+    Current configuration:
+    !
+    !version 2.0.2J build 120538
+    service timestamps log date
+    service timestamps debug date
+    service password-encryption
+    logging trap debugging
+    !
+    !
+    hostname FS-LAB-OXI
+    !
+    !
+    lldp run
+    !
+    !
+    ip domain-list example.com
+    ip domain-list intra.example.com
+    ip name-server 1.1.1.1
+    ip name-server 8.8.8.8
+    !
+    !
+    !
+    !
+    spanning-tree mode mstp
+    !
+    dot1x enable
+    dot1x authen-type chap
+    dot1x re-authentication
+    dot1x timeout re-authperiod 604800
+    dot1x guest-vlan
+    dot1x mabformat 3
+    !
+    !
+    !
+    !
+    ip access-list standard ACL_SNMP
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    aaa authentication banner \"Use your Admin password.\"
+    aaa authentication fail-message \"Access is restricted to Admins!!\"
+    aaa authentication login default local group admin-radius continue-on-failed
+    aaa authentication enable default none
+    aaa authentication dot1x default group user-radius
+    aaa authorization exec default group admin-radius local
+    aaa accounting connection default start-stop group accounting-radius
+    !
+    username admin password 7 0932840928a209842390
+    username oxidized password 7 098234092384d92384f92384
+    !
+    !
+    !
+    !
+    interface Null0
+    !
+    interface GigaEthernet0/1
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/2
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/3
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/4
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/5
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/6
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/7
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/8
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/9
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/10
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/11
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/12
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/13
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/14
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/15
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/16
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/17
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/18
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/19
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/20
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/21
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/22
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/23
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/24
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/25
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/26
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/27
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/28
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/29
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/30
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/31
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/32
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/33
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/34
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/35
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/36
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/37
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/38
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/39
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/40
+     description \"USER\"
+     dot1x authentication method user-radius
+     dot1x port-control misc-mab
+     dot1x accounting method accounting-radius
+     dot1x accounting enable
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     no lldp transmit
+     no lldp receive
+     storm-control broadcast threshold 200
+     poe disable
+    !
+    interface GigaEthernet0/41
+     description \"TRUNK\"
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+     switchport trunk vlan-untagged 1201
+     switchport mode trunk
+     switchport pvid 1201
+    !
+    interface GigaEthernet0/42
+     description \"TRUNK\"
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+     switchport trunk vlan-untagged 1201
+     switchport mode trunk
+     switchport pvid 1201
+    !
+    interface GigaEthernet0/43
+     description \"TRUNK\"
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+     switchport trunk vlan-untagged 1201
+     switchport mode trunk
+     switchport pvid 1201
+    !
+    interface GigaEthernet0/44
+     description \"TRUNK\"
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+     switchport trunk vlan-untagged 1201
+     switchport mode trunk
+     switchport pvid 1201
+    !
+    interface GigaEthernet0/45
+     description \"TRUNK\"
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+     switchport trunk vlan-untagged 1201
+     switchport mode trunk
+     switchport pvid 1201
+    !
+    interface GigaEthernet0/46
+     description \"TRUNK\"
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+     switchport trunk vlan-untagged 1201
+     switchport mode trunk
+     switchport pvid 1201
+    !
+    interface GigaEthernet0/47
+     description \"TRUNK\"
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+     switchport trunk vlan-untagged 1201
+     switchport mode trunk
+     switchport pvid 1201
+    !
+    interface GigaEthernet0/48
+     description \"TRUNK\"
+     spanning-tree bpdufilter enable
+     spanning-tree bpduguard enable
+     switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+     switchport trunk vlan-untagged 1201
+     switchport mode trunk
+     switchport pvid 1201
+    !
+    interface TGigaEthernet0/1
+     shutdown
+    !
+    interface TGigaEthernet0/2
+     description \"UPLINK\"
+     switchport trunk vlan-allowed 1101,1201,1310-1311,2000-3999
+     switchport mode trunk
+    !
+    interface TGigaEthernet0/3
+     shutdown
+    !
+    interface TGigaEthernet0/4
+     shutdown
+    !
+    interface VLAN1101
+     description system_switch
+     ip address 172.16.57.3 255.255.128.0
+     no ip directed-broadcast
+     no ip route-cache
+    !
+    !
+    !
+    vlan 1101
+     name system_switch
+    !
+    vlan 1201
+     name trunk
+    !
+    vlan 1310
+     name management_sys
+    !
+    vlan 1311
+     name management_user
+    !
+    vlan 1,1101,1201,1310-1311,2000-3999
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    !
+    ip route default 172.16.127.254\x20
+    ip exf
+    !
+    ipv6 exf
+    !
+    no ip telnet enable
+    !
+    !
+    !
+    snmp-server group snmp-nms v3 priv read ro-view\x20
+    snmp-server user snmp-nms snmp-nms v3 priv aes256-c auth sha256 7 77fea4aabdfafba68e490caacf31b257cbf7db15179386c47c1c68e746e5f1c2 efa1f375d76194fa51a3556a97e641e61685f914d446979da50a551a4333ffd7\x20
+    snmp-server community 7 114f45314d581e RO ACL_SNMP
+    snmp-server contact admin@example.com
+    snmp-server host 192.168.1.3 public snmp
+    snmp-server location \"SAHARA [24.173223, -10.519086]\"
+    snmp-server encryption
+    snmp-server view ro-view iso included
+    snmp-server view ro-view system included
+    !
+    aaa group server radius admin-radius
+     server 1.2.3.4 key 7 09341b42313f535e30553d55283f4f60
+
+    !
+    aaa group server radius user-radius
+     server 1.2.3.5 key 7 040b2f2f3e474329544438545f
+
+     server 1.2.3.6 key 7 040b2f2f3e474329544438545f1c544759275040
+
+    !
+    aaa group server radius accounting-radius
+     server 1.2.3.4 key 7 09341b4231
+
+    !
+    !
+    ip sshd auth-retries 65500
+    ip sshd silence-period 0
+    ip sshd enable
+    ip sshd version 2
+    !
+    ntp server 185.254.101.25 version 4
+    ntp server 5.39.80.51 version 4
+    ntp server 82.65.248.56 version 4
+    !
+    !
+    !
+    FS-LAB-OXI#
+  exit: |-
+    exit
+oxidized_output: |-
+  ! show version
+  ! Fiberstore Co., Limited Internetwork Operating System Software
+  ! S3400-48T4SP Software, Version 2.0.2J Build 120538, RELEASE SOFTWARE
+  ! Copyright (c) 2019 by FS.COM All Rights Reserved
+  ! Compiled: 2023-11-21 15:39:8 by SYS, Image text-base: 0x80010000
+  ! ROM: System Bootstrap, Version 0.1.3,hardware version:A
+  ! Serial num:CG2XXXXXX, ID num:2000000
+  ! System image file is \"Switch.bin\"
+  ! FS S3400-48T4SP RISC
+  ! 262144K bytes of memory,16384K bytes of flash
+  ! Base ethernet MAC Address: 64:9d:99:23:25:04
+  ! snmp info:
+  !   vend_ID:52642   product_ID:445   system_ID:1.3.6.1.4.1.52642.1.445.0
+  !  Reboot history information:
+  !   No. 1: System is rebooted by power-on
+  !   No. 2: System is rebooted by command at 2000-1-1 0:7:30, uptime 0:00:07:12
+  !   No. 3: System is rebooted by command at 2000-1-1 2:50:33, uptime 0:02:50:16
+  ! FS-LAB-OXI#
+
+
+  Current configuration:
+  !
+  !version 2.0.2J build 120538
+  service timestamps log date
+  service timestamps debug date
+  service password-encryption
+  logging trap debugging
+  !
+  !
+  hostname FS-LAB-OXI
+  !
+  !
+  lldp run
+  !
+  !
+  ip domain-list example.com
+  ip domain-list intra.example.com
+  ip name-server 1.1.1.1
+  ip name-server 8.8.8.8
+  !
+  !
+  !
+  !
+  spanning-tree mode mstp
+  !
+  dot1x enable
+  dot1x authen-type chap
+  dot1x re-authentication
+  dot1x timeout re-authperiod 604800
+  dot1x guest-vlan
+  dot1x mabformat 3
+  !
+  !
+  !
+  !
+  ip access-list standard ACL_SNMP
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  aaa authentication banner \"Use your Admin password.\"
+  aaa authentication fail-message \"Access is restricted to Admins!!\"
+  aaa authentication login default local group admin-radius continue-on-failed
+  aaa authentication enable default none
+  aaa authentication dot1x default group user-radius
+  aaa authorization exec default group admin-radius local
+  aaa accounting connection default start-stop group accounting-radius
+  !
+  username admin password 7 0932840928a209842390
+  username oxidized password 7 098234092384d92384f92384
+  !
+  !
+  !
+  !
+  interface Null0
+  !
+  interface GigaEthernet0/1
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/2
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/3
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/4
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/5
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/6
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/7
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/8
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/9
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/10
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/11
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/12
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/13
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/14
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/15
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/16
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/17
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/18
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/19
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/20
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/21
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/22
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/23
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/24
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/25
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/26
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/27
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/28
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/29
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/30
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/31
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/32
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/33
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/34
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/35
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/36
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/37
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/38
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/39
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/40
+   description \"USER\"
+   dot1x authentication method user-radius
+   dot1x port-control misc-mab
+   dot1x accounting method accounting-radius
+   dot1x accounting enable
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   no lldp transmit
+   no lldp receive
+   storm-control broadcast threshold 200
+   poe disable
+  !
+  interface GigaEthernet0/41
+   description \"TRUNK\"
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+   switchport trunk vlan-untagged 1201
+   switchport mode trunk
+   switchport pvid 1201
+  !
+  interface GigaEthernet0/42
+   description \"TRUNK\"
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+   switchport trunk vlan-untagged 1201
+   switchport mode trunk
+   switchport pvid 1201
+  !
+  interface GigaEthernet0/43
+   description \"TRUNK\"
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+   switchport trunk vlan-untagged 1201
+   switchport mode trunk
+   switchport pvid 1201
+  !
+  interface GigaEthernet0/44
+   description \"TRUNK\"
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+   switchport trunk vlan-untagged 1201
+   switchport mode trunk
+   switchport pvid 1201
+  !
+  interface GigaEthernet0/45
+   description \"TRUNK\"
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+   switchport trunk vlan-untagged 1201
+   switchport mode trunk
+   switchport pvid 1201
+  !
+  interface GigaEthernet0/46
+   description \"TRUNK\"
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+   switchport trunk vlan-untagged 1201
+   switchport mode trunk
+   switchport pvid 1201
+  !
+  interface GigaEthernet0/47
+   description \"TRUNK\"
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+   switchport trunk vlan-untagged 1201
+   switchport mode trunk
+   switchport pvid 1201
+  !
+  interface GigaEthernet0/48
+   description \"TRUNK\"
+   spanning-tree bpdufilter enable
+   spanning-tree bpduguard enable
+   switchport trunk vlan-allowed 1201,1310-1311,2000-3999
+   switchport trunk vlan-untagged 1201
+   switchport mode trunk
+   switchport pvid 1201
+  !
+  interface TGigaEthernet0/1
+   shutdown
+  !
+  interface TGigaEthernet0/2
+   description \"UPLINK\"
+   switchport trunk vlan-allowed 1101,1201,1310-1311,2000-3999
+   switchport mode trunk
+  !
+  interface TGigaEthernet0/3
+   shutdown
+  !
+  interface TGigaEthernet0/4
+   shutdown
+  !
+  interface VLAN1101
+   description system_switch
+   ip address 172.16.57.3 255.255.128.0
+   no ip directed-broadcast
+   no ip route-cache
+  !
+  !
+  !
+  vlan 1101
+   name system_switch
+  !
+  vlan 1201
+   name trunk
+  !
+  vlan 1310
+   name management_sys
+  !
+  vlan 1311
+   name management_user
+  !
+  vlan 1,1101,1201,1310-1311,2000-3999
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  !
+  ip route default 172.16.127.254\x20
+  ip exf
+  !
+  ipv6 exf
+  !
+  no ip telnet enable
+  !
+  !
+  !
+  snmp-server group snmp-nms v3 priv read ro-view\x20
+  snmp-server user snmp-nms snmp-nms v3 priv aes256-c auth sha256 7 77fea4aabdfafba68e490caacf31b257cbf7db15179386c47c1c68e746e5f1c2 efa1f375d76194fa51a3556a97e641e61685f914d446979da50a551a4333ffd7\x20
+  snmp-server community 7 114f45314d581e RO ACL_SNMP
+  snmp-server contact admin@example.com
+  snmp-server host 192.168.1.3 public snmp
+  snmp-server location \"SAHARA [24.173223, -10.519086]\"
+  snmp-server encryption
+  snmp-server view ro-view iso included
+  snmp-server view ro-view system included
+  !
+  aaa group server radius admin-radius
+   server 1.2.3.4 key 7 09341b42313f535e30553d55283f4f60
+
+  !
+  aaa group server radius user-radius
+   server 1.2.3.5 key 7 040b2f2f3e474329544438545f
+
+   server 1.2.3.6 key 7 040b2f2f3e474329544438545f1c544759275040
+
+  !
+  aaa group server radius accounting-radius
+   server 1.2.3.4 key 7 09341b4231
+
+  !
+  !
+  ip sshd auth-retries 65500
+  ip sshd silence-period 0
+  ip sshd enable
+  ip sshd version 2
+  !
+  ntp server 185.254.101.25 version 4
+  ntp server 5.39.80.51 version 4
+  ntp server 82.65.248.56 version 4
+  !
+  !
+  !
+  FS-LAB-OXI#

--- a/examples/device-simulation/yaml/fsos_S3400-48T4SP_2.0.2J-120538.yaml
+++ b/examples/device-simulation/yaml/fsos_S3400-48T4SP_2.0.2J-120538.yaml
@@ -2,6 +2,15 @@
 init_prompt: |-
   FS-LAB-OXI#
 commands:
+  enable: |-
+    enable
+    FS-LAB-OXI#
+  terminal length 0: |-
+    terminal length 0
+    FS-LAB-OXI#
+  terminal width 512: |-
+    terminal width 512
+    FS-LAB-OXI#
   show version: |-
     show version
     Fiberstore Co., Limited Internetwork Operating System Software

--- a/lib/oxidized/model/fsos.rb
+++ b/lib/oxidized/model/fsos.rb
@@ -2,6 +2,7 @@ class FSOS < Oxidized::Model
   # Fiberstore / fs.com
   using Refinements
   comment '! '
+  prompt /^([\w.@()-]+[#>]\s?)$/
 
   # Handle paging
   expect /^ --More--.*$/ do |data, re|
@@ -40,7 +41,7 @@ class FSOS < Oxidized::Model
   cfg :telnet, :ssh do
     post_login 'enable'
     post_login 'terminal length 0'
-    post_login 'terminal width 256'
+    post_login 'terminal width 512'
     pre_logout 'exit'
     pre_logout 'exit'
   end

--- a/lib/oxidized/model/fsos.rb
+++ b/lib/oxidized/model/fsos.rb
@@ -13,6 +13,7 @@ class FSOS < Oxidized::Model
     cfg.gsub! /(secret \w+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(snmp-server community \d+) (\S+).*/, '\\1 <secret hidden>'
+    cfg.gsub! /^(.*key \d+) (\S+).*/, '\\1 <secret hidden>'
     cfg
   end
 

--- a/lib/oxidized/model/fsos.rb
+++ b/lib/oxidized/model/fsos.rb
@@ -13,6 +13,8 @@ class FSOS < Oxidized::Model
     cfg.gsub! /(secret \w+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(snmp-server community \d+) (\S+).*/, '\\1 <secret hidden>'
+    cfg.gsub! /^(snmp-server host \S+( udp-port \d+)?( permit|deny \d+)?( informs?)?( traps?)?(( version v3 (priv|auth|noauth))|( version (v1|v2c))?)) +\S+( .*)?$*/, '\\1 <secret hidden>'
+    cfg.gsub! /^(snmp-server user \S+ \S+ v3( priv (des|aes128|aes256|aes256-c))?( auth (md5|sha|sha256) \d+)) +\S+( .*)?$*/, '\\1 <secret hidden>'
     cfg.gsub! /^(.*key \d+) (\S+).*/, '\\1 <secret hidden>'
     cfg
   end

--- a/spec/model/fsos_spec.rb
+++ b/spec/model/fsos_spec.rb
@@ -1,0 +1,46 @@
+require_relative 'model_helper'
+
+describe 'model/FSOS' do
+  before(:each) do
+    init_model_helper
+    @node = Oxidized::Node.new(name:  'example.com',
+                               input: 'ssh',
+                               model: 'fsos')
+  end
+
+  it 'matches different prompts' do
+    _('FS-LAB-OXI#').must_match FSOS.prompt
+    _('fs-lab-oxi#').must_match FSOS.prompt
+  end
+
+  it 'runs on S3400 with FSOS 2.0.2J build 120538' do
+    mockmodel = MockSsh.new('examples/device-simulation/yaml/fsos_S3400-48T4SP_2.0.2J-120538.yaml')
+    Net::SSH.stubs(:start).returns mockmodel
+
+    status, result = @node.run
+
+    _(status).must_equal :success
+    _(result.to_cfg).must_equal mockmodel.oxidized_output
+  end
+
+  it 'removes secrets from FSOS 2.0.2J build 120538' do
+    Oxidized.config.vars.remove_secret = true
+    mockmodel = MockSsh.new('examples/device-simulation/yaml/fsos_S3400-48T4SP_2.0.2J-120538.yaml')
+    Net::SSH.stubs(:start).returns mockmodel
+
+    status, result = @node.run
+
+    _(status).must_equal :success
+    _(result.to_cfg).must_match(/<secret hidden>/)
+    _(result.to_cfg).wont_match(/09341b4231/)
+    _(result.to_cfg).wont_match(/040b2f2f3e474329544438545f1c544759275040/)
+    _(result.to_cfg).wont_match(/040b2f2f3e474329544438545f/)
+    _(result.to_cfg).wont_match(/09341b42313f535e30553d55283f4f60/)
+    _(result.to_cfg).wont_match(/ public /)
+    _(result.to_cfg).wont_match(/114f45314d581e/)
+    _(result.to_cfg).wont_match(/77fea4aabdfafba68e490caacf31b257cbf7db15179386c47c1c68e746e5f1c2/)
+    _(result.to_cfg).wont_match(/efa1f375d76194fa51a3556a97e641e61685f914d446979da50a551a4333ffd7/)
+    _(result.to_cfg).wont_match(/098234092384d92384f92384/)
+    _(result.to_cfg).wont_match(/0932840928a209842390/)
+  end
+end


### PR DESCRIPTION
Either unencrypted (0) or encrypted (7) secrets should be hidden

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Added multiple cfg.gsub to match every line containing "key ..." to hide unencrypted (`key 0`) or encrypted (`key 7`) secrets.