### PR TITLE
aos7: remove extra lines when hw-info runs slow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - powerconnect: Mask the changing temperature issue for non-stacked switches. Fixes #2088 (@clifcox)
 - Fix frozen string literals (@robertcheramy)
 - powerconnect: Cleanup login/logout logic. Fixes #3437 (@clifcox)
+- aos7: remove extra lines occuring when `show hardware-info` runs slow (@rouven0)
 
 ## [0.32.2 – 2025-02-27]
 This patch release mainly fixes the docker building process, wich resulted in

--- a/lib/oxidized/model/aos7.rb
+++ b/lib/oxidized/model/aos7.rb
@@ -26,6 +26,9 @@ class AOS7 < Oxidized::Model
   end
 
   cmd 'show hardware-info' do |cfg|
+    # Remove extra lines occuring when the command runs slow
+    cfg.gsub! /^Please wait...\n/, ''
+    cfg.gsub! /^\n\n\n/, "\n\n"
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
When `show hardware-info` runs slow on alcatel-lucent devices. An extra 'Please Wait'- and a newline is printed. This should not appear in the saved configuration.

