### PR TITLE
Change path for new opnsense version

### DIFF
--- a/lib/oxidized/model/opnsense.rb
+++ b/lib/oxidized/model/opnsense.rb
@@ -18,7 +18,7 @@ class OpnSense < Oxidized::Model
   # that lack the opnsense-version command. Newer versions of OPNsense no longer
   # store the version information in this file, so both versions have to be
   # supported here for now.
-  cmd 'opnsense-version || echo "OPNsense "`cat /usr/local/opnsense/version/opnsense`' do |version|
+  cmd 'opnsense-version || echo "OPNsense "`cat /usr/local/opnsense/version/base`' do |version|
     xmlcomment version
   end
 

--- a/lib/oxidized/model/opnsense.rb
+++ b/lib/oxidized/model/opnsense.rb
@@ -18,7 +18,7 @@ class OpnSense < Oxidized::Model
   # that lack the opnsense-version command. Newer versions of OPNsense no longer
   # store the version information in this file, so both versions have to be
   # supported here for now.
-  cmd 'opnsense-version || echo "OPNsense "`cat /usr/local/opnsense/version/base`' do |version|
+  cmd 'opnsense-version || echo "OPNsense "`cat /usr/local/opnsense/version/base 2>/dev/null || cat /usr/local/opnsense/version/opnsense 2>/dev/null`' do |version|
     xmlcomment version
   end
 


### PR DESCRIPTION
From 24.x the file opnsense doesn't exist anymore

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Enhanced the OPNsense version retrieval command with improved error handling and fallback mechanisms for version information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->