### PR TITLE
Fixes for Cisco ASA model (asa.rb)

### DIFF
--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -15,7 +15,7 @@ class ASA < Oxidized::Model
     cfg.gsub! /enable password (\S+) (.*)/, 'enable password <secret hidden> \2'
     cfg.gsub! /^passwd (\S+) (.*)/, 'passwd <secret hidden> \2'
     cfg.gsub! /username (\S+) password (\S+) (.*)/, 'username \1 password <secret hidden> \3'
-    cfg.gsub! /(ikev[12] ((remote|local)-authentication )?pre-shared-key) (\S+)/, '\1 <secret hidden>'
+    cfg.gsub! /(ikev[12] ((remote|local)-authentication )?pre-shared-key( hex)?) (\S+)/, '\1 <secret hidden>'
     cfg.gsub! /^(aaa-server TACACS\+? \(\S+\) host[^\n]*\n(\s+[^\n]+\n)*\skey) \S+$/mi, '\1 <secret hidden>'
     cfg.gsub! /^(aaa-server \S+ \(\S+\) host[^\n]*\n(\s+[^\n]+\n)*\s+key) \S+$/mi, '\1 <secret hidden>'
     cfg.gsub! /ldap-login-password (\S+)/, 'ldap-login-password <secret hidden>'

--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -38,6 +38,7 @@ class ASA < Oxidized::Model
     cfg = cfg.join
     cfg.gsub! /^Configuration has not been modified since last system restart.*\n/, ''
     cfg.gsub! /^Configuration last modified by.*\n/, ''
+    cfg.gsub! /^Start-up time.*\n/, ''
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
1) Hide secrets for ipsec pre-shared-keys specified with "hex" qualifier
2) Remove boot process timer output from "show version" to prevent extraneous commits


<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of pre-shared key configurations for IKEv1 and IKEv2
  - Removed start-up time information from version output to enhance configuration clarity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->