### PR TITLE
HTTP Digest Auth password encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+- digest auth handles special characters in passwords by itself (no need to url encode them manually) (@einglasvollkakao)
+
+
 ## [0.32.2 – 2025-02-27]
 This patch release mainly fixes the docker building process, wich resulted in
 0.32.1 not beeing built.

--- a/lib/oxidized/input/http.rb
+++ b/lib/oxidized/input/http.rb
@@ -59,7 +59,7 @@ module Oxidized
 
       if res.code == '401' && res['www-authenticate']&.include?('Digest')
         uri.user = @username
-        uri.password = @password
+        uri.password = URI.encode_www_form_component(@password)
         Oxidized.logger.debug "Server requires Digest authentication"
         auth = Net::HTTP::DigestAuth.new.auth_header(uri, res['www-authenticate'], 'GET')
 


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
With this PR the password string used for digest authentication gets automatically url encoded which is needed if you have special characters in your password. 
If you don't do this you just get a `URI::InvalidComponentError with msg "bad password component"` error.
