### PR TITLE
aosw: fix secret parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add content-type header for PUT request in rest client (@deesel)
 - docker: do not remove git. Fixes #3482 (@robertcheramy)
 - awplus: fix skip password when enable=true (@shigechika)
+- aosw: fix secret parsing (@rouven0)
 
 ## [0.33.0 - 2025-03-26]
 This release changes the way to configure oxidized-web. The old `rest`

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -25,24 +25,25 @@ class AOSW < Oxidized::Model
   end
 
   cmd :secret do |cfg|
-    cfg.gsub!(/secret (\S+)$/, 'secret <secret removed>')
-    cfg.gsub!(/enable secret (\S+)$/, 'enable secret <secret removed>')
-    cfg.gsub!(/PRE-SHARE (\S+)$/, 'PRE-SHARE <secret removed>')
-    cfg.gsub!(/ipsec (\S+)$/, 'ipsec <secret removed>')
-    cfg.gsub!(/community (\S+)$/, 'community <secret removed>')
+    cfg.gsub!(/secret (\S+)\s?$/, 'secret <secret removed>')
+    cfg.gsub!(/enable secret (\S+)\s?$/, 'enable secret <secret removed>')
+    cfg.gsub!(/PRE-SHARE (\S+)\s?$/, 'PRE-SHARE <secret removed>')
+    cfg.gsub!(/ipsec (\S+)\s?$/, 'ipsec <secret removed>')
+    cfg.gsub!(/community (\S+)\s?$/, 'community <secret removed>')
     cfg.gsub!(/ sha (\S+)/, ' sha <secret removed>')
     cfg.gsub!(/ des (\S+)/, ' des <secret removed>')
     cfg.gsub!(/mobility-manager (\S+) user (\S+) (\S+)/, 'mobility-manager \1 user \2 <secret removed>')
-    cfg.gsub!(/mgmt-user (\S+) (root|guest-provisioning|network-operations|read-only|location-api-mgmt) (\S+)$/, 'mgmt-user \1 \2 <secret removed>') # MAS & Wireless Controler
-    cfg.gsub!(/mgmt-user (\S+) (\S+)( (read-only|guest-mgmt))?$/, 'mgmt-user \1 <secret removed> \3') # IAP
+    cfg.gsub!(/mgmt-user (\S+) (root|guest-provisioning|network-operations|read-only|location-api-mgmt) (\S+)\s?$/, 'mgmt-user \1 \2 <secret removed>') # MAS & Wireless Controler
+    cfg.gsub!(/mgmt-user (\S+) (\S+)( (read-only|guest-mgmt))?\s?$/, 'mgmt-user \1 <secret removed> \3') # IAP
     # MAS format: mgmt-user <username> <accesslevel> <password hash>
     # IAP format (root user): mgmt-user <username> <password hash>
     # IAP format: mgmt-user <username> <password hash> <access level>
-    cfg.gsub!(/key (\S+)$/, 'key <secret removed>')
-    cfg.gsub!(/wpa-passphrase (\S+)$/, 'wpa-passphrase <secret removed>')
-    cfg.gsub!(/bkup-passwords (\S+)$/, 'bkup-passwords <secret removed>')
-    cfg.gsub!(/user (\S+) (\S+) (\S+)$/, 'user \1 <secret removed> \3')
-    cfg.gsub!(/virtual-controller-key (\S+)$/, 'virtual-controller-key <secret removed>')
+    cfg.gsub!(/key (\S+)\s?$/, 'key <secret removed>')
+    cfg.gsub!(/vrrp-passphrase (\S+)\s?$/, 'vrrp-passphrase <secret removed>')
+    cfg.gsub!(/wpa-passphrase (\S+)\s?$/, 'wpa-passphrase <secret removed>')
+    cfg.gsub!(/bkup-passwords (\S+)\s?$/, 'bkup-passwords <secret removed>')
+    cfg.gsub!(/ap-console-password (\S+)\s?$/, 'ap-console-password <secret removed>')
+    cfg.gsub!(/virtual-controller-key (\S+)\s?$/, 'virtual-controller-key <secret removed>')
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
- In some cases, whitespaces are appended on the end of a line of config. We now catch these.
- VRRP Passphrases and AP Console Passwords are now catched too
- The regex matching `user ...` produces a lot of false positives, for example in ACL lists. It is now removed.

Tested on Aruba 9240 Gateways and Mobility Conductors