### PR TITLE
3437 clean up login logout code for powerconnect.rb

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- model for Unifi / AirOS APs and some Unifi switches. Re: #3430 (@clifcox)
 
 ### Changed
 - docker image: updated github CI to explicitly build tag versions (@robertcheramy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - powerconnect: Mask the changing temperature issue for non-stacked switches. Fixes #2088 (@clifcox)
-
+- powerconnect: Cleanup login/logout logic. Fixes #3437 (@clifcox)
 
 ## [0.32.2 – 2025-02-27]
 This patch release mainly fixes the docker building process, wich resulted in

--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -34,7 +34,8 @@ class PowerConnect < Oxidized::Model
   end
 
   cmd 'show running-config' do |cfg|
-    cfg.sub(/^(sflow \S+ destination owner \S+ timeout )\d+$/, '! \1<timeout>')
+    cfg.sub(/^(sflow \S+ destination owner \S+ timeout )\d+$/, '! \1<timeout>') # Remove changing timeout
+    cfg
   end
 
   cfg :telnet, :ssh do
@@ -52,10 +53,15 @@ class PowerConnect < Oxidized::Model
       end
     end
 
-    post_login "terminal datadump"
-    post_login "terminal length 0"
-    pre_logout "logout"
-    pre_logout "exit"
+    post_login do
+      cmd "terminal datadump"
+      cmd "terminal length 0"
+    end
+    pre_logout do
+      send "exit\r"
+      sleep(0.25)
+      send "logout\r"
+    end
   end
 
   def clean(cfg)

--- a/lib/oxidized/model/powerconnect.rb
+++ b/lib/oxidized/model/powerconnect.rb
@@ -35,7 +35,6 @@ class PowerConnect < Oxidized::Model
 
   cmd 'show running-config' do |cfg|
     cfg.sub(/^(sflow \S+ destination owner \S+ timeout )\d+$/, '! \1<timeout>') # Remove changing timeout
-    cfg
   end
 
   cfg :telnet, :ssh do


### PR DESCRIPTION
This makes it more clear (at least to me ;-) which commands are waiting for a prompt and which ones are not, (sends). I looked for documentation on post_login, and pre_logout but didn't find anything.

Also, I'm pretty sure the cli logout command needs to come after the last exit, not before. So I switched the order there, and added a little delay just for good luck. Lastly I added a comment on filtering out a timeout.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->

Re: #3437