### PR TITLE
aos7: remove more lines occuring when commands run slow

### DIFF
--- a/lib/oxidized/model/aos7.rb
+++ b/lib/oxidized/model/aos7.rb
@@ -33,10 +33,16 @@ class AOS7 < Oxidized::Model
   end
 
   cmd 'show running-directory' do |cfg|
+    # Remove extra lines occuring when the command runs slow
+    cfg.gsub! /^Please wait...\n/, ''
+    cfg.gsub! /^\n\n/, "\n"
     comment cfg
   end
 
   cmd 'show configuration snapshot' do |cfg|
+    # Remove extra lines occuring when the command runs slow
+    cfg.gsub! /^Please wait...\n/, ''
+    cfg.gsub! /^\n\n/, "\n"
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Follow-UP to #3445.
The `Please wait` lines are now removed for more commands.
