### PR TITLE
docker: do not remove git

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - githubrepo: explicitly tell when Rugged isn't installed with ssh support (@robertcheramy)
 - ironware: mask temperatures with more than two digits (@merelissdgr)
 - add content-type header for PUT request in rest client (@deesel)
+- docker: do not remove git. Fixes #3482 (@robertcheramy)
 
 
 ## [0.33.0 - 2025-03-26]

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,7 @@ WORKDIR /tmp/oxidized
 # Install gems which needs a build environment
 RUN apt-get -qy update && \
     apt-get -qy install --no-install-recommends \
-                        build-essential git ruby-dev && \
+                        build-essential ruby-dev && \
     ##### X25519 (a.k.a. Curve25519) Elliptic Curve Diffie-Hellman
     gem install x25519 && \
     ##### build & install oxidized from the working repository
@@ -80,7 +80,7 @@ RUN apt-get -qy update && \
     git fetch --unshallow || true && \
     rake install && \
     # remove the packages we do not need.
-    apt-get -qy remove build-essential git ruby-dev && \
+    apt-get -qy remove build-essential ruby-dev && \
     apt-get -qy autoremove && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/Rakefile
+++ b/Rakefile
@@ -90,7 +90,7 @@ end
 
 desc 'Build the container image with docker or podman'
 task :build_container do
-  branch_name = %x(git rev-parse --abbrev-ref HEAD).chop
+  branch_name = %x(git rev-parse --abbrev-ref HEAD).chop.gsub '/', '_'
   sha_hash = %x(git rev-parse --short HEAD).chop
   image_tag = "#{branch_name}-#{sha_hash}"
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
While removing the building environment, the Dockerfile wrongly removed git.

This also fixes the rake task `task :build_container` when the branch contains a `/`

Fixes #3482