### PR TITLE
New Model for Unifi APs, switches, and AirOS APs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- unifiap: new model for Unifi APs, switches, and AirOS APs (@clifcox)
 
 ### Changed
 - fortios: support for FortiADC (@electrocret)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -169,6 +169,7 @@
 |                    |Edgeos                        |[edgeos](/lib/oxidized/model/edgeos.rb)
 |                    |EdgeSwitch                    |[edgeswitch](/lib/oxidized/model/edgeswitch.rb)
 |                    |AirFiber                      |[airfiber](/lib/oxidized/model/airfiber.rb)
+|                    |UnifiAP                       |[unifiap](/lib/oxidized/model/unifiap.rb)              |@clifcox      |Also suports AirOS, and some Unifi switches
 |Uplink              |EP4440-DP                     |[EP4440](/lib/oxidized/model/uplinkolt.rb)             | |Might support all EP4440 series
 |VMWare              |NSX Edge (configuration)      |[nsxconfig](/lib/oxidized/model/nsxconfig.rb)
 |                    |NSX Edge (firewall rules)     |[nsxfirewall](/lib/oxidized/model/nsxfirewall.rb)

--- a/lib/oxidized/model/unifiap.rb
+++ b/lib/oxidized/model/unifiap.rb
@@ -83,7 +83,7 @@ class Unifiap < Oxidized::Model
       @ntpserver = true
       @sync = "Synchronized"
     end
-    comment "SKEWXY!!!!!!!!!!!!!!!    #{@skew}\n" # TEST TEST TEST
+    ""
   end
 
   # Now we can display it all as a banner

