### PR TITLE
Make Output#version return a Time object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - output/git: cache commit log to improve performance of oxidized-web. Fixes #3121 (@robertcheramy)
 - digest auth handles special characters in passwords by itself (no need to url encode them manually) (@einglasvollkakao)
 - netgear: add pager-handler workaround, fixes: #2394 and #3341 (@candlerb, @syn-bit)
+- Output#version (git/gitcrypt) returns a Time object in its hash for more flexibility in oxidized-web (@robertcheramy)
 
 ### Fixed
 - powerconnect: Mask the changing temperature issue for non-stacked switches. Fixes #2088 (@clifcox)

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -164,7 +164,10 @@ module Oxidized
             next unless delta.added? || delta.modified?
 
             hash = {}
+            # We keep :date for reverse compatibility on oxidized-web <= 0.15.1
             hash[:date] = commit.time.to_s
+            # date as a Time instance for more flexibility in oxidized-web
+            hash[:time] = commit.time
             hash[:oid] = commit.oid
             hash[:author] = commit.author
             hash[:message] = commit.message

--- a/lib/oxidized/output/gitcrypt.rb
+++ b/lib/oxidized/output/gitcrypt.rb
@@ -114,7 +114,10 @@ module Oxidized
         tab = []
         walker.each do |commit|
           hash = {}
+          # We keep :date for reverse compatibility on oxidized-web <= 0.15.1
           hash[:date] = commit.date.to_s
+          # date as a Time instance for more flexibility in oxidized-web
+          hash[:time] = commit.date
           hash[:oid] = commit.objectish
           hash[:author] = commit.author
           hash[:message] = commit.message


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR contains modifications needed in order to resolve https://github.com/ytti/oxidized-web/issues/258 .
It returns the time of a commit as a Time object (hash key `:time`), in order not having to reconvert a String ( hash key `:date`) back into a Time object later.

The hash key `date` cannot be removed for now, this has to happen after new versions of oxidized and oxidized-web have been released.
