### PR TITLE
netgear handle pager

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fortios: support for FortiADC (@electrocret)
 - output/git: cache commit log to improve performance of oxidized-web. Fixes #3121 (@robertcheramy)
 - digest auth handles special characters in passwords by itself (no need to url encode them manually) (@einglasvollkakao)
+- netgear: add pager-handler workaround, fixes: #2394 and #3341 (@candlerb, @syn-bit)
 
 ### Fixed
 - powerconnect: Mask the changing temperature issue for non-stacked switches. Fixes #2088 (@clifcox)

--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -4,6 +4,12 @@ class Netgear < Oxidized::Model
   comment '!'
   prompt /^\(?[\w \-+.]+\)? ?[#>] ?$/
 
+  # Handle pager for "show version" on old Netgear models: #2394
+  expect /^--More-- or \(q\)uit$/ do |data, re|
+    send ' '
+    data.sub re, ''
+  end
+
   cmd :secret do |cfg|
     cfg.gsub!(/password (\S+)/, 'password <hidden>')
     cfg.gsub!(/encrypted (\S+)/, 'encrypted <hidden>')


### PR DESCRIPTION
Add pager handler to workaround an issue on some Netgear models that disabling the pager does not work for config dumps.