### PR TITLE
awplus: fix bug with enable password when supplied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - aosw: fix secret parsing (@rouven0)
 - mlnxos: handle ANSI-ESC codes and pager requests. The prompt has been
   reengineered, open an issue if you experience timeouts. Fixes #3469 (@robertcheramy)
+- awplus: fix enable password when supplied (@sgsimpson)
 
 
 ## [0.33.0 - 2025-03-26]

--- a/lib/oxidized/model/awplus.rb
+++ b/lib/oxidized/model/awplus.rb
@@ -73,7 +73,7 @@ class AWPlus < Oxidized::Model
         cmd "enable"
       elsif vars(:enable)
         cmd "enable", /^[pP]assword:/
-        cmd vars(:enable)
+        cmd vars(:enable) + "\r\n"
       end
       #      cmd 'terminal length 0' #set so the entire config is output without intervention.
     end

--- a/lib/oxidized/model/awplus.rb
+++ b/lib/oxidized/model/awplus.rb
@@ -68,6 +68,7 @@ class AWPlus < Oxidized::Model
       cmd "enable", /^[pP]assword:/
       cmd vars(:enable) + (cr ? "\r" : "")
     end
+    # cmd 'terminal length 0' # set so the entire config is output without intervention.
   end
 
   # Config required for telnet to detect username & password prompt.
@@ -78,12 +79,18 @@ class AWPlus < Oxidized::Model
     password /^Password:\s/
 
     post_login { instance_exec(false, &enable_cmd) }
-    pre_logout { send "exit\r\n" }
+    pre_logout do
+      # cmd 'terminal no length' # sets term length back to default on exit.
+      send "exit\r\n"
+    end
   end
 
   # Config required for ssh to send CR after enable password.
   cfg :ssh do
     post_login { instance_exec(true, &enable_cmd) }
-    pre_logout { send "exit\r\n" }
+    pre_logout do
+      # cmd 'terminal no length' # sets term length back to default on exit.
+      send "exit\r\n"
+    end
   end
 end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

- #3494 introduced a bug where there is no return character when an enable password is supplied. The ssh session just hangs and times out.
- Test on `x610-5.4.5-3.7` with enable password supplied and on `x210-5.4.6-1.2` with enable = true.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
