### PR TITLE
Fix Code Scanning Alert #40

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - AricentISS: fix codeQL alert #15 (@robertcheramy)
 - Update installation instructions on Rocky Linux 9. Fixes #3368 (@robertcheramy)
 - awplus: fix enable password when supplied (@sgsimpson)
+- Polynomial regular expression in node.rb / Code scanning alert #40 (@robertcheramy)
 
 
 ## [0.33.0 - 2025-03-26]

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -157,7 +157,8 @@ module Oxidized
 
     def resolve_input(opt)
       inputs = resolve_key :input, opt, Oxidized.config.input.default
-      inputs.split(/\s*,\s*/).map do |input|
+      inputs.split(',').map do |input|
+        input.strip!
         unless Oxidized.mgr.input[input]
           Oxidized.mgr.add_input(input) || raise(MethodNotFound, "#{input} not found for node #{ip}")
         end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -159,4 +159,25 @@ describe Oxidized::Node do
       end
     end
   end
+
+  describe '#resolve_input' do
+    it 'resolves input.default without whitespaces' do
+      Oxidized.config.input.default = 'ssh,telnet,ftp'
+
+      input_classes = @node.send(:resolve_input, {})
+      _(input_classes[0]).must_equal Oxidized::SSH
+      _(input_classes[1]).must_equal Oxidized::Telnet
+      _(input_classes[2]).must_equal Oxidized::FTP
+    end
+
+    it 'resolves input.default without whitespaces' do
+      Oxidized.config.input.default = "ssh  , \ttelnet, ftp ,scp"
+
+      input_classes = @node.send(:resolve_input, {})
+      _(input_classes[0]).must_equal Oxidized::SSH
+      _(input_classes[1]).must_equal Oxidized::Telnet
+      _(input_classes[2]).must_equal Oxidized::FTP
+      _(input_classes[3]).must_equal Oxidized::SCP
+    end
+  end
 end


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR fixes https://github.com/ytti/oxidized/security/code-scanning/40

