### PR TITLE
ironware model: gracefully handle three-digit temps in temp masking substitutions

### DIFF
--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -38,6 +38,7 @@ class IronWare < Oxidized::Model
     cfg.gsub! /\d* deg C/, '' # Fix for ADX temperature reporting
     cfg.gsub! /([\[]*)1([\]]*)<->([\[]*)2([\]]*)(<->([\[]*)3([\]]*))*/, ''
     cfg.gsub! /\d{2}\.\d deg-C/, 'XX.X deg-C'
+    cfg.gsub! /1XX\.X/, 'XX.X'
     if cfg.include? "TEMPERATURE"
       sc = StringScanner.new cfg
       out = ''


### PR DESCRIPTION
… to create unnecessary config commits when 100 deg-C threshold is crossed in either direction.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Gracefully handle three-digit temperatures in ironware model config output masking. 

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
