### PR TITLE
Added support for "show chassis cluster status" output on SRX series

### DIFF
--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -32,6 +32,8 @@ class JunOS < Oxidized::Model
       out << cmd('show chassis fabric reachability') { |cfg| comment cfg }
     when /^(ex22|ex3[34]|ex4|ex8|qfx)/
       out << cmd('show virtual-chassis') { |cfg| comment cfg }
+    when /^srx/
+      out << cmd('show chassis cluster status') { |cfg| comment cfg }
     end
     out
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Added support for "show chassis cluster status" output on SRX series

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
