### PR TITLE
srosmd: add ignore regex for 64-bit system up time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix frozen string literals (@robertcheramy)
 - powerconnect: Cleanup login/logout logic. Fixes #3437 (@clifcox)
 - aos7: remove extra lines occuring when `show hardware-info` runs slow (@rouven0)
+- srosmd: add ignore regex for 64-bit system uptime (@emiliaaah)
 
 ## [0.32.2 – 2025-02-27]
 This patch release mainly fixes the docker building process, wich resulted in

--- a/lib/oxidized/model/srosmd.rb
+++ b/lib/oxidized/model/srosmd.rb
@@ -26,7 +26,7 @@ class SROSMD < Oxidized::Model
     #
     # Strip uptime.
     #
-    cfg.sub! /^System Up Time.*\n/, ''
+    cfg.gsub! /^System Up Time.*\n/, ''
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Somewhere between version `B-23.7.R2` and `B-23.10.R2` on the Nokia 7750 SR, a field for 64-bit system uptime was added. Before this didn't get filtered, so this PR fixes that.

The system information now includes both system uptime fields like this:
```
...
System Up Time         : 1 days, 01:01:01.11 (hr:min:sec)
System Up Time (64-bit): 1 days, 01:01:01.11 (hr:min:sec)
...
```
