### PR TITLE
Updated acos.rb to fix #2291

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add iosxr support to SyslogMonitor (@deesel)
 
 ### Changed
+- acos: remove free storage amount from show version. Fixes #3492 (@991jo)
 
 ### Fixed
 - nxos: ignore bootflash size and permission errors (@rouven0)

--- a/lib/oxidized/model/acos.rb
+++ b/lib/oxidized/model/acos.rb
@@ -20,6 +20,7 @@ class ACOS < Oxidized::Model
     cfg.gsub! /\s(Memory).*/, ' \\1 <removed>'
     cfg.gsub! /\s(Current time is).*/, ' \\1 <removed>'
     cfg.gsub! /\s(The system has been up).*/, ' \\1 <removed>'
+    cfg.gsub! /\s(Hardware: \d+ CPUs\(Stepping \d+\). Single \d+G drive. Free storage is).*/, ' \\1 <removed>'
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
This removes the amount of free storage from the show version output, because it can fluctuate, e.g. due to log files getting created and cleaned up.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Closes #2291