### PR TITLE
Update unifiap.rb

### DIFF
--- a/lib/oxidized/model/unifiap.rb
+++ b/lib/oxidized/model/unifiap.rb
@@ -41,7 +41,7 @@ class Unifiap < Oxidized::Model
   end
 
   # We check here to see if we succeeded with /etc/hosts. If not, then we try again with ifconfig, and /tmp/system.cfg
-  cmd do
+  cmd 'echo' do
     unless @ip
       cmd 'ifconfig br0' do |cfg|
         @ip = Regexp.last_match(1) if cfg =~ /inet addr:\s*(\d+\.\d+\.\d+\.\d+)/i
@@ -87,7 +87,7 @@ class Unifiap < Oxidized::Model
   end
 
   # Now we can display it all as a banner
-  cmd do
+  cmd 'echo' do
     out = []
     out << "*************************"
     out << "Model:       #{@model}"


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fixed errors with "unifiap" model occurring due to "cmd do" resulting in blank command, which threw nil error when logging from ssh input module.  Replaced blank command with "echo" to function as a noop.