--- a/lib/oxidized/model/unifiap.rb
+++ b/lib/oxidized/model/unifiap.rb
@@ -1,0 +1,142 @@
+class Unifiap < Oxidized::Model
+  using Refinements
+
+  # Ubiquiti Unifi AP circa 6.x
+  # Should also work for unfi switches, and airOS, maybe they could be combined.
+  # Since it relies on exec channels, because the interactive session wouldn't
+  # capture all of the system.cfg output, you can't use telnet with this model.
+
+  # Sometimes there's a handy info command that summarizes some device attributes,
+  # but it doesn't seem to be available in exec mode. So we try to build up a similar
+  # list by extracting tidbits from various places. AirOS doesn't have some of these
+  # files, so we  # may have to fall back on other commands, or locations.
+
+  # First get the board model
+  cmd 'head -4 /etc/board.info' do |cfg|
+    @model = Regexp.last_match(1) if cfg =~ /board\.name=(\S+)/i
+    ""
+  end
+
+  # and version
+  cmd 'cat /etc/version' do |cfg|
+    @version = Regexp.last_match(1) if cfg =~ /(\S+)$/i
+    ""
+  end
+
+  # Now the Mac address
+  cmd 'ifconfig eth0' do |cfg|
+    @mac = Regexp.last_match(1) if cfg =~ /eth0\s+Link encap:Ethernet\s+HWaddr\s+(\w+:\w+:\w+:\w+:\w+:\w+)/i
+    ""
+  end
+
+  # Next see if we can get our IP and host name out of /etc/hosts
+  cmd 'cat /etc/hosts' do |cfg|
+    cfg = cfg.split("\n").reject { |line| line[/^\s*(127|0000:0000:0000:0000:0000:0000:0000:0001|0:0:0:0:0:0:0:1|::1)/] }
+    cfg.select do |line|
+      if (match = line.match(/(\d+\.\d+\.\d+\.\d+)\s+(\S+)/))
+        @ip, @hostname = match.captures
+      end
+    end
+    ""
+  end
+
+  # We check here to see if we succeeded with /etc/hosts. If not, then we try again with ifconfig, and /tmp/system.cfg
+  cmd do
+    unless @ip
+      cmd 'ifconfig br0' do |cfg|
+        @ip = Regexp.last_match(1) if cfg =~ /inet addr:\s*(\d+\.\d+\.\d+\.\d+)/i
+      end
+
+      unless @ip
+        cmd 'ifconfig eth0' do |cfg|
+          @ip = Regexp.last_match(1) if cfg =~ /inet addr:\s*(\d+\.\d+\.\d+\.\d+)/i
+        end
+      end
+    end
+
+    unless @hostname
+      cmd 'cat /tmp/system.cfg' do |cfg|
+        @hostname = Regexp.last_match(1) if cfg =~ /resolv.host.1.name=(\S+)/i
+      end
+    end
+    ""
+  end
+
+  # Check if ntpclient is running
+  cmd 'ps wwww' do |cfg|
+    @ntpserver = Regexp.last_match(1) if cfg =~ /bin\/ntpclient.+-h\s*(\S+)/i
+    ""
+  end
+
+  # If it's a Unifi device it may have NTP health indication
+  # If there are other places that Ubiquiti puts these status files, add them here.
+  cmd '[ -e /tmp/run/ntp.ready ] || [ -e /var/run/ntp.ready ] && echo "File(s) exist(s)" || echo "No such file"' do |cfg|
+    if cfg =~ /No such file/i
+      if @ntpserver
+        # Ok, now lets try getting the skew from the output of ntpclient
+        cmd "ntpclient -d -n -c 2 -i0 -h #{@ntpserver}" do |cfg|
+          @skew = ntpskew(cfg)
+        end
+        @sync = !@skew.nil? && @skew.to_f.abs < 1e6 ? "Synchronized" : "FAIL"
+      end
+    else
+      @ntpserver = true
+      @sync = "Synchronized"
+    end
+    comment "SKEWXY!!!!!!!!!!!!!!!    #{@skew}\n" # TEST TEST TEST
+  end
+
+  # Now we can display it all as a banner
+  cmd do
+    out = []
+    out << "*************************"
+    out << "Model:       #{@model}"
+    out << "Version:     #{@version}"
+    out << "MAC Address: #{@mac}"
+    out << "IP Address:  #{@ip}"
+    out << "Hostname:    #{@hostname}"
+    out << "NTP:         #{@sync}" if @ntpserver
+    out << "*************************"
+    comment out.join("\n") + "\n"
+  end
+
+  # Followed by the board info
+  cmd 'cat /etc/board.info' do |cfg|
+    cfg = "#\n# Board Info:\n#\n" + cfg
+    comment cfg
+  end
+
+  # Lastly the system config
+  cmd 'cat /tmp/system.cfg' do |cfg|
+    cfg = "#\n# System Config:\n#\n" + cfg
+    cfg + "\n"
+  end
+
+  cmd :secret do |cfg|
+    cfg.gsub! /^((?:users|snmp\.(?:user|community))\.\d+\.password)=.+/, "# \\1=<hidden>"
+    cfg
+  end
+
+  cfg :ssh do
+    exec true # Don't run shell, run each command in exec channel
+  end
+
+  # NTPskew: Return the skew in micro seconds from the ntpclient output
+  def ntpskew(cfg)
+    index = skew = nil
+
+    cfg.each_line do |line|
+      # Look for the header just before the stats line, and find which number is skew
+      if line.match(/^\s*[a-z]+\s+[a-z]+\s+[a-z]+\s+[a-z]+/i)
+        words = line.split
+        index = words.map(&:downcase).index("skew")
+      end
+      # Now look for the single stats line and grab the skew
+      if !index.nil? && line.match(/^\s*[\d.]+\s+[\d.]+\s+[\d.]+\s+[\d.]+/)
+        numbers = line.split
+        skew = numbers[index]
+      end
+    end
+    skew
+  end
+end


### PR DESCRIPTION
Here is a new model for several Ubiquiti devices. Probably if it has /tmp/system.cfg, and /etc/board_info it has a decent chance of working. The hardest part was duplicating the output of the "info" command that is seemingly an internal command in the shell, or just not available in the AIrOS versions I tried.

    Clif

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Suggested model for issue #3430