### PR TITLE
Simple solution to issue #3413 Removing inserted blank lines from pagnated output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
-
+- powerconnect: Remove undesirable inserted blank lines during pagination. Fixes #3413 (@clifcox)
 
 ## [0.32.0 – 2025-02-17]
 This release fixes a security issue in oxidized-web, which is included in the

--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -5,7 +5,7 @@ class PowerConnect < Oxidized::Model
 
   comment '! '
 
-  expect /^\s*--More--\s+.*$/ do |data, re|
+  expect /\n\s*--More--\s+.*/ do |data, re| # Also grab the blank line above the --More--
     send ' '
     data.sub re, ''
   end


### PR DESCRIPTION

We make the lazy assumption that when you can't turn off pagination with something like "terminal length 0", that Dell always puts an undesirable blank line before the --More-- prompt. :-)

This will make diffs fail between TFTPd and oxidized copies of the same config.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->

Perhaps Closes #3413 ?