### PR TITLE
[AOSW]: exclude power measurements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - xos: Hide radius accounting secret
 - fsos: Hide AAA and SNMP secrets (@RayaneB35)
 - aos7: fix prompt for version 8.8x. Fixes #3351 (@robertcheramy)
+- aosw: Hide power measurements (@rouven0)
 
 ## [0.31.0 – 2024-11-29]
 

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -117,7 +117,7 @@ class AOSW < Oxidized::Model
       next if line =~ /Output \d Config/i
       next if line =~ /(Tachometers|Temperatures|Voltages)/
       next if line =~ /((Card|CPU) Temperature|Chassis Fan|VMON1[0-9])/
-      next if line =~ /[0-9]+\s+(RPMS?|m?V|C)/i
+      next if line =~ /[0-9]+\s+(RPMS?|m?V|C|W)/i
 
       out << line.strip
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Newer Aruba Models start to include power measurements when running `show inventory`.
Observed and tested on a Aruba 9240 Campus Gateway.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Hidden power measurements for the "aosw" model to enhance output privacy

- **Documentation**
  - Updated CHANGELOG.md to reflect the power measurement hiding change

<!-- end of auto-generated comment: release notes by coderabbit.ai -->