### PR TITLE
undo edgerouter changes in vyatta.rb (from #3547)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - sonicos: remove inefficient regular expression / Fixes code scanning alert #4 and #11 (@robertcheramy)
 - quantaos: remove inefficient regular expression / Fixes code scanning alerts 9 and 10 (@robertcheramy)
 - fabricos: remove power supply input voltage from `chassisShow` output (@hops)
-- vyatta: Ignore system uptime in `show version` on Edgerouter devices (@shanemcc)
 - netgear: include running-config in config output (@bradleywehmeier)
 - eltex: remove inefficient regular expression / Fixes code scanning alert 7 / See Issue #3513 (@robertcheramy)
 - tmos: remove deprecated secrets (@rouven0)

--- a/lib/oxidized/model/vyatta.rb
+++ b/lib/oxidized/model/vyatta.rb
@@ -21,7 +21,6 @@ class Vyatta < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    cfg.gsub! /^Uptime[^\n]*\n/, ''
     comment cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Pull request #3547 changes vyatta.rb instead of edgeos.rb. This pull request fixed this fault.

See https://github.com/ytti/oxidized/pull/3547#issuecomment-3044689710