### PR TITLE
Clean the configuration of obsolete nodes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -16,6 +16,7 @@ Metrics/AbcSize:
 Metrics/ClassLength:
   Exclude:
     - 'lib/oxidized/node.rb'
+    - 'lib/oxidized/output/git.rb'
 
 # Offense count: 19
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add nxos: support for complete hardware inventory (@garryshtern)
 - ssh: support 'newline "string"' cfg block method to allow defining \r\n newline (@ytti)
 - model for Netgate TNSR (@Vantomas)
+- ouput/file: clean node configurations which are not listed in the source anymore. (@robertcheramy)
 
 ### Changed
 - acos: remove free storage amount from show version. Fixes #3492 (@991jo)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - add nxos: support for complete hardware inventory (@garryshtern)
 - ssh: support 'newline "string"' cfg block method to allow defining \r\n newline (@ytti)
 - model for Netgate TNSR (@Vantomas)
-- ouput/file: clean node configurations which are not listed in the source anymore. (@robertcheramy)
+- ouput/file, output/git: clean node configurations which are not listed in the source anymore. Fixes: #1805 (@robertcheramy)
 
 ### Changed
 - acos: remove free storage amount from show version. Fixes #3492 (@991jo)

--- a/docs/Docker.md
+++ b/docs/Docker.md
@@ -222,7 +222,9 @@ If not, a quick way to solve it is to delete `~/.local/share/containers/`.
 Beware - this will delete **all** your containers!
 
 ### Store the ssh keys a remote git repository
-When you user the githubrepo hook to upload your configs to a remote git repository, you have to store your ssh-key and the public keys of the remote server. Create a folder `~/oxidized-ssh` and map it to `/home/oxidized/.ssh`.
+When you user the githubrepo hook to upload your configs to a remote git
+repository, you have to store your ssh-key and the public keys of the remote
+server. Create a directory `~/oxidized-ssh` and map it to `/home/oxidized/.ssh`.
 
 
 To generate an ssh-key, run:
@@ -230,8 +232,9 @@ To generate an ssh-key, run:
 ssh-keygen -q -t ed25519 -C "Oxidized Push Key@`hostname`" -N "YOURPASSPHRASE" -m PEM -f ~/oxidized-ssh/oxidized-key
 ```
 
-You also need to store the public keys of the remote git server in known_hosts. If you do not,
-oxidized will refuse to push to the remote Git with the error `#<Rugged::SshError: invalid or unknown remote ssh hostkey>`, see Issue #2753.
+You also need to store the public keys of the remote git server in known_hosts.
+If you do not, oxidized will refuse to push to the remote Git with the error
+`#<Rugged::SshError: invalid or unknown remote ssh hostkey>`, see Issue #2753.
 
 ```shell
 ssh-keyscan git-server.example.com > ~/oxidized-ssh/known_hosts

--- a/docs/Outputs.md
+++ b/docs/Outputs.md
@@ -47,7 +47,8 @@ output:
 
 ## Output: Git
 
-This uses the rugged/libgit2 interface. So you should remember that normal Git hooks will not be executed.
+This uses the rugged/libgit2 interface. So you should remember that normal Git
+hooks will not be executed.
 
 For a single repository containing all devices:
 
@@ -98,7 +99,42 @@ output:
 
 ```
 
