### PR TITLE
log an error when no suitable input is found for a node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - netgear: include running-config in config output (@bradleywehmeier)
 - eltex: remove inefficient regular expression / Fixes code scanning alert 7 / See Issue #3513 (@robertcheramy)
 - tmos: remove deprecated secrets (@rouven0)
+- log an error when no suitable input is found for a node. Fixes: #3346 (@robertcheramy) 
 
 
 ## [0.33.0 - 2025-03-26]

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -55,6 +55,8 @@ module Oxidized
           status = :no_connection
         end
       end
+      Oxidized.logger.error "No suitable input found for #{name}" unless @model.input
+
       @model.input = nil
       [status, config]
     end

--- a/spec/model/apc_aos_spec.rb
+++ b/spec/model/apc_aos_spec.rb
@@ -64,6 +64,8 @@ describe 'Model apc_aos' do
                                username: 'alma',
                                password: 'armud',
                                prompt:   'test_prompt')
+    Oxidized.logger.expects(:error)
+            .with("No suitable input found for example.com")
 
     status, = @node.run
 

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -64,6 +64,20 @@ describe Oxidized::Node do
       fails = after_fails - before_fails
       _(fails).must_equal 1
     end
+
+    it 'should warn when no suitable input has been found' do
+      node = Oxidized::Node.new(name:     'example.com',
+                                input:    'http',
+                                output:   'git',
+                                model:    'junos',
+                                username: 'alma',
+                                password: 'armud',
+                                prompt:   'test_prompt')
+      Oxidized.logger.expects(:error)
+              .with("No suitable input found for example.com")
+      status, = node.run
+      _(status).must_equal :fail
+    end
   end
 
   describe '#repo' do


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fixes: #3346
