### PR TITLE
tmos: remove deprecated secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - node.rb: remove Polynomial regular expression / Fixes Code scanning alert #40 (@robertcheramy)
 - asa: remove Inefficient regular expression / Fixes Code scanning alert #5 and #6 (@robertcheramy)
 - quantaos: remove inefficient regular expression / Fixes code scanning alerts 9 and 10 (@robertcheramy)
+- tmos: remove deprecated secrets (@rouven0)
 
 
 ## [0.33.0 - 2025-03-26]

--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -32,6 +32,7 @@ class TMOS < Oxidized::Model
     cfg.gsub!(/^\s+bandwidth-bps (\d+)/, '')
     cfg.gsub!(/^\s+bandwidth-cps (\d+)/, '')
     cfg.gsub!(/^\s+bandwidth-pps (\d+)\n/, '')
+    cfg.gsub!(/^[\s\t]*\S*encrypted \S+\n/, '')
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Secrets ending with `-encrypted` are deprecated (see [here](https://cdn.f5.com/product/bugtracker/ID532181.html#:~:text=Note%3A%20The%20auth%2Dpassword%2Dencrypted%20and%20privacy%2Dpassword%2Dencrypted%20keywords%20have%20been%20deprecated%20but%20display%20for%20backwards%20compatibility.)) and produce noise in the config as they change every time the config is fetched. In this PR we just remove them.