-Over time, your Git repository will expand, potentially leading to performance issues. For instructions on how to address this, see [git performance issues with large device counts](Troubleshooting.md#git-performance-issues-with-large-device-counts).
+### Git performance issues with large device counts
+When you use git to store your configurations, the size of your repository will
+grow over time. This growth can lead to performance issues. If you encounter
+such issues, you should perform a Git garbage collection on your repository.
+
+Follow these steps to do so:
+
+1. Stop oxidized (no one should access the git repository while running garbage
+   collection)
+2. Make a backup of your oxidized data, especially the Git repository
+3. Change directory your oxidized git repository (as configured in oxidized
+   configuration file)
+4. Execute the command `git gc` to run the garbage collection
+5. Restart oxidized - you're done!
+
+### Clean obsolete nodes
+The `git` output can automatically remove the configuration of nodes not
+present in the [source](Sources.md) anymore.
+
+> :warning: Restrictions: this currently only works with `single_repo: true`
+> and without [output types](#output-types).
+>
+> There will be no warnings when using output types. Do not use in combination!
+
+Oxidized will remove **any** file not matching the group and hostname of the
+nodes configured in the source and will commit the change in the git
+repository.
+
+```yaml
+output:
+  default: git
+  clean_obsolete_nodes: true
+  git:
+    single_repo: true
+    repo: "~/.config/oxidized/devices.git"
+```
 
 ## Output: Git-Crypt
 

--- a/docs/Outputs.md
+++ b/docs/Outputs.md
@@ -11,8 +11,8 @@ output:
 ```
 
 ### Groups
-If you use groups, the nodes will be stored in folders named after the
-groups. The folder are stored one level above the folder for configurations
+If you use groups, the nodes will be stored in directories named after the
+groups. The directories are stored one level above the directory for configurations
 without groups.
 
 Example:
@@ -32,10 +32,10 @@ longer present in the [source](Sources.md).
 > in the source.
 
 When using groups, it will remove any files not matching the hostnames of the
-nodes from the groups folders (which are on the same level as the default
-folder). As a safety measure, oxidized will only clean configuration out of
+nodes from the groups directories (which are on the same level as the default
+directory). As a safety measure, oxidized will only clean configuration out of
 active groups. If the group `example` isn't used anymore, oxidized won't clean
-the configurations out of the folder `../example/`.
+the configurations out of the directory `../example/`.
 
 Configuration:
 
@@ -129,7 +129,7 @@ longer present in the [source](Sources.md).
 > - oxidized will refuse to remove old configurations
 >   when saving  [output types](#output-types) in a subdirectory of the git
 >   repository (`type_as_directory: true`), or it would remove the output
->   type folders
+>   type directories
 
 Oxidized will remove **any** file within the git repository not matching the
 group and hostname of the nodes configured in the source and will then commit

--- a/docs/Outputs.md
+++ b/docs/Outputs.md
@@ -10,6 +10,41 @@ output:
     directory: /var/lib/oxidized/configs
 ```
 
+### Groups
+If you use groups, the nodes will be stored in folders named after the
+groups. The folder are stored one level above the folder for configurations
+without groups.
+
+Example:
+```
+/var/lib/oxidized/
++ configs/     # Configurations of groupless nodes
++ group1/      # Configurations of nodes in group1
++ group2/      # Configurations of nodes in group2
+```
+
+### Clean obsolete nodes
+The `file` output can automatically remove the configuration of nodes not
+present in the [source](Sources.md) anymore.
+
+Be warned that this might be a dangerous operation: oxidized will remove **any**
+file not matching the hostname of the nodes configured in the source.
+
+When using groups, it will remove any files not matching the hostnames of the
+nodes out of the groups folders (which are on the same level as the default
+folder). As a safety measure, Oxidized will only clean configuration out of
+active groups. If the group `example` isn't used anymore, oxidized won't clean
+the configurations out of the folder `../example/`.
+
+```yaml
+output:
+  default: file
+  clean_obsolete_nodes: true
+  file:
+    directory: "~/.config/oxidized/configs/default"
+```
+
+
 ## Output: Git
 
 This uses the rugged/libgit2 interface. So you should remember that normal Git hooks will not be executed.

--- a/docs/Outputs.md
+++ b/docs/Outputs.md
@@ -24,17 +24,20 @@ Example:
 ```
 
 ### Clean obsolete nodes
-The `file` output can automatically remove the configuration of nodes not
-present in the [source](Sources.md) anymore.
+The `file` output can automatically remove the configuration of nodes no
+longer present in the [source](Sources.md).
 
-Be warned that this might be a dangerous operation: oxidized will remove **any**
-file not matching the hostname of the nodes configured in the source.
+> :warning: **Warning:** this might be a dangerous operation: oxidized
+> will remove **any** file not matching the hostname of the nodes configured
+> in the source.
 
 When using groups, it will remove any files not matching the hostnames of the
-nodes out of the groups folders (which are on the same level as the default
-folder). As a safety measure, Oxidized will only clean configuration out of
+nodes from the groups folders (which are on the same level as the default
+folder). As a safety measure, oxidized will only clean configuration out of
 active groups. If the group `example` isn't used anymore, oxidized won't clean
 the configurations out of the folder `../example/`.
+
+Configuration:
 
 ```yaml
 output:
@@ -101,7 +104,7 @@ output:
 
 ### Git performance issues with large device counts
 When you use git to store your configurations, the size of your repository will
-grow over time. This growth can lead to performance issues. If you encounter
+grow over time. This growth may lead to performance issues. If you encounter
 such issues, you should perform a Git garbage collection on your repository.
 
 Follow these steps to do so:
@@ -114,18 +117,25 @@ Follow these steps to do so:
 4. Execute the command `git gc` to run the garbage collection
 5. Restart oxidized - you're done!
 
+
 ### Clean obsolete nodes
-The `git` output can automatically remove the configuration of nodes not
-present in the [source](Sources.md) anymore.
+The `git` output can automatically remove the configuration of nodes no
+longer present in the [source](Sources.md).
 
-> :warning: Restrictions: this currently only works with `single_repo: true`
-> and without [output types](#output-types).
->
-> There will be no warnings when using output types. Do not use in combination!
+> :warning: **Limitations**
+> - this currently only works with `single_repo: true`
+> - it will ignore configurations saved as [output types](#output-types) in
+>   a separate repository.
+> - oxidized will refuse to remove old configurations
+>   when saving  [output types](#output-types) in a subdirectory of the git
+>   repository (`type_as_directory: true`), or it would remove the output
+>   type folders
 
-Oxidized will remove **any** file not matching the group and hostname of the
-nodes configured in the source and will commit the change in the git
-repository.
+Oxidized will remove **any** file within the git repository not matching the
+group and hostname of the nodes configured in the source and will then commit
+the change into git.
+
+Configuration:
 
 ```yaml
 output:

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -27,7 +27,10 @@ Welcome to the advanced nuclear launchinator 5A-X20. Proceed with caution.
 SEKRET-5A-X20#
 ```
 
-Review the relevant device model file and identify the defined prompt. You can find the device models in the `lib/oxidized/model` sub-folder of the repository. For example, the Cisco IOS model, `ios.rb` may use the following prompt:
+Review the relevant device model file and identify the defined prompt. You can
+find the device models in the `lib/oxidized/model` subdirectory of the
+repository. For example, the Cisco IOS model, `ios.rb` may use the following
+prompt:
 
 ```text
   prompt /^([\w.@()-]+[#>]\s?)$/

--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -85,23 +85,6 @@ If you are running oxidized in a container, you need to map /home/oxidized/.ssh 
 container to a local repository and save the known_hosts in the local repository. You can
 find an example how to do this under [examples/podman-compose](/examples/podman-compose/)
 
-## Git performance issues with large device counts
-When you use git to store your configurations, the size of your repository will
-grow over time. This growth can lead to performance issues. To resolve these
-issues, you should perform a Git garbage collection on your repository.
-
-Follow these steps to do so:
-
-1. Stop oxidized (no one should access the git repository while running garbage collection)
-2. Make a backup of your oxidized data, especially the Git repository
-3. Change directory your oxidized git repository (as configured in oxidized configuration file)
-4. Execute the command `git gc` to run the garbage collection
-5. Restart oxidized - you're done!
-
-Note that slow performance in oxidized-web when listing the versions of a device
-are due to the necessity to go through the whole git log to search the
-history. See Issue #3121, the fix will come with oxidized version 0.33.0.
-
 ## Oxidized ignores the changes I made to its git repository
 First of all: you shouldn't manipulate the git repository of oxidized. Don't
 create it, don't modify it, leave it alone. You can break things. You have

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -10,6 +10,7 @@ module Oxidized
     attr_accessor :running, :user, :email, :msg, :from, :stats, :retry, :err_type, :err_reason
     alias running? running
 
+    # opt is a hash with the node parameters given in the source (:name, :group, :ip...)
     def initialize(opt)
       Oxidized.logger.debug 'resolving DNS for %s...' % opt[:name]
       # remove the prefix if an IP Address is provided with one as IPAddr converts it to a network address.

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -28,6 +28,7 @@ module Oxidized
           end
         end
         size.zero? ? replace(new) : update_nodes(new)
+        Output.clean_obsolete_nodes(self) if node_want.nil?
         Oxidized.logger.info "lib/oxidized/nodes.rb: Loaded #{size} nodes"
       end
     end

--- a/lib/oxidized/output/file.rb
+++ b/lib/oxidized/output/file.rb
@@ -19,6 +19,9 @@ module Oxidized
         raise NoConfig, "no output file config, edit #{Oxidized::Config.configfile}"
       end
 
+      # node: node name (String)
+      # outputs: Oxidized::Outputs
+      # opts: hash of node vars
       def store(node, outputs, opt = {})
         file = ::File.expand_path @cfg.directory
         file = ::File.join ::File.dirname(file), opt[:group] if opt[:group]
@@ -33,7 +36,7 @@ module Oxidized
         node_name = node.name
 
         if group # group is explicitly defined by user
-          cfg_dir = ::File.join ::File.dirname(cfg_dir), group
+          cfg_dir = ::File.join :File.dirname(cfg_dir), group
           ::File.read ::File.join(cfg_dir, node_name)
         elsif ::File.exist? ::File.join(cfg_dir, node_name) # node configuration file is stored on base directory
           ::File.read ::File.join(cfg_dir, node_name)
@@ -52,6 +55,31 @@ module Oxidized
 
       def get_version(_node, _group, _oid)
         'not supported'
+      end
+
+      def self.node_path(node_name, group_name = nil)
+        cfg_dir = ::File.expand_path Oxidized.config.output.file.directory
+
+        if group_name
+          ::File.join ::File.dirname(cfg_dir), group_name, node_name
+        else
+          ::File.join cfg_dir, node_name
+        end
+      end
+
+      def self.clean_obsolete_nodes(active_nodes)
+        cfg_dir = ::File.expand_path Oxidized.config.output.file.directory
+        dir_base = ::File.dirname(cfg_dir)
+        default_dir = ::File.basename(cfg_dir)
+
+        keep_files = active_nodes.map { |n| node_path(n.name, n.group) }
+        active_groups = active_nodes.map(&:group).compact.uniq
+
+        [default_dir, *active_groups].each do |group|
+          Dir.glob(::File.join(dir_base, group, "*")).each do |file|
+            ::File.delete(file) if ::File.file?(file) && !keep_files.include?(file)
+          end
+        end
       end
     end
   end

--- a/lib/oxidized/output/file.rb
+++ b/lib/oxidized/output/file.rb
@@ -36,7 +36,7 @@ module Oxidized
         node_name = node.name
 
         if group # group is explicitly defined by user
-          cfg_dir = ::File.join :File.dirname(cfg_dir), group
+          cfg_dir = ::File.join ::File.dirname(cfg_dir), group
           ::File.read ::File.join(cfg_dir, node_name)
         elsif ::File.exist? ::File.join(cfg_dir, node_name) # node configuration file is stored on base directory
           ::File.read ::File.join(cfg_dir, node_name)

--- a/lib/oxidized/output/file.rb
+++ b/lib/oxidized/output/file.rb
@@ -20,7 +20,7 @@ module Oxidized
       end
 
       # node: node name (String)
-      # outputs: Oxidized::Outputs
+      # outputs: Oxidized::Models::Outputs
       # opts: hash of node vars
       def store(node, outputs, opt = {})
         file = ::File.expand_path @cfg.directory

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -211,6 +211,13 @@ module Oxidized
           return
         end
 
+        if git_config.type_as_directory?
+          Oxidized.logger.warn "clean_obsolete_nodes is not implemented for " \
+                               "output types as a directory within the git " \
+                               "repository"
+          return
+        end
+
         # The repo might not exist on the first run
         return unless ::File.directory?(repo_path)
 

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -204,7 +204,6 @@ module Oxidized
         git_config = Oxidized.config.output.git
         repo_path = git_config.repo
 
-        # Multiple Repo (and types) not implemented yet
         unless git_config.single_repo?
           Oxidized.logger.warn "clean_obsolete_nodes is not implemented for " \
                                "multiple git repositories"
@@ -236,9 +235,10 @@ module Oxidized
           files_to_delete << file_path unless keep_files.include?(file_path)
         end
 
-        return unless files_to_delete.any?
+        return if files_to_delete.empty?
 
-        Oxidized.logger.info "Removing #{files_to_delete.size} obsolete configs"
+        Oxidized.logger.info "clean_obsolete_nodes: removing " \
+                             "#{files_to_delete.size} obsolete configs"
         index = repo.index
 
         files_to_delete.each { |file_path| index.remove(file_path) }

--- a/lib/oxidized/output/git.rb
+++ b/lib/oxidized/output/git.rb
@@ -200,6 +200,55 @@ module Oxidized
         @gitcache = nil
       end
 
+      def self.clean_obsolete_nodes(active_nodes)
+        git_config = Oxidized.config.output.git
+        repo_path = git_config.repo
+
+        # Multiple Repo (and types) not implemented yet
+        unless git_config.single_repo?
+          Oxidized.logger.warn "clean_obsolete_nodes is not implemented for " \
+                               "multiple git repositories"
+          return
+        end
+
+        # The repo might not exist on the first run
+        return unless ::File.directory?(repo_path)
+
+        repo = Rugged::Repository.new repo_path
+        return if repo.empty?
+
+        keep_files = active_nodes.map do |n|
+          n.group ? ::File.join(n.group, n.name) : n.name
+        end
+
+        tree = repo.last_commit.tree
+        files_to_delete = []
+
+        tree.walk_blobs do |root, entry|
+          file_path = root.empty? ? entry[:name] : ::File.join(root, entry[:name])
+          files_to_delete << file_path unless keep_files.include?(file_path)
+        end
+
+        return unless files_to_delete.any?
+
+        Oxidized.logger.info "Removing #{files_to_delete.size} obsolete configs"
+        index = repo.index
+
+        files_to_delete.each { |file_path| index.remove(file_path) }
+
+        repo.config['user.name']  = git_config.user
+        repo.config['user.email'] = git_config.email
+        Rugged::Commit.create(
+          repo,
+          tree:       index.write_tree(repo),
+          message:    "Removing #{files_to_delete.size} obsolete configs",
+          parents:    [repo.head.target].compact,
+          update_ref: 'HEAD'
+        )
+
+        index.write
+      end
+
       private
 
       def yield_repo_and_path(node, group)

--- a/lib/oxidized/output/output.rb
+++ b/lib/oxidized/output/output.rb
@@ -1,10 +1,22 @@
 module Oxidized
   module Output
+    def self.clean_obsolete_nodes(active_nodes)
+      return unless Oxidized.config.output.clean_obsolete_nodes?
+
+      output_name = Oxidized.config.output.default
+      output = Oxidized.mgr.add_output output_name
+      output[output_name].clean_obsolete_nodes(active_nodes)
+    end
+
     class Output
       class NoConfig < OxidizedError; end
 
       def cfg_to_str(cfg)
         cfg.select { |h| h[:type] == 'cfg' }.map { |h| h[:data] }.join
+      end
+
+      def self.clean_obsolete_nodes(active_nodes)
+        # Not implemented
       end
     end
   end

--- a/lib/oxidized/output/output.rb
+++ b/lib/oxidized/output/output.rb
@@ -15,8 +15,9 @@ module Oxidized
         cfg.select { |h| h[:type] == 'cfg' }.map { |h| h[:data] }.join
       end
 
-      def self.clean_obsolete_nodes(active_nodes)
-        # Not implemented
+      def self.clean_obsolete_nodes(_active_nodes)
+        Oxidized.logger.warn "clean_obsolete_nodes is not implemented for " \
+                             "#{name}"
       end
     end
   end

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -44,8 +44,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'slop',                 '~> 4.6'
 
   s.add_development_dependency 'bundler',             '~> 2.2'
-  s.add_development_dependency 'fakefs',              '~> 1.2.0', '<=3.0'
-  s.add_development_dependency 'git',                 '>= 2.0',   '<=3.0'
+  s.add_development_dependency 'git',                 '>= 2.0', '<=3.0'
   s.add_development_dependency 'minitest',            '~> 5.25.4'
   s.add_development_dependency 'mocha',               '~> 2.1'
   s.add_development_dependency 'pry',                 '~> 0.15.0'

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -44,7 +44,8 @@ Gem::Specification.new do |s|
   s.add_dependency 'slop',                 '~> 4.6'
 
   s.add_development_dependency 'bundler',             '~> 2.2'
-  s.add_development_dependency 'git',                 '>= 2.0', '<=3.0'
+  s.add_development_dependency 'fakefs',              '~> 1.2.0', '<=3.0'
+  s.add_development_dependency 'git',                 '>= 2.0',   '<=3.0'
   s.add_development_dependency 'minitest',            '~> 5.25.4'
   s.add_development_dependency 'mocha',               '~> 2.1'
   s.add_development_dependency 'pry',                 '~> 0.15.0'

--- a/spec/output/file_spec.rb
+++ b/spec/output/file_spec.rb
@@ -1,5 +1,6 @@
 require_relative '../spec_helper'
 require 'oxidized/output/file'
+require 'fakefs/safe'
 
 describe 'Oxidized::Output::File' do
   describe '#setup' do
@@ -17,6 +18,118 @@ describe 'Oxidized::Output::File' do
 
       err = _(-> { oxidized_file.setup }).must_raise Oxidized::NoConfig
       _(err.message).must_match(/^no output file config, edit \/cfg_path\/config$/)
+    end
+  end
+
+  describe '#store' do
+    before do
+      Oxidized.asetus = Asetus.new
+      Oxidized.config.output.file.directory = '/fakefs'
+      Oxidized.asetus.cfg.debug = false
+      Oxidized.setup_logger
+      @file = Oxidized::Output::File.new
+      @outputs = Oxidized::Model::Outputs.new
+      @outputs << 'configuration'
+    end
+    it 'stores configurations in the configured folder' do
+      FakeFS.with_fresh do
+        Dir.mkdir('/fakefs')
+        @file.store('node1', @outputs)
+
+        _(File.exist?('/fakefs/node1')).must_equal true
+        _(File.read('/fakefs/node1')).must_equal 'configuration'
+      end
+    end
+
+    it 'stores group configurations in the parent folder' do
+      FakeFS.with_fresh do
+        Dir.mkdir('/fakefs')
+        @file.store('node1', @outputs, { group: 'gr1' })
+
+        _(File.exist?('/fakefs/node1')).must_equal false
+        _(File.exist?('/gr1/node1')).must_equal true
+        _(File.read('/gr1/node1')).must_equal 'configuration'
+      end
+    end
+  end
+
+  describe '#clean_obsolete_nodes' do
+    before do
+      Oxidized.asetus = Asetus.new
+      Oxidized.config.output.file.directory = '/fakefs'
+      Oxidized.asetus.cfg.debug = false
+      Oxidized.setup_logger
+      @opts = {
+        input:  'ssh',
+        output: 'file',
+        model:  'junos'
+      }
+    end
+
+    it "removes obsolete configuration files - without groups" do
+      FakeFS.with_fresh do
+        Dir.mkdir('/fakefs')
+        File.write('/fakefs/node1', 'Configuration')
+        File.write('/fakefs/node2', 'Configuration')
+        File.write('/fakefs/node3', 'Configuration')
+
+        nodes = %w[node1 node2].map { |e| Oxidized::Node.new(@opts.merge(name: e)) }
+
+        Oxidized::Output::File.clean_obsolete_nodes(nodes)
+
+        _(File.exist?('/fakefs/node1')).must_equal true
+        _(File.exist?('/fakefs/node2')).must_equal true
+        _(File.exist?('/fakefs/node3')).must_equal false
+      end
+    end
+
+    it "does not remove non-configuration files" do
+      FakeFS.with_fresh do
+        Dir.mkdir('/fakefs')
+        Dir.mkdir('/fakefs/subdir')
+        File.write('/fakefs/subdir/nonode', 'no config')
+        File.write('/fakefs/.nonode', 'no config')
+        File.write('/some_file', 'no config')
+
+        nodes = %w[node1 node2].map { |e| Oxidized::Node.new(@opts.merge(name: e)) }
+
+        Oxidized::Output::File.clean_obsolete_nodes(nodes)
+
+        # Nodes can't be in subdirectories
+        _(File.exist?('/fakefs/subdir/nonode')).must_equal true
+        # Files beginning with . are not deleted
+        _(File.exist?('/fakefs/.nonode')).must_equal true
+        # Files outside /fakefs are not deleted
+        _(File.exist?('/some_file')).must_equal true
+      end
+    end
+
+    it "removes obsolete configuration files - with groups" do
+      FakeFS.with_fresh do
+        Dir.mkdir('/gr1')
+        File.write('/gr1/node11', 'Configuration')
+        File.write('/gr1/node12', 'Configuration')
+        File.write('/gr1/node13', 'Configuration')
+        Dir.mkdir('/gr2')
+        File.write('/gr2/node21', 'Configuration')
+        Dir.mkdir('/gr1/gr3')
+        File.write('/gr1/gr3/node131', 'Configuration')
+        File.write('/gr1/gr3/node141', 'Configuration')
+
+        nodes = %w[node11 node12].map { |e| Oxidized::Node.new(@opts.merge(name: e, group: 'gr1')) }
+        nodes << Oxidized::Node.new(@opts.merge(name: 'node131', group: 'gr1/gr3'))
+
+        Oxidized::Output::File.clean_obsolete_nodes(nodes)
+
+        _(File.exist?('/gr1/node11')).must_equal true
+        _(File.exist?('/gr1/node12')).must_equal true
+        _(File.exist?('/gr1/node13')).must_equal false
+        # We don't remove from obsolete groups as it could be something else
+        _(File.exist?('/gr2/node21')).must_equal true
+        # Works with groups containing / (subgroups)
+        _(File.exist?('/gr1/gr3/node131')).must_equal true
+        _(File.exist?('/gr1/gr3/node132')).must_equal false
+      end
     end
   end
 end

--- a/spec/output/file_spec.rb
+++ b/spec/output/file_spec.rb
@@ -53,7 +53,7 @@ describe 'Oxidized::Output::File' do
     end
   end
 
-  describe '#clean_obsolete_nodes' do
+  describe 'clean_obsolete_nodes' do
     before do
       Oxidized.asetus = Asetus.new
       Oxidized.config.output.file.directory = '/fakefs'

--- a/spec/output/file_spec.rb
+++ b/spec/output/file_spec.rb
@@ -2,7 +2,7 @@ require_relative '../spec_helper'
 require 'oxidized/output/file'
 
 describe 'Oxidized::Output::File' do
-  describe 'setup' do
+  describe '#setup' do
     it 'raises Oxidized::NoConfig when no config is provided' do
       Asetus.any_instance.expects(:load)
       Asetus.any_instance.expects(:create).returns(false)
@@ -20,7 +20,7 @@ describe 'Oxidized::Output::File' do
     end
   end
 
-  describe 'store' do
+  describe '#store' do
     before do
       Oxidized.asetus = Asetus.new
       Oxidized.asetus.cfg.debug = false
@@ -29,7 +29,7 @@ describe 'Oxidized::Output::File' do
       @outputs = Oxidized::Model::Outputs.new
       @outputs << 'configuration'
     end
-    it 'stores configurations in the configured folder' do
+    it 'stores configurations in the configured directory' do
       Dir.mktmpdir do |temp_dir|
         Oxidized.config.output.file.directory = temp_dir
 
@@ -40,7 +40,7 @@ describe 'Oxidized::Output::File' do
       end
     end
 
-    it 'stores group configurations in the parent folder' do
+    it 'stores group configurations in the parent directory' do
       Dir.mktmpdir do |temp_dir|
         config_dir = File.join(temp_dir, 'configs')
         Oxidized.config.output.file.directory = config_dir
@@ -55,7 +55,7 @@ describe 'Oxidized::Output::File' do
     end
   end
 
-  describe 'clean_obsolete_nodes' do
+  describe '.clean_obsolete_nodes' do
     before do
       Oxidized.asetus = Asetus.new
       Oxidized.asetus.cfg.debug = false

--- a/spec/output/file_spec.rb
+++ b/spec/output/file_spec.rb
@@ -1,9 +1,8 @@
 require_relative '../spec_helper'
 require 'oxidized/output/file'
-require 'fakefs/safe'
 
 describe 'Oxidized::Output::File' do
-  describe '#setup' do
+  describe 'setup' do
     it 'raises Oxidized::NoConfig when no config is provided' do
       Asetus.any_instance.expects(:load)
       Asetus.any_instance.expects(:create).returns(false)
@@ -21,10 +20,9 @@ describe 'Oxidized::Output::File' do
     end
   end
 
-  describe '#store' do
+  describe 'store' do
     before do
       Oxidized.asetus = Asetus.new
-      Oxidized.config.output.file.directory = '/fakefs'
       Oxidized.asetus.cfg.debug = false
       Oxidized.setup_logger
       @file = Oxidized::Output::File.new
@@ -32,23 +30,27 @@ describe 'Oxidized::Output::File' do
       @outputs << 'configuration'
     end
     it 'stores configurations in the configured folder' do
-      FakeFS.with_fresh do
-        Dir.mkdir('/fakefs')
+      Dir.mktmpdir do |temp_dir|
+        Oxidized.config.output.file.directory = temp_dir
+
         @file.store('node1', @outputs)
 
-        _(File.exist?('/fakefs/node1')).must_equal true
-        _(File.read('/fakefs/node1')).must_equal 'configuration'
+        _(File.exist?(File.join(temp_dir, 'node1'))).must_equal true
+        _(File.read(File.join(temp_dir, 'node1'))).must_equal 'configuration'
       end
     end
 
     it 'stores group configurations in the parent folder' do
-      FakeFS.with_fresh do
-        Dir.mkdir('/fakefs')
+      Dir.mktmpdir do |temp_dir|
+        config_dir = File.join(temp_dir, 'configs')
+        Oxidized.config.output.file.directory = config_dir
+        Dir.mkdir(config_dir)
+
         @file.store('node1', @outputs, { group: 'gr1' })
 
-        _(File.exist?('/fakefs/node1')).must_equal false
-        _(File.exist?('/gr1/node1')).must_equal true
-        _(File.read('/gr1/node1')).must_equal 'configuration'
+        _(File.exist?(File.join(temp_dir, 'node1'))).must_equal false
+        _(File.exist?(File.join(temp_dir, 'gr1/node1'))).must_equal true
+        _(File.read(File.join(temp_dir, 'gr1/node1'))).must_equal 'configuration'
       end
     end
   end
@@ -56,7 +58,6 @@ describe 'Oxidized::Output::File' do
   describe 'clean_obsolete_nodes' do
     before do
       Oxidized.asetus = Asetus.new
-      Oxidized.config.output.file.directory = '/fakefs'
       Oxidized.asetus.cfg.debug = false
       Oxidized.setup_logger
       @opts = {
@@ -67,68 +68,77 @@ describe 'Oxidized::Output::File' do
     end
 
     it "removes obsolete configuration files - without groups" do
-      FakeFS.with_fresh do
-        Dir.mkdir('/fakefs')
-        File.write('/fakefs/node1', 'Configuration')
-        File.write('/fakefs/node2', 'Configuration')
-        File.write('/fakefs/node3', 'Configuration')
+      Oxidized.config.output.file.directory = '/fakefs'
+      nodes = %w[node1 node2].map { |e| Oxidized::Node.new(@opts.merge(name: e)) }
 
-        nodes = %w[node1 node2].map { |e| Oxidized::Node.new(@opts.merge(name: e)) }
+      Dir.expects(:glob).with('/fakefs/*').returns(['/fakefs/node1',
+                                                    '/fakefs/node2',
+                                                    '/fakefs/node3',
+                                                    '/fakefs/directory'])
 
-        Oxidized::Output::File.clean_obsolete_nodes(nodes)
+      File.expects(:file?).with('/fakefs/directory').returns(false)
+      File.expects(:file?).returns(true).times(3)
+      File.expects(:delete).with('/fakefs/node1').never
+      File.expects(:delete).with('/fakefs/node2').never
+      File.expects(:delete).with('/fakefs/node3')
+      File.expects(:delete).with('/fakefs/directory').never
 
-        _(File.exist?('/fakefs/node1')).must_equal true
-        _(File.exist?('/fakefs/node2')).must_equal true
-        _(File.exist?('/fakefs/node3')).must_equal false
-      end
+      Oxidized::Output::File.clean_obsolete_nodes(nodes)
     end
 
     it "does not remove non-configuration files" do
-      FakeFS.with_fresh do
-        Dir.mkdir('/fakefs')
-        Dir.mkdir('/fakefs/subdir')
-        File.write('/fakefs/subdir/nonode', 'no config')
-        File.write('/fakefs/.nonode', 'no config')
-        File.write('/some_file', 'no config')
+      Dir.mktmpdir do |temp_dir|
+        config_dir = File.join(temp_dir, 'configs')
+        Oxidized.config.output.file.directory = config_dir
+
+        Dir.mkdir(config_dir)
+        Dir.mkdir(File.join(config_dir, 'subdir'))
+        File.write(File.join(config_dir, 'subdir/nonode'), 'no config')
+        File.write(File.join(config_dir, '.nonode'), 'no config')
+        File.write(File.join(temp_dir, '/some_file'), 'no config')
 
         nodes = %w[node1 node2].map { |e| Oxidized::Node.new(@opts.merge(name: e)) }
 
         Oxidized::Output::File.clean_obsolete_nodes(nodes)
 
         # Nodes can't be in subdirectories
-        _(File.exist?('/fakefs/subdir/nonode')).must_equal true
+        _(File.exist?(File.join(config_dir, 'subdir/nonode'))).must_equal true
         # Files beginning with . are not deleted
-        _(File.exist?('/fakefs/.nonode')).must_equal true
+        _(File.exist?(File.join(config_dir, '.nonode'))).must_equal true
         # Files outside /fakefs are not deleted
-        _(File.exist?('/some_file')).must_equal true
+        _(File.exist?(File.join(temp_dir, '/some_file'))).must_equal true
       end
     end
 
     it "removes obsolete configuration files - with groups" do
-      FakeFS.with_fresh do
-        Dir.mkdir('/gr1')
-        File.write('/gr1/node11', 'Configuration')
-        File.write('/gr1/node12', 'Configuration')
-        File.write('/gr1/node13', 'Configuration')
-        Dir.mkdir('/gr2')
-        File.write('/gr2/node21', 'Configuration')
-        Dir.mkdir('/gr1/gr3')
-        File.write('/gr1/gr3/node131', 'Configuration')
-        File.write('/gr1/gr3/node141', 'Configuration')
+      Dir.mktmpdir do |temp_dir|
+        config_dir = File.join(temp_dir, 'configs')
+        Oxidized.config.output.file.directory = config_dir
+
+        Dir.mkdir(config_dir)
+        Dir.mkdir(File.join(temp_dir, 'gr1'))
+        File.write(File.join(temp_dir, 'gr1/node11'), 'Configuration')
+        File.write(File.join(temp_dir, 'gr1/node12'), 'Configuration')
+        File.write(File.join(temp_dir, 'gr1/node13'), 'Configuration')
+        Dir.mkdir(File.join(temp_dir, 'gr2'))
+        File.write(File.join(temp_dir, 'gr2/node21'), 'Configuration')
+        Dir.mkdir(File.join(temp_dir, 'gr1/gr3'))
+        File.write(File.join(temp_dir, 'gr1/gr3/node131'), 'Configuration')
+        File.write(File.join(temp_dir, 'gr1/gr3/node141'), 'Configuration')
 
         nodes = %w[node11 node12].map { |e| Oxidized::Node.new(@opts.merge(name: e, group: 'gr1')) }
         nodes << Oxidized::Node.new(@opts.merge(name: 'node131', group: 'gr1/gr3'))
 
         Oxidized::Output::File.clean_obsolete_nodes(nodes)
 
-        _(File.exist?('/gr1/node11')).must_equal true
-        _(File.exist?('/gr1/node12')).must_equal true
-        _(File.exist?('/gr1/node13')).must_equal false
+        _(File.exist?(File.join(temp_dir, 'gr1/node11'))).must_equal true
+        _(File.exist?(File.join(temp_dir, 'gr1/node12'))).must_equal true
+        _(File.exist?(File.join(temp_dir, 'gr1/node13'))).must_equal false
         # We don't remove from obsolete groups as it could be something else
-        _(File.exist?('/gr2/node21')).must_equal true
+        _(File.exist?(File.join(temp_dir, 'gr2/node21'))).must_equal true
         # Works with groups containing / (subgroups)
-        _(File.exist?('/gr1/gr3/node131')).must_equal true
-        _(File.exist?('/gr1/gr3/node132')).must_equal false
+        _(File.exist?(File.join(temp_dir, 'gr1/gr3/node131'))).must_equal true
+        _(File.exist?(File.join(temp_dir, 'gr1/gr3/node132'))).must_equal false
       end
     end
   end

--- a/spec/output/git_spec.rb
+++ b/spec/output/git_spec.rb
@@ -166,14 +166,13 @@ describe Oxidized::Output::Git do
     end
   end
 
-  describe 'clean_obsolete_nodes with single_repo = true' do
+  describe 'clean_obsolete_nodes' do
     before do
       Oxidized.asetus = Asetus.new
 
       Oxidized.config.output.git.user = 'Oxidized'
       Oxidized.config.output.git.email = 'oxidized@example.com'
       Oxidized.config.output.git.repo = '/gitrepo'
-      Oxidized.config.output.git.single_repo = true
 
       Oxidized.asetus.cfg.debug = false
       Oxidized.asetus.cfg.log = File::NULL
@@ -187,12 +186,14 @@ describe Oxidized::Output::Git do
     end
 
     it "does nothing when the repo dir doesn't exists" do
+      Oxidized.config.output.git.single_repo = true
       File.expects(:directory?).with('/gitrepo').returns(false)
       Rugged::Repository.expects(:new).never
 
       Oxidized::Output::Git.clean_obsolete_nodes([])
     end
     it "does nothing when the repo is empty" do
+      Oxidized.config.output.git.single_repo = true
       File.expects(:directory?).with('/gitrepo').returns(true)
       mock_repo = mock('Rugged::Repository')
       Rugged::Repository.expects(:new).returns(mock_repo)
@@ -201,7 +202,22 @@ describe Oxidized::Output::Git do
       Oxidized::Output::Git.clean_obsolete_nodes([])
     end
 
+    it "does nothing without single_repo = true" do
+      Rugged::Repository.expects(:new).never
+
+      Oxidized::Output::Git.clean_obsolete_nodes([])
+    end
+
+    it "does nothing when type_as_directory = true" do
+      Oxidized.config.output.git.single_repo = true
+      Oxidized.config.output.git.type_as_directory = true
+      Rugged::Repository.expects(:new).never
+
+      Oxidized::Output::Git.clean_obsolete_nodes([])
+    end
+
     it "removes obsolete configuration files" do
+      Oxidized.config.output.git.single_repo = true
       File.expects(:directory?).with('/gitrepo').returns(true)
 
       mock_repo = mock('Rugged::Repository')

--- a/spec/output/output_spec.rb
+++ b/spec/output/output_spec.rb
@@ -1,0 +1,43 @@
+require_relative '../spec_helper'
+require 'oxidized/output/output'
+require 'oxidized/output/git'
+require 'oxidized/output/file'
+require 'oxidized/output/http'
+
+describe 'Oxidized::Output' do
+  describe '.clean_obsolete_nodes' do
+    before do
+      Oxidized.asetus = Asetus.new
+      Oxidized.asetus.cfg.debug = false
+      Oxidized.setup_logger
+    end
+    it 'runs on git' do
+      Oxidized.config.output.default = 'git'
+      Oxidized.config.output.git.repo = 'gitrepo'
+      Oxidized.config.output.clean_obsolete_nodes = true
+      Oxidized::Output::Git.expects(:clean_obsolete_nodes)
+      Oxidized::Output::File.expects(:clean_obsolete_nodes).never
+      Oxidized::Output.clean_obsolete_nodes([])
+    end
+    it 'runs on file' do
+      Oxidized.config.output.default = 'file'
+      Oxidized.config.output.file.directory = 'configs'
+      Oxidized.config.output.clean_obsolete_nodes = true
+      Oxidized::Output::File.expects(:clean_obsolete_nodes)
+      Oxidized::Output::Git.expects(:clean_obsolete_nodes).never
+      Oxidized::Output.clean_obsolete_nodes([])
+    end
+
+    it 'runs the default method on http' do
+      Oxidized.config.output.default = 'http'
+      Oxidized.config.output.http.url = 'fakeurl'
+      Oxidized.config.output.clean_obsolete_nodes = true
+      Oxidized::Output::File.expects(:clean_obsolete_nodes).never
+      Oxidized::Output::Git.expects(:clean_obsolete_nodes).never
+      Oxidized.logger.expects(:warn)
+              .with("clean_obsolete_nodes is not " \
+                    "implemented for Oxidized::Output::Http")
+      Oxidized::Output.clean_obsolete_nodes([])
+    end
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
When the configuration `output.clean_obsolete_nodes` is set to `true`, the outputs git and file will remove the configuration files of nodes not listed in source anymore. See the documentation for more details.


Closes Issue #1805 (Remove saved configuration for devices not listed in sources anymore)
