### PR TITLE
Mock DNS result in SSH spec

### DIFF
--- a/spec/input/ssh_spec.rb
+++ b/spec/input/ssh_spec.rb
@@ -11,12 +11,11 @@ describe Oxidized::SSH do
     Oxidized::Node.any_instance.stubs(:resolve_repo)
     Oxidized::Node.any_instance.stubs(:resolve_input)
     Oxidized::Node.any_instance.stubs(:resolve_output)
+    Resolv.any_instance.stubs(:getaddress).with('example.com').returns('192.0.2.2')
   end
 
   describe "#connect" do
     it "should use proxy command when proxy host given and connect by ip if resolve_dns is true" do
-      # If this test fails, check it exemple.com still resolves to 93.184.215.14
-      # If not, update Net::SSH.expects(:start).with('93.184.215.14'... below
       Oxidized.config.resolve_dns = true
       @node = Oxidized::Node.new(name:     'example.com',
                                  input:    'ssh',
@@ -46,7 +45,7 @@ describe Oxidized::SSH do
         auth_methods:                    %w[none publickey password],
         proxy:                           proxy
       }
-      Net::SSH.expects(:start).with('93.184.215.14', 'alma', ssh_options)
+      Net::SSH.expects(:start).with('192.0.2.2', 'alma', ssh_options)
 
       ssh.instance_variable_set("@exec", true)
       ssh.connect(@node)


### PR DESCRIPTION
Fixes #3370



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
    - Updated SSH connection test to use a stubbed IP address for consistent DNS resolution
    - Replaced hardcoded IP address with a controlled test IP
    - Improved test reliability by controlling DNS resolution behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->