### PR TITLE
Explicitly tell when Rugged isn't installed with ssh support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 - nxos: ignore bootflash size and permission errors (@rouven0)
+- githubrepo: explicitly tell when Rugged isn't installed with ssh support (@robertcheramy)
 
 ## [0.33.0 - 2025-03-26]
 This release changes the way to configure oxidized-web. The old `rest`

--- a/lib/oxidized/hook/githubrepo.rb
+++ b/lib/oxidized/hook/githubrepo.rb
@@ -36,8 +36,8 @@ class GithubRepo < Oxidized::Hook
       if e.message == 'unsupported URL protocol'
         log "Rugged does not support the git URL '#{url}'.", :warn
         unless Rugged.features.include?(:ssh)
-          log 'You may need to install Rugged with ssh support ' \
-              '(gem install rugged -- --with-ssh)', :warn
+          log "Note: Rugged isn't installed with ssh support. You may need " \
+              '"gem install rugged -- --with-ssh"', :warn
         end
       end
       # re-raise exception for the calling method


### PR DESCRIPTION
Fixes: #3464

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
I hope that if we explicitly tell that Rugged isn't installed with ssh support, it will help out users to find the problem.

Closes #3464

