### PR TITLE
Cache git logs to accelerate displaying  the versions of a node in oxidized-web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - fortios: support for FortiADC (@electrocret)
+- output/git: cache commit log to improve performance of oxidized-web. Fixes #3121 (@robertcheramy)
 
 ### Fixed
 - powerconnect: Mask the changing temperature issue for non-stacked switches. Fixes #2088 (@clifcox)

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -87,7 +87,8 @@ find an example how to do this under [examples/podman-compose](/examples/podman-
 
 ## Git performance issues with large device counts
 When you use git to store your configurations, the size of your repository will
-grow over time. This growth can lead to performance issues. To resolve these issues, you should perform a Git garbage collection on your repository.
+grow over time. This growth can lead to performance issues. To resolve these
+issues, you should perform a Git garbage collection on your repository.
 
 Follow these steps to do so:
 
@@ -96,6 +97,10 @@ Follow these steps to do so:
 3. Change directory your oxidized git repository (as configured in oxidized configuration file)
 4. Execute the command `git gc` to run the garbage collection
 5. Restart oxidized - you're done!
+
+Note that slow performance in oxidized-web when listing the versions of a device
+are due to the necessity to go through the whole git log to search for the
+versions. See Issue #3121, the fix will come with oxidized version 0.32.0.
 
 ## Oxidized ignores the changes I made to its git repository
 First of all: you shouldn't manipulate the git repository of oxidized. Don't

--- a/spec/output/git_helper.rb
+++ b/spec/output/git_helper.rb
@@ -1,0 +1,88 @@
+require 'simplecov'
+require 'minitest/autorun'
+require 'mocha/minitest'
+
+require 'oxidized'
+require 'oxidized/output/git'
+
+Oxidized.mgr = Oxidized::Manager.new
+
+class RepoMock
+  attr_reader :commits, :head
+
+  def initialize
+    @commits = []
+  end
+
+  HeadMock = Struct.new(:target)
+  TargetMock = Struct.new(:oid)
+
+  def add_commit(added_files, modified_files, time, oid)
+    @commits.append CommitMock.new(added_files, modified_files, time, oid)
+
+    # #head.target.oid
+    @head = HeadMock.new(TargetMock.new(oid))
+  end
+end
+
+class CommitMock
+  attr_reader :oid, :time, :author, :message, :diff,
+              :added_files, :modified_files
+
+  def initialize(added_files, modified_files, time, oid)
+    @added_files = added_files
+    @modified_files = modified_files
+    @time = time
+    @oid = oid
+    @author =  { email: 'ox@id.iz', time: time, name: 'oxidized' }
+    @message = "Commit ##{oid}"
+    deltas = added_files.map do |file|
+      DeltaMock.new(file, :added)
+    end
+    deltas += modified_files.map do |file|
+      DeltaMock.new(file, :modified)
+    end
+    @diff = DiffMock.new deltas
+  end
+end
+
+class DiffMock
+  def initialize(deltas)
+    @deltas = deltas
+  end
+
+  def each_delta(&)
+    @deltas.each(&)
+  end
+end
+
+class DeltaMock
+  attr_reader :new_file
+
+  def initialize(filename, status)
+    @new_file = { path: filename }
+    @status = status
+  end
+
+  def added?
+    @status == :added
+  end
+
+  def modified?
+    @status == :modified
+  end
+end
+
+class WalkerMock
+  def initialize(repo)
+    @repo = repo
+  end
+
+  def sorting(*); end
+
+  def push(*); end
+
+  def each(&)
+    @repo.commits.reverse_each(&)
+  end
+end

--- a/spec/output/git_spec.rb
+++ b/spec/output/git_spec.rb
@@ -55,7 +55,8 @@ describe Oxidized::Output::Git do
 
     it 'returns a list of hashes' do
       @repo.add_commit(%w[file1 file2], [], Time.new(2001), 'C0001')
-      @repo.add_commit(['file3'], ['file1'], Time.new(2002), 'C0002')
+      @repo.add_commit([], ['file2'], Time.new(2002), 'C0002')
+      @repo.add_commit(['file3'], ['file1'], Time.new(2003), 'C0003')
 
       hashlist = Oxidized::Output::Git.hash_list('file1', '/tmp/o.git')
       _(hashlist.length).must_equal 2
@@ -71,9 +72,6 @@ describe Oxidized::Output::Git do
       CommitMock.any_instance.expects(:diff).never
       hashlist = Oxidized::Output::Git.hash_list('file1', '/tmp/o.git')
       _(hashlist.length).must_equal 2
-
-      # Clean the persistent cache at the end of the test
-      Oxidized::Output::Git.clear_cache
     end
 
     it 'returns recent commits in the right order' do
@@ -96,9 +94,75 @@ describe Oxidized::Output::Git do
     end
   end
 
-  describe '::version' do
+  describe '#version' do
+    after do
+      # Clean the persistent cache at the end of the test
+      Oxidized::Output::Git.clear_cache
+    end
+
     it 'works with single_repo=false' do
-      skip 'no test yet'
+      Oxidized.asetus = Asetus.new
+      Oxidized.config.output.git.single_repo = false
+
+      @repo_group1 = RepoMock.new
+      @repo_group1.add_commit(%w[node1 node2], [], Time.new(2001), 'C0001')
+      @repo_group1.add_commit([], ['node1'], Time.new(2002), 'C0002')
+      Rugged::Repository.expects(:new).with('/tmp/group1.git').returns(@repo_group1)
+      walker = WalkerMock.new(@repo_group1)
+      Rugged::Walker.expects(:new).with(@repo_group1).returns(walker)
+      @mock_node1 = mock('Oxidized::Node')
+      @mock_node1.expects(:repo).returns('/tmp/group1.git')
+      @mock_node1.expects(:name).returns('node1')
+
+      @repo_group2 = RepoMock.new
+      @repo_group2.add_commit(%w[node8 node9], [], Time.new(2008), 'C0008')
+      @repo_group2.add_commit([], ['node9'], Time.new(2009), 'C0009')
+      Rugged::Repository.expects(:new).with('/tmp/group2.git').returns(@repo_group2)
+      walker = WalkerMock.new(@repo_group2)
+      Rugged::Walker.expects(:new).with(@repo_group2).returns(walker)
+      @mock_node8 = mock('Oxidized::Node')
+      @mock_node8.expects(:repo).returns('/tmp/group2.git')
+      @mock_node8.expects(:name).returns('node8')
+
+      git = Oxidized::Output::Git.new
+
+      version_group1_node1 = git.version @mock_node1, 'group1'
+      _(version_group1_node1.length).must_equal 2
+
+      version_group2_node8 = git.version @mock_node8, 'group2'
+      _(version_group2_node8.length).must_equal 1
+    end
+
+    it 'works with single_repo=true' do
+      Oxidized.asetus = Asetus.new
+      Oxidized.config.output.git.single_repo = true
+
+      @repo = RepoMock.new
+      @repo.add_commit(%w[group1/node1 group1/node2],
+                       [], Time.new(2001), 'C0001')
+      @repo.add_commit([], ['group1/node1'], Time.new(2002), 'C0002')
+      @repo.add_commit(%w[group2/node8 group2/node9],
+                       [], Time.new(2008), 'C0008')
+      @repo.add_commit([], ['group2/node9'], Time.new(2009), 'C0009')
+
+      Rugged::Repository.expects(:new).with('/tmp/oxidized.git').returns(@repo).twice
+      walker = WalkerMock.new(@repo)
+      Rugged::Walker.expects(:new).with(@repo).returns(walker).twice
+      @mock_node1 = mock('Oxidized::Node')
+      @mock_node1.expects(:repo).returns('/tmp/oxidized.git')
+      @mock_node1.expects(:name).returns('node1').twice
+
+      @mock_node8 = mock('Oxidized::Node')
+      @mock_node8.expects(:repo).returns('/tmp/oxidized.git')
+      @mock_node8.expects(:name).returns('node8').twice
+
+      git = Oxidized::Output::Git.new
+
+      version_group1_node1 = git.version @mock_node1, 'group1'
+      _(version_group1_node1.length).must_equal 2
+
+      version_group2_node8 = git.version @mock_node8, 'group2'
+      _(version_group2_node8.length).must_equal 1
     end
   end
 end

--- a/spec/output/git_spec.rb
+++ b/spec/output/git_spec.rb
@@ -1,5 +1,4 @@
-require_relative '../spec_helper'
-require 'oxidized/output/git'
+require_relative 'git_helper'
 
 describe Oxidized::Output::Git do
   describe '#yield_repo_and_path' do
@@ -38,6 +37,66 @@ describe Oxidized::Output::Git do
       Oxidized.config.output.git.single_repo = false
       result = @git.send(:yield_repo_and_path, @mock_node, 'testgroup')
       _(result).must_equal ['/tmp/oxidized.git', 'switch-42']
+    end
+  end
+
+  describe '::hash_list' do
+    before do
+      @repo = RepoMock.new
+      Rugged::Repository.stubs(:new).returns(@repo)
+      walker = WalkerMock.new(@repo)
+      Rugged::Walker.stubs(:new).returns(walker)
+    end
+
+    after do
+      # Clean the persistent cache at the end of the test
+      Oxidized::Output::Git.clear_cache
+    end
+
+    it 'returns a list of hashes' do
+      @repo.add_commit(%w[file1 file2], [], Time.new(2001), 'C0001')
+      @repo.add_commit(['file3'], ['file1'], Time.new(2002), 'C0002')
+
+      hashlist = Oxidized::Output::Git.hash_list('file1', '/tmp/o.git')
+      _(hashlist.length).must_equal 2
+    end
+
+    it 'does not walk the logs twice when ran twice' do
+      @repo.add_commit(%w[file1 file2], [], Time.new(2001), 'C0001')
+      @repo.add_commit(['file3'], ['file1'], Time.new(2002), 'C0002')
+
+      hashlist = Oxidized::Output::Git.hash_list('file1', '/tmp/o.git')
+      _(hashlist.length).must_equal 2
+
+      CommitMock.any_instance.expects(:diff).never
+      hashlist = Oxidized::Output::Git.hash_list('file1', '/tmp/o.git')
+      _(hashlist.length).must_equal 2
+
+      # Clean the persistent cache at the end of the test
+      Oxidized::Output::Git.clear_cache
+    end
+
+    it 'returns the new commits in the right sequence' do
+      skip 'not implemented yet'
+      @repo.add_commit(%w[file1 file2], [], Time.new(2001), 'C0001')
+      @repo.add_commit(['file3'], ['file1'], Time.new(2002), 'C0002')
+      hashlist = Oxidized::Output::Git.hash_list('file1', '/tmp/o.git')
+      _(hashlist.length).must_equal 2
+      _(hashlist[0][:oid]).must_equal 'C0002'
+      _(hashlist[1][:oid]).must_equal 'C0001'
+
+      @repo.add_commit(['file3'], %w[file1 file2], Time.new(2003), 'C0003')
+      hashlist = Oxidized::Output::Git.hash_list('file1', '/tmp/o.git')
+      _(hashlist.length).must_equal 3
+      _(hashlist[0][:oid]).must_equal 'C0003'
+      _(hashlist[1][:oid]).must_equal 'C0002'
+      _(hashlist[2][:oid]).must_equal 'C0001'
+    end
+  end
+
+  describe '::version' do
+    it 'works with single_repo=false' do
+      skip 'no test yet'
     end
   end
 end

--- a/spec/output/git_spec.rb
+++ b/spec/output/git_spec.rb
@@ -76,8 +76,7 @@ describe Oxidized::Output::Git do
       Oxidized::Output::Git.clear_cache
     end
 
-    it 'returns the new commits in the right sequence' do
-      skip 'not implemented yet'
+    it 'returns recent commits in the right order' do
       @repo.add_commit(%w[file1 file2], [], Time.new(2001), 'C0001')
       @repo.add_commit(['file3'], ['file1'], Time.new(2002), 'C0002')
       hashlist = Oxidized::Output::Git.hash_list('file1', '/tmp/o.git')
@@ -86,11 +85,14 @@ describe Oxidized::Output::Git do
       _(hashlist[1][:oid]).must_equal 'C0001'
 
       @repo.add_commit(['file3'], %w[file1 file2], Time.new(2003), 'C0003')
+      @repo.add_commit([], %w[file1], Time.new(2004), 'C0004')
       hashlist = Oxidized::Output::Git.hash_list('file1', '/tmp/o.git')
-      _(hashlist.length).must_equal 3
-      _(hashlist[0][:oid]).must_equal 'C0003'
-      _(hashlist[1][:oid]).must_equal 'C0002'
-      _(hashlist[2][:oid]).must_equal 'C0001'
+
+      _(hashlist.length).must_equal 4
+      _(hashlist[0][:oid]).must_equal 'C0004'
+      _(hashlist[1][:oid]).must_equal 'C0003'
+      _(hashlist[2][:oid]).must_equal 'C0002'
+      _(hashlist[3][:oid]).must_equal 'C0001'
     end
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
In order to address the performance issues observed in oxidzed-web when listing the versions of a node, this PR caches git log into memory. At the first time, we still have a slow performance, subsequent calls only need to scan new commits and are *very* much faster.

Closes #3121 