### PR TITLE
quantaos: remove inefficient regular expression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - awplus: fix enable password when supplied (@sgsimpson)
 - node.rb: remove Polynomial regular expression / Fixes Code scanning alert #40 (@robertcheramy)
 - asa: remove Inefficient regular expression / Fixes Code scanning alert #5 and #6 (@robertcheramy)
+- quantaos: remove inefficient regular expression / Fixes code scanning alerts 9 and 10 (@robertcheramy)
 
 
 ## [0.33.0 - 2025-03-26]

--- a/lib/oxidized/model/quantaos.rb
+++ b/lib/oxidized/model/quantaos.rb
@@ -1,15 +1,17 @@
 class QuantaOS < Oxidized::Model
   using Refinements
 
-  prompt /^\((\w|\S)+\) (>|#)$/
+  prompt /^\(\S+\) (>|#)$/
   comment '! '
 
+  cmd :all do |cfg|
+    # Remove command echo and prompt
+    cfg.cut_both
+  end
+
   cmd 'show run' do |cfg|
-    cfg.each_line.select do |line|
-      (not line.match /^!.*$/) &&
-        (not line.match /^\((\w|\S)+\) (>|#)$/) &&
-        (not line.match /^show run$/)
-    end.join
+    # Remove commented lines
+    cfg.lines.grep_v(/^!/).join
   end
 
   cfg :telnet do

--- a/spec/model/data/quantaos:snippets:output.txt
+++ b/spec/model/data/quantaos:snippets:output.txt
@@ -1,0 +1,1 @@
+This line is not removed

--- a/spec/model/data/quantaos:snippets:simulation.yaml
+++ b/spec/model/data/quantaos:snippets:simulation.yaml
@@ -1,0 +1,24 @@
+# This is no real simulation file. It is used to test some regexp
+# in the model
+init_prompt: |-
+  Hello!
+  (some_prompt) >
+commands:
+  "enable\n": |-
+    enter your enable password:
+  "\n": "\n(some_prompt) #"
+  "terminal length 0\n": |-
+    terminal length 0
+    (some_prompt) #
+  "show run\n": |-
+    show run
+    ! Running config
+    ! Comments are removed
+    This line is not removed
+    (some_prompt) #
+  "show current-config\n": |-
+    show current-config
+    (some_prompt) #
+  "quit\n": |-
+    Bye ;-)
+  "n\n":


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Working on Issue #3513
Fixes code scanning alerts https://github.com/ytti/oxidized/security/code-scanning/9 and https://github.com/ytti/oxidized/security/code-scanning/10 for quantaos

Adds a model unit test (only snippets) to avoid regressions.