### PR TITLE
arubainstant: fix prompt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fsos: Hide AAA and SNMP secrets (@RayaneB35)
 - aos7: fix prompt for version 8.8x. Fixes #3351 (@robertcheramy)
 - aosw: Hide power measurements (@rouven0)
+- arubainstant: show version prepends a space to prompt when a core file is present. Fixes #3398 (@robertcheramy)
 
 ## [0.31.0 – 2024-11-29]
 

--- a/lib/oxidized/model/arubainstant.rb
+++ b/lib/oxidized/model/arubainstant.rb
@@ -4,7 +4,7 @@ class ArubaInstant < Oxidized::Model
   # Aruba IAP, Instant Controller
 
   comment '# '
-  prompt(/^[\w\:.@-]+[#>] $/)
+  prompt(/^ ?[\w\:.@-]+[#>] $/)
 
   cmd :all do |cfg|
     # Remove command echo and prompt

--- a/spec/model/data/arubainstant:generic:prompt.yaml
+++ b/spec/model/data/arubainstant:generic:prompt.yaml
@@ -1,2 +1,4 @@
 pass:
   - 'AAAA-AP123456# '
+  # Issue #3398: show version prepends a space to prompt when a core file is present
+  - ' AAAA-AP123456# '


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
show version prepends a space to prompt when a core file is present.
Fixes #3398
