### PR TITLE
Strip double uptime from Nokia SROS (#3315)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Fix frozen string literals (@robertcheramy)
 - powerconnect: Cleanup login/logout logic. Fixes #3437 (@clifcox)
 - aos7: remove extra lines occuring when `show hardware-info` runs slow (@rouven0)
+- srosmd: strip 64-bit uptime from config (@wdoekes)
 
 ## [0.32.2 – 2025-02-27]
 This patch release mainly fixes the docker building process, wich resulted in

--- a/lib/oxidized/model/srosmd.rb
+++ b/lib/oxidized/model/srosmd.rb
@@ -26,7 +26,7 @@ class SROSMD < Oxidized::Model
     #
     # Strip uptime.
     #
-    cfg.sub! /^System Up Time.*\n/, ''
+    cfg.gsub! /^System Up Time[^\n]*\n/, ''
     comment cfg
   end
 


### PR DESCRIPTION
Certain devices show two uptimes as seen in [1]:

    System Name            : NS123456789
    System Type            : 7750 SR-1-24D
    Chassis Topology       : Standalone
    System Version         : C-24.10.R1
    System Contact         :\x20
    System Location        :\x20
    System Coordinates     :\x20
    System Up Time         : 0 days, 00:23:28.02 (hr:min:sec)
    System Up Time (64-bit): 0 days, 00:23:28.02 (hr:min:sec)

Make sure both are stripped. Previously only the first one would be removed.

[1] https://github.com/user-attachments/files/17832953/srosmd_7750-SR-1-24D_24.10.R1.yaml.txt

Fixes: #3315

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

See commit message.