### PR TITLE
Change oxidized-web configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
+This release changes the way to configure oxidized-web. The old `rest`
+configuration is still supported but deprecated. See
+[docs/Configuration.md](/docs/Configuration.md#oxidized-web-RESTful-API-and-web-interface).
+
 ### Added
 - unifiap: new model for Unifi APs, switches, and AirOS APs (@clifcox)
 - github: Issue templates for bugs, feature requests and support requests (@robertcheramy)
@@ -14,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fortios: support for FortiADC (@electrocret)
 - output/git: cache commit log to improve performance of oxidized-web. Fixes #3121 (@robertcheramy)
 - digest auth handles special characters in passwords by itself (no need to url encode them manually) (@einglasvollkakao)
+- changed the configuration for oxidized-web from rest: to extentions.oxidized-web (@robertcheramy)
 - netgear: add pager-handler workaround, fixes: #2394 and #3341 (@candlerb, @syn-bit)
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 This release changes the way to configure oxidized-web. The old `rest`
-configuration is still supported but deprecated. See
-[docs/Configuration.md](/docs/Configuration.md#oxidized-web-RESTful-API-and-web-interface).
+configuration is still supported but deprecated. The new configuration works
+with oxidized-web 0.16.0 or later.
+See [docs/Configuration.md](/docs/Configuration.md#oxidized-web-RESTful-API-and-web-interface).
 
 ### Added
 - unifiap: new model for Unifi APs, switches, and AirOS APs (@clifcox)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ configuration is still supported but deprecated. See
 - fortios: support for FortiADC (@electrocret)
 - output/git: cache commit log to improve performance of oxidized-web. Fixes #3121 (@robertcheramy)
 - digest auth handles special characters in passwords by itself (no need to url encode them manually) (@einglasvollkakao)
-- changed the configuration for oxidized-web from rest: to extentions.oxidized-web (@robertcheramy)
+- changed the configuration for oxidized-web from rest: to extensions.oxidized-web (@robertcheramy)
 - netgear: add pager-handler workaround, fixes: #2394 and #3341 (@candlerb, @syn-bit)
 
 ### Fixed

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -2,9 +2,15 @@
 
 ## Debugging
 
-In case a model plugin doesn't work correctly (ios, procurve, etc.), you can enable live debugging of SSH/Telnet sessions. Just add a `debug` option containing the value true to the `input` section. The log files will be created depending on the parent directory of the logfile option.
+In case a model plugin doesn't work correctly (ios, procurve, etc.), you can
+enable live debugging of SSH/Telnet sessions. Just add a `debug` option
+containing the value true to the `input` section. The log files will be created
+depending on the parent directory of the logfile option.
 
-The following example will log an active ssh/telnet session `/home/oxidized/.config/oxidized/log/<IP-Address>-<PROTOCOL>`. The file will be truncated on each consecutive ssh/telnet session, so you need to put a `tailf` or `tail -f` on that file!
+The following example will log an active ssh/telnet session
+`/home/oxidized/.config/oxidized/log/<IP-Address>-<PROTOCOL>`. The file will be
+truncated on each consecutive ssh/telnet session, so you need to put a `tailf`
+or `tail -f` on that file!
 
 ```yaml
 log: /home/oxidized/.config/oxidized/log
@@ -22,7 +28,9 @@ input:
 
 ## Privileged mode
 
-To start privileged mode before pulling the configuration, Oxidized needs to send the enable command. You can globally enable this, by adding the following snippet to the global section of the configuration file.
+To start privileged mode before pulling the configuration, Oxidized needs to
+send the enable command. You can globally enable this, by adding the following
+snippet to the global section of the configuration file.
 
 ```yaml
 vars:
@@ -31,14 +39,17 @@ vars:
 
 ## Removing secrets
 
-To strip out secrets from configurations before storing them, Oxidized needs the `remove_secret` flag. You can globally enable this by adding the following snippet to the global section of the configuration file.
+To strip out secrets from configurations before storing them, Oxidized needs the
+`remove_secret` flag. You can globally enable this by adding the following
+snippet to the global section of the configuration file.
 
 ```yaml
 vars:
   remove_secret: true
 ```
 
-Device models that contain substitution filters to remove sensitive data will now be run on any fetched configuration.
+Device models that contain substitution filters to remove sensitive data will
+now be run on any fetched configuration.
 
 As a partial example from ios.rb:
 
@@ -56,7 +67,9 @@ The above strips out snmp community strings from your saved configs.
 
 ## Disabling SSH exec channels
 
-Oxidized uses exec channels to make information extraction simpler, but there are some situations where this doesn't work well, e.g. configuring devices. This feature can be turned off by setting the `ssh_no_exec`
+Oxidized uses exec channels to make information extraction simpler, but there
+are some situations where this doesn't work well, e.g. configuring devices. This
+feature can be turned off by setting the `ssh_no_exec`
 variable.
 
 ```yaml
@@ -66,7 +79,11 @@ vars:
 
 ## Disabling SSH keepalives
 
-Oxidized SSH input makes use of SSH keepalives to prevent timeouts from slower devices and to quickly tear down stale sessions in larger deployments. There have been reports of SSH keepalives breaking compatibility with certain OS types. They can be disabled using the `ssh_no_keepalive` variable on a per-node basis (by specifying it in the source) or configured application-wide.
+Oxidized SSH input makes use of SSH keepalives to prevent timeouts from slower
+devices and to quickly tear down stale sessions in larger deployments. There
+have been reports of SSH keepalives breaking compatibility with certain OS
+types. They can be disabled using the `ssh_no_keepalive` variable on a per-node
+basis (by specifying it in the source) or configured application-wide.
 
 ```yaml
 vars:
@@ -84,9 +101,12 @@ vars:
 
 ## Public Key Authentication with SSH
 
-Instead of password-based login, Oxidized can make use of key-based SSH authentication.
+Instead of password-based login, Oxidized can make use of key-based SSH
+authentication.
 
-You can tell Oxidized to use one or more private keys globally, or specify the key to be used on a per-node basis. The latter can be done by mapping the `ssh_keys` variable through the active source.
+You can tell Oxidized to use one or more private keys globally, or specify the
+key to be used on a per-node basis. The latter can be done by mapping the
+`ssh_keys` variable through the active source.
 
 Global:
 
@@ -108,7 +128,8 @@ vars_map:
 # ...
 ```
 
-If you are using a non-standard path, especially when copying the private key via a secured channel, make sure that the permissions are set correctly:
+If you are using a non-standard path, especially when copying the private key
+via a secured channel, make sure that the permissions are set correctly:
 
 ```bash
 foo@bar:~$ ls -la ~/.ssh/
@@ -120,15 +141,20 @@ drwx------ 5 oxidized oxidized 4096 Mar 13 21:40 ..
 -rw-r--r-- 1 oxidized oxidized   94 Mar 13 17:02 id_ed25519.pub
 ```
 
-Finally, multiple private keys can be specified as an array of file paths, such as `["~/.ssh/id_rsa", "~/.ssh/id_another_rsa"]`.
+Finally, multiple private keys can be specified as an array of file paths, such
+as `["~/.ssh/id_rsa", "~/.ssh/id_another_rsa"]`.
 
 ## SSH Proxy Command
 
-Oxidized can `ssh` through a proxy as well. To do so we just need to set `ssh_proxy` variable with the proxy host information and optionally set the `ssh_proxy_port` with the SSH port if it is not listening on port 22.
+Oxidized can `ssh` through a proxy as well. To do so we just need to set
+`ssh_proxy` variable with the proxy host information and optionally set the
+`ssh_proxy_port` with the SSH port if it is not listening on port 22.
 
-This can be provided on a per-node basis by mapping the proper fields from your source.
+This can be provided on a per-node basis by mapping the proper fields from your
+source.
 
-An example for a `csv` input source that maps the 4th field as the `ssh_proxy` value and the 5th field as `ssh_proxy_port`.
+An example for a `csv` input source that maps the 4th field as the `ssh_proxy`
+value and the 5th field as `ssh_proxy_port`.
 
 ```yaml
 # ...
@@ -144,9 +170,12 @@ vars_map:
 
 ## SSH enabling legacy algorithms
 
-When connecting to older firmware over SSH, it is sometimes necessary to enable legacy/disabled settings like KexAlgorithms, HostKeyAlgorithms, MAC or the Encryption.
+When connecting to older firmware over SSH, it is sometimes necessary to enable
+legacy/disabled settings like KexAlgorithms, HostKeyAlgorithms, MAC or the
+Encryption.
 
-These settings can be provided on a per-node basis by mapping the ssh_kex, ssh_host_key, ssh_hmac and the ssh_encryption fields from you source.
+These settings can be provided on a per-node basis by mapping the ssh_kex,
+ssh_host_key, ssh_hmac and the ssh_encryption fields from you source.
 
 ```yaml
 # ...
@@ -164,7 +193,9 @@ vars_map:
 
 ## FTP Passive Mode
 
-Oxidized uses ftp passive mode by default. Some devices require passive mode to be disabled. To do so, we can set `input.ftp.passive` to false - this will make use of FTP active mode.
+Oxidized uses ftp passive mode by default. Some devices require passive mode to
+be disabled. To do so, we can set `input.ftp.passive` to false - this will make
+use of FTP active mode.
 
 ```yaml
 input:
@@ -207,7 +238,21 @@ crash:
 vars:
   enable: S3cr3tx
 groups: {}
-rest: 127.0.0.1:8888
+extentions:
+  oxidized-web:
+    load: true
+    # Bind to any IPv4 interface
+    listen: 0.0.0.0
+    # Bind to port 8888 (default)
+    port: 8888
+    # Prefix prod to the URL, so http://oxidized.full.domain/prod/
+    url_prefix: prod
+    # virtual hosts to listen to (others will be denied)
+    vhosts:
+      - localhost
+      - 127.0.0.1
+      - oxidized
+      - oxidized.full.domain
 pid: ~/.config/oxidized/oxidized.pid
 input:
   default: ssh, telnet
@@ -337,35 +382,92 @@ From least to most important:
 
 More important options overwrite less important ones if they are set.
 
-## RESTful API and Web Interface
+## oxidized-web: RESTful API and web interface
 
-The RESTful API and Web Interface is enabled by configuring the `rest:` parameter in the config file.  This parameter can optionally contain a relative URI.
+The RESTful API and web interface are enabled by installing the `oxidized-web`
+gem and configuring the `extentions.oxidized-web:` section in the configuration
+file. You can set the following parameter:
+- load: `true`/`false`: Enables or disables the `oxidized-web` extention
+  (default: `false`)
+- listen: Specifies the interface to bind to (default: `127.0.0.1`). Valid
+  options:
+  - `127.0.0.1`: Allows IPv4 connections from localhost only
+  - `'[::1]'`: Allows IPv6 connections from localhost only
+  - `<IPv4-Address>` or `'[<IPv6-Address>]'`: Binds to a specific interface
+  - `0.0.0.0`: Binds to any IPv4 interface
+  - `'[::]'`:  Binds to any IPv4 and IPv6 interface
+- port: Specifies the TCP port to listen to (default: `8888`)
+- prefix: Defines a URL prefix (default: no prefix)
+- vhosts: A list of virtual hosts to listen to. If not specified, it will
+  respond to any virtual host.
+
+> [!NOTE]
+> The old syntax `rest: 127.0.0.1:8888/prefix` is still supported but
+> deprecated. It produces a warning and won't be suported in future releases.
+
 
 ```yaml
 # Listen on http://[::1]:8888/
-rest: "[::1]:8888"
+extentions:
+  oxidized-web:
+    load: true
+    listen: '[::1]'
+    port: 8888
 ```
 
 ```yaml
 # Listen on http://127.0.0.1:8888/
-rest: 127.0.0.1:8888
+extentions:
+  oxidized-web:
+    load: true
+    listen: 127.0.0.1
+    port: 8888
 ```
 
 ```yaml
 # Listen on http://[2001:db8:0:face:b001:0:dead:beaf]:8888/oxidized/
-rest: "[2001:db8:0:face:b001:0:dead:beaf]:8888"
+extentions:
+  oxidized-web:
+    load: true
+    listen: '[2001:db8:0:face:b001:0:dead:beaf]'
+    port: 8888
+    url_prefix: oxidized
 ```
 
 ```yaml
 # Listen on http://10.0.0.1:8000/oxidized/
-rest: 10.0.0.1:8000/oxidized
+extentions:
+  oxidized-web:
+    load: true
+    listen: 10.0.0.1
+    port: 8000
+    url_prefix: oxidized
+```
+
+```yaml
+# Listen on any interface to http://oxidized.rocks:8888 and
+# http://oxidized:8888
+extentions:
+  oxidized-web:
+    load: true
+    listen: '[::]'
+    url_prefix: oxidized
+    vhosts:
+     - oxidized.rocks
+     - oxidized
 ```
 
 ## Triggered backups
 
-A node can be moved to head-of-queue via the REST API `GET/POST /node/next/[NODE]`. This can be useful to immediately schedule a fetch of the configuration after some other event such as a syslog message indicating a configuration update on the device.
+A node can be moved to head-of-queue via the REST API `GET/PUT
+/node/next/[NODE]`. This can be useful to immediately schedule a fetch of the
+configuration after some other event such as a syslog message indicating a
+configuration update on the device.
 
-In the default configuration this node will be processed when the next job worker becomes available, it could take some time if existing backups are in progress. To execute moved jobs immediately a new job can be added automatically:
+In the default configuration this node will be processed when the next job
+worker becomes available, it could take some time if existing backups are in
+progress. To execute moved jobs immediately a new job can be added
+automatically:
 
 ```yaml
 next_adds_job: true
@@ -375,7 +477,10 @@ This will allow for a more timely fetch of the device configuration.
 
 ## Disabling DNS resolution
 
-In some instances it might not be desirable to attempt to resolve names of nodes. One such use case is when nodes are accessed through an SSH proxy, where the remote end resolves the names differently than the host on which Oxidized runs would.
+In some instances it might not be desirable to attempt to resolve names of
+nodes. One such use case is when nodes are accessed through an SSH proxy, where
+the remote end resolves the names differently than the host on which Oxidized
+runs would.
 
 Names can instead be passed verbatim to the input:
 

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -408,6 +408,10 @@ file. You can set the following parameter:
 > If the `rest` configuration is used, the extensions.oxidized-web will be
 > ignored.
 
+> [!NOTE]
+> You need oxidized-web version 0.16.0 or later to use the
+> extentions.oxidized-web configuration
+
 
 ```yaml
 # Listen on http://[::1]:8888/

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -238,7 +238,7 @@ crash:
 vars:
   enable: S3cr3tx
 groups: {}
-extentions:
+extensions:
   oxidized-web:
     load: true
     # Bind to any IPv4 interface
@@ -385,30 +385,33 @@ More important options overwrite less important ones if they are set.
 ## oxidized-web: RESTful API and web interface
 
 The RESTful API and web interface are enabled by installing the `oxidized-web`
-gem and configuring the `extentions.oxidized-web:` section in the configuration
+gem and configuring the `extensions.oxidized-web:` section in the configuration
 file. You can set the following parameter:
-- load: `true`/`false`: Enables or disables the `oxidized-web` extention
+- `load`: `true`/`false`: Enables or disables the `oxidized-web` extension
   (default: `false`)
-- listen: Specifies the interface to bind to (default: `127.0.0.1`). Valid
+- `listen`: Specifies the interface to bind to (default: `127.0.0.1`). Valid
   options:
   - `127.0.0.1`: Allows IPv4 connections from localhost only
   - `'[::1]'`: Allows IPv6 connections from localhost only
   - `<IPv4-Address>` or `'[<IPv6-Address>]'`: Binds to a specific interface
   - `0.0.0.0`: Binds to any IPv4 interface
   - `'[::]'`:  Binds to any IPv4 and IPv6 interface
-- port: Specifies the TCP port to listen to (default: `8888`)
-- prefix: Defines a URL prefix (default: no prefix)
-- vhosts: A list of virtual hosts to listen to. If not specified, it will
+- `port`: Specifies the TCP port to listen to (default: `8888`)
+- `url_prefix`: Defines a URL prefix (default: no prefix)
+- `vhosts`: A list of virtual hosts to listen to. If not specified, it will
   respond to any virtual host.
 
 > [!NOTE]
 > The old syntax `rest: 127.0.0.1:8888/prefix` is still supported but
 > deprecated. It produces a warning and won't be suported in future releases.
+>
+> If the `rest` configuration is used, the extensions.oxidized-web will be
+> ignored.
 
 
 ```yaml
 # Listen on http://[::1]:8888/
-extentions:
+extensions:
   oxidized-web:
     load: true
     listen: '[::1]'
@@ -417,7 +420,7 @@ extentions:
 
 ```yaml
 # Listen on http://127.0.0.1:8888/
-extentions:
+extensions:
   oxidized-web:
     load: true
     listen: 127.0.0.1
@@ -426,7 +429,7 @@ extentions:
 
 ```yaml
 # Listen on http://[2001:db8:0:face:b001:0:dead:beaf]:8888/oxidized/
-extentions:
+extensions:
   oxidized-web:
     load: true
     listen: '[2001:db8:0:face:b001:0:dead:beaf]'
@@ -436,7 +439,7 @@ extentions:
 
 ```yaml
 # Listen on http://10.0.0.1:8000/oxidized/
-extentions:
+extensions:
   oxidized-web:
     load: true
     listen: 10.0.0.1
@@ -447,7 +450,7 @@ extentions:
 ```yaml
 # Listen on any interface to http://oxidized.rocks:8888 and
 # http://oxidized:8888
-extentions:
+extensions:
   oxidized-web:
     load: true
     listen: '[::]'

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -35,13 +35,15 @@ module Oxidized
       asetus.default.timeout       = 20
       asetus.default.retries       = 3
       asetus.default.prompt        = /^([\w.@-]+[#>]\s?)$/
-      asetus.default.rest          = '127.0.0.1:8888' # or false to disable
       asetus.default.next_adds_job = false            # if true, /next adds job, so device is fetched immmeiately
       asetus.default.vars          = {}               # could be 'enable'=>'enablePW'
       asetus.default.groups        = {}               # group level configuration
       asetus.default.group_map     = {}               # map aliases of groups to names
       asetus.default.models        = {}               # model level configuration
       asetus.default.pid           = File.join(Oxidized::Config::ROOT, 'pid')
+
+      # Extentions
+      asetus.default.extentions['oxidized-web'].load = true
 
       asetus.default.crash.directory = File.join(Oxidized::Config::ROOT, 'crashes')
       asetus.default.crash.hostnames = false

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -43,7 +43,7 @@ module Oxidized
       asetus.default.pid           = File.join(Oxidized::Config::ROOT, 'pid')
 
       # Extentions
-      asetus.default.extentions['oxidized-web'].load = true
+      asetus.default.extensions['oxidized-web'].load = false
 
       asetus.default.crash.directory = File.join(Oxidized::Config::ROOT, 'crashes')
       asetus.default.crash.hostnames = false

--- a/lib/oxidized/core.rb
+++ b/lib/oxidized/core.rb
@@ -23,35 +23,24 @@ module Oxidized
       end
       Signals.register_signal('HUP', reload_proc)
 
-      # Load extentions, currently only oxidized-web
+      # Load extensions, currently only oxidized-web
       # We have different namespaces for oxidized-web, which needs to be
-      # adressed if we need a generic way to load extentions:
+      # adressed if we need a generic way to load extensions:
       # - gem: oxidized-web
       # - module: Oxidized::API
       # - path: oxidized/web
       # - entrypoint: Oxidized::API::Web.new(nodes, configuration)
 
-      # Warn about deprecated configuration
-      if Oxidized.config.rest? &&
-         Oxidized.config.extentions.has_key?('oxidized-web')
-        Oxidized.logger.warn(
-          'configuration: both "rest" and "extentions.oxidized-web" are ' \
-          'defined. "extentions.oxidized-web" will be used, remove "rest"'
-        )
-      end
-
       # Initialize oxidized-web if requested
-      if Oxidized.config.extentions.has_key?('oxidized-web')
-        if Oxidized.config.extentions['oxidized-web'].load?
-          # This comment stops rubocop complaining about Style/IfUnlessModifier
-          configuration = Oxidized.config.extentions['oxidized-web']
-        end
-      elsif Oxidized.config.rest?
+      if Oxidized.config.has_key? 'rest'
         Oxidized.logger.warn(
-          'configuration: "rest" is depreacated. Migrate to ' \
-          '"extentions.oxidized-web"'
+          'configuration: "rest" is deprecated. Migrate to ' \
+          '"extensions.oxidized-web" and remove "rest" from the configuration'
         )
         configuration = Oxidized.config.rest
+      elsif Oxidized.config.extensions['oxidized-web'].load?
+        # This comment stops rubocop complaining about Style/IfUnlessModifier
+        configuration = Oxidized.config.extensions['oxidized-web']
       end
 
       if configuration
@@ -60,7 +49,7 @@ module Oxidized
         rescue LoadError
           raise OxidizedError,
                 'oxidized-web not found: install it or disable it by ' \
-                'removing "rest" and "extentions.oxidized-web" from your ' \
+                'removing "rest" and "extensions.oxidized-web" from your ' \
                 'configuration'
         end
         @rest = API::Web.new nodes, configuration

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -58,6 +58,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov',           '~> 0.22.0'
 
   # Dependencies on optional libraries, used for unit tests & development
-  s.add_development_dependency 'oxidized-web',        '>= 0.15.0'
+  s.add_development_dependency 'oxidized-web',        '>= 0.16.0'
   s.add_development_dependency 'sequel',              '>= 5.63.0', '<= 5.90.0'
 end


### PR DESCRIPTION
This Pull Request cannot be merged into master until the PR https://github.com/ytti/oxidized-web/pull/325 has been released into oxidized-web, because it depends on oxidized-web understanding the new configuration passed to it.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This pull request changes the configuration of oxidized-web, so that we can pass more arguments than just the interface to bind to, the port and an URL prefix.

This PR will close #3340 .
