### PR TITLE
nxos: ignore bootflash size and errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+### Fixed
+- nxos: ignore bootflash size and permission errors (@rouven0)
+
 ## [0.33.0 - 2025-03-26]
 This release changes the way to configure oxidized-web. The old `rest`
 configuration is still supported but deprecated. The new configuration works

--- a/lib/oxidized/model/nxos.rb
+++ b/lib/oxidized/model/nxos.rb
@@ -22,7 +22,7 @@ class NXOS < Oxidized::Model
 
   cmd 'show version' do |cfg|
     cfg = filter cfg
-    cfg = cfg.each_line.take_while { |line| not line.match(/uptime/i) }
+    cfg = cfg.each_line.take_while { |line| not line.match(/uptime|bootflash:\s+\d+\skB|sysmgrcli_show_flash_size/i) }
     comment cfg.join
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Some Cisco nexus devices occasionally run into a [Bug](https://bst.cisco.com/quickview/bug/CSCvz71586) where the bootflash size is  displayed as 0 kB and a warning message appears, which results in a lot of logged changes. This PR migitates the problem by just ignoring the bootflash lines and the warning.
