### PR TITLE
ios: Hide aaa server-key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fortios: support for FortiADC (@electrocret)
 - output/git: cache commit log to improve performance of oxidized-web. Fixes #3121 (@robertcheramy)
 - digest auth handles special characters in passwords by itself (no need to url encode them manually) (@einglasvollkakao)
+- ios: hide secret key of aaa radius (@martinberg, @robertcheramy)
 
 ### Fixed
 - powerconnect: Mask the changing temperature issue for non-stacked switches. Fixes #2088 (@clifcox)

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -50,6 +50,7 @@ class IOS < Oxidized::Model
     cfg.gsub! /^( +client \S+ server-key \d) (.*)$/, '\\1 <secret hidden>'
     cfg.gsub! /^( +domain-password) \S+ ?(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^( +pre-shared-key).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(.*server-key(?:\s+\d+)?\s+(\S+))/, '\\1 <secret hidden>'
     cfg
   end
 

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -50,7 +50,7 @@ class IOS < Oxidized::Model
     cfg.gsub! /^( +client \S+ server-key \d) (.*)$/, '\\1 <secret hidden>'
     cfg.gsub! /^( +domain-password) \S+ ?(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^( +pre-shared-key).*/, '\\1 <configuration removed>'
-    cfg.gsub! /^(.*server-key(?:\s+\d+)?\s+(\S+))/, '\\1 <secret hidden>'
+    cfg.gsub! /^(.*server-key(?: \d)?) \S+/, '\\1 <secret hidden>'
     cfg
   end
 

--- a/spec/model/data/ios:C9200L-24P-4G_17.09.04a:output.txt
+++ b/spec/model/data/ios:C9200L-24P-4G_17.09.04a:output.txt
@@ -69,6 +69,9 @@ no aaa accounting system guarantee-first
 aaa session-id common
 !
 !
+aaa server radius dynamic-author
+ client 10.10.10.10 server-key AAAAAAAAAABBBBBBBBBB
+ client 10.10.20.20 server-key 7 AAAAAAAAAABBBBBBBBBB
 !
 clock timezone CET 1 0
 clock summer-time CEST recurring last Sun Mar 2:00 last Sun Oct 2:00

--- a/spec/model/data/ios:C9200L-24P-4G_17.09.04a:simulation.yaml
+++ b/spec/model/data/ios:C9200L-24P-4G_17.09.04a:simulation.yaml
@@ -170,6 +170,9 @@ commands:
     aaa session-id common
     !
     !
+    aaa server radius dynamic-author
+     client 10.10.10.10 server-key AAAAAAAAAABBBBBBBBBB
+     client 10.10.20.20 server-key 7 AAAAAAAAAABBBBBBBBBB
     !
     clock timezone CET 1 0
     clock summer-time CEST recurring last Sun Mar 2:00 last Sun Oct 2:00


### PR DESCRIPTION
Remove secret for aaa server

Config could look like this
```
aaa server radius dynamic-author
  client 10.10.10.10 server-key keytobehidden
  client 10.10.20.20 server-key 7 0709285E4B1E18091B5C0814
```

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
