### PR TITLE
fabricos: remove input voltage from chassisShow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - node.rb: remove Polynomial regular expression / Fixes Code scanning alert #40 (@robertcheramy)
 - asa: remove Inefficient regular expression / Fixes Code scanning alert #5 and #6 (@robertcheramy)
 - quantaos: remove inefficient regular expression / Fixes code scanning alerts 9 and 10 (@robertcheramy)
+- fabricos: remove power supply input voltage from `chassisShow` output (@hops)
 
 
 ## [0.33.0 - 2025-03-26]

--- a/lib/oxidized/model/fabricos.rb
+++ b/lib/oxidized/model/fabricos.rb
@@ -8,7 +8,7 @@ class FabricOS < Oxidized::Model
   comment '# '
 
   cmd 'chassisShow' do |cfg|
-    comment cfg.each_line.reject { |line| line.match(/Time Awake:/) || line.match(/Power Usage \(Watts\):/) || line.match(/Power Usage:/) || line.match(/Time Alive:/) || line.match(/Update:/) }.join
+    comment cfg.each_line.reject { |line| line.match(/Time Awake:/) || line.match(/Power Usage \(Watts\):/) || line.match(/Power Usage:/) || line.match(/Time Alive:/) || line.match(/Update:/) || line.match(/PS Voltage input:/) }.join
   end
 
   cmd 'configShow -all' do |cfg|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Some Brocade Fibre Channel switches report the power supply input voltage in the output of `chassisShow`. This pull request removes lines containing `PS Voltage input` because voltage fluctuations are unavoidable and would cause unnecessary backup changes.
This is an example line from a Brocade G630: `PS Voltage input:	231.00 V`

~I didn't run the tests or rubocop but~ I built the docker image with this change and tested it against the actual device.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
