### PR TITLE
Fix firepower timeout on syntax error

### DIFF
--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -47,7 +47,7 @@ module Oxidized
     def cmd(cmd, expect = node.prompt)
       logger.debug "Sending '#{cmd.dump}' @ #{node.name} with expect: #{expect.inspect}"
       if Oxidized.config.input.debug?
-        @log.puts "sent #{cmd.dump}"
+        @log.puts "sent cmd #{@exec ? cmd.dump : (cmd + newline).dump}"
         @log.flush
       end
       cmd_output = if @exec
@@ -60,6 +60,10 @@ module Oxidized
     end
 
     def send(data)
+      if Oxidized.config.input.debug?
+        @log.puts "sent data #{data.dump}"
+        @log.flush
+      end
       @ses.send_data data
     end
 

--- a/lib/oxidized/model/firelinuxos.rb
+++ b/lib/oxidized/model/firelinuxos.rb
@@ -3,12 +3,21 @@ class FireLinuxOS < Oxidized::Model
 
   # Fire Linux OS is what the new FTD (FirePOWER) series devices from Cisco run. At the backend, it's mostly identical to ASA's.
 
-  prompt /^[#>]\(?.+\)?\s?/
-  comment  '! '
+  prompt /^[#>]\(?.+\)? ?$/
+  comment '! '
+
+  expect /^Syntax error: .*\n.*$/ do |data, re|
+    # The firepower does not remove the entered command, so
+    # Send CTRL-U and \n for a fresh prompt
+    send "\x15\n"
+    data.sub re, ''
+  end
 
   cmd :all do |cfg|
     cfg.gsub! /^% Invalid input detected at '\^' marker\.$|^\s+\^$/, ''
-    cfg.each_line.to_a[1..-2].join
+    # Ged rid of ANSI escape codes
+    cfg.gsub! /\e\[[0-?]*[ -\/]*[@-~]\r?/, ''
+    cfg.cut_both
   end
 
   cmd :secret do |cfg|

--- a/spec/model/data/firelinuxos#FPR-1010_7.4.2#output.txt
+++ b/spec/model/data/firelinuxos#FPR-1010_7.4.2#output.txt
@@ -1,0 +1,82 @@
+! -------------------[ FPR-12345 ]--------------------
+! Model                     : Cisco Firepower 1010 Threat Defense (78) Version 7.4.2 (Build 172)
+! UUID                      : 5d111111-0000-0000-0000-00000000cafe
+! LSP version               : lsp-rel-20250114-1341
+! VDB version               : 400
+! ----------------------------------------------------
+! 
+! Cisco Adaptive Security Appliance Software Version 9.20(2)32 
+! SSP Operating System Version 2.14(1.167)
+! 
+! Compiled on Mon 29-Jul-24 18:15 GMT by builders
+! System image file is "disk0:/installables/switch/fxos-k8-fp1k-lfbff.2.14.1.167.SPA"
+! Config file at boot was "startup-config"
+! 
+! Start-up time 20 secs
+! 
+! Hardware:   FPR-1010, 2581 MB RAM, CPU Atom C3000 series 2200 MHz, 1 CPU (4 cores)
+! 
+! Encryption hardware device : Cisco FP Crypto on-board accelerator (revision 0x11)
+!                              Driver version        : 4.12.0
+!                              Number of accelerators: 6
+! 
+!  1: Int: Internal-Data0/0    : address is 00a0.c900.0000, irq 10
+!  3: Ext: Management1/1       : address is 5c5a.c700.cafe, irq 0
+!  4: Int: Internal-Data1/1    : address is 0000.0100.0001, irq 0
+!  5: Int: Internal-Data1/2    : address is 0000.0300.0001, irq 0
+!  6: Int: Internal-Control1/1 : address is 0000.0001.0001, irq 0
+! 
+! Serial Number: JAD20000AAA
+! Configuration has not been modified since last system restart.
+! Name: "module 0", DESCR: "Firepower 1010 Appliance, Desktop, 8 GE, 1 MGMT"
+! PID: FPR-1010          , VID: V01     , SN: JMX0000AAAA
+! 
+:
+NGFW Version 7.4.2 
+!
+command-alias exec h help
+command-alias exec lo logout
+command-alias exec p ping
+command-alias exec s show
+terminal width 80
+hostname FPR-12345
+enable password ***** encrypted
+no asp load-balance per-packet
+! ...
+!
+interface Vlan1
+ no nameif
+ no cts manual
+ no security-level
+ vrf forwarding default
+ no ip address
+ delay 10
+!
+interface Ethernet1/1
+ description outside interface
+ no switchport
+ nameif OUTSIDE
+ no cts manual
+ security-level 0
+ vrf forwarding default
+ ip address 10.42.42.18 255.255.255.248 
+ delay 1
+!
+! ...
+interface Management1/1
+ speed auto
+ duplex auto
+ management-only
+ nameif management
+ cts manual
+  propagate sgt preserve-untag
+  policy static sgt disabled trusted
+ security-level 0
+ vrf forwarding default
+ delay 100
+!
+! ...
+snort preserve-connection
+snort multichannel-lb enable
+no dp-tcp-proxy
+Cryptochecksum:70000cafe00000000000effffaaaacd0

--- a/spec/model/data/firelinuxos#FPR-1010_7.4.2#simulation.yaml
+++ b/spec/model/data/firelinuxos#FPR-1010_7.4.2#simulation.yaml
@@ -1,0 +1,117 @@
+---
+init_prompt: |-
+    Last login: Thu Jul 10 09:11:54 UTC 2025 from 10.42.1.2 on pts/0
+    Successful login attempts for user 'oxidized' : 42
+    Last failed login: Thu Jul 10 09:21:42 UTC 2025 from 10.42.1.2 on ssh:notty
+    There was 1 failed login attempt since the last successful login.
+    Last login: Thu Jul 10 09:21:45 2025 from 10.42.1.2\r
+    
+    Copyright 2004-2024, Cisco and/or its affiliates. All rights reserved.\x20
+    Cisco is a registered trademark of Cisco Systems, Inc.\x20
+    All other trademarks are property of their respective owners.
+    
+    Cisco Firepower Extensible Operating System (FX-OS) v2.14.1 (build 167)
+    Cisco Firepower 1010 Threat Defense v7.4.2 (build 172)
+    
+    >\x20
+commands:
+  - "show version system\n": |-
+      show version system
+      -------------------[ FPR-12345 ]--------------------
+      Model                     : Cisco Firepower 1010 Threat Defense (78) Version 7.4.2 (Build 172)
+      UUID                      : 5d111111-0000-0000-0000-00000000cafe
+      LSP version               : lsp-rel-20250114-1341
+      VDB version               : 400
+      ----------------------------------------------------
+      
+      Cisco Adaptive Security Appliance Software Version 9.20(2)32\x20
+      SSP Operating System Version 2.14(1.167)
+      
+      Compiled on Mon 29-Jul-24 18:15 GMT by builders
+      System image file is \"disk0:/installables/switch/fxos-k8-fp1k-lfbff.2.14.1.167.SPA\"
+      Config file at boot was \"startup-config\"
+      
+      FPR-12345 up 40 days 21 hours
+      Start-up time 20 secs
+      
+      Hardware:   FPR-1010, 2581 MB RAM, CPU Atom C3000 series 2200 MHz, 1 CPU (4 cores)
+      
+      Encryption hardware device : Cisco FP Crypto on-board accelerator (revision 0x11)
+                                   Driver version        : 4.12.0
+                                   Number of accelerators: 6
+      
+       1: Int: Internal-Data0/0    : address is 00a0.c900.0000, irq 10
+       3: Ext: Management1/1       : address is 5c5a.c700.cafe, irq 0
+       4: Int: Internal-Data1/1    : address is 0000.0100.0001, irq 0
+       5: Int: Internal-Data1/2    : address is 0000.0300.0001, irq 0
+       6: Int: Internal-Control1/1 : address is 0000.0001.0001, irq 0
+      
+      Serial Number: JAD20000AAA
+      Configuration has not been modified since last system restart.
+      >\x20
+  - "show inventory\n": |-
+      show inventory
+      Name: \"module 0\", DESCR: \"Firepower 1010 Appliance, Desktop, 8 GE, 1 MGMT\"
+      PID: FPR-1010          , VID: V01     , SN: JMX0000AAAA
+      
+      >\x20
+  - "show running-config all\n": |-
+      show running-config all
+      : Saved
+      
+      :\x20
+      : Serial Number: JAD20000AAA
+      : Hardware:   FPR-1010, 2581 MB RAM, CPU Atom C3000 series 2200 MHz, 1 CPU (4 cores)
+      :
+      NGFW Version 7.4.2\x20
+      !
+      command-alias exec h help
+      command-alias exec lo logout
+      command-alias exec p ping
+      command-alias exec s show
+      terminal width 80
+      hostname FPR-12345
+      enable password ***** encrypted
+      no asp load-balance per-packet
+      ! ...
+      !
+      interface Vlan1
+       no nameif
+       no cts manual
+       no security-level
+       vrf forwarding default
+       no ip address
+       delay 10
+      !
+      interface Ethernet1/1
+       description outside interface
+       no switchport
+       nameif OUTSIDE
+       no cts manual
+       security-level 0
+       vrf forwarding default
+       ip address 10.42.42.18 255.255.255.248\x20
+       delay 1
+      !
+      ! ...
+      interface Management1/1
+       speed auto
+       duplex auto
+       management-only
+       nameif management
+       cts manual
+        propagate sgt preserve-untag
+        policy static sgt disabled trusted
+       security-level 0
+       vrf forwarding default
+       delay 100
+      !
+      ! ...
+      snort preserve-connection
+      snort multichannel-lb enable
+      no dp-tcp-proxy
+      Cryptochecksum:70000cafe00000000000effffaaaacd0
+      : end
+      >\x20
+  - "exit\n": |-
+      exit

--- a/spec/model/data/firelinuxos#show_inventory_unsupported#output.txt
+++ b/spec/model/data/firelinuxos#show_inventory_unsupported#output.txt
@@ -1,0 +1,80 @@
+! -------------------[ FPR-12345 ]--------------------
+! Model                     : Cisco Firepower 1010 Threat Defense (78) Version 7.4.2 (Build 172)
+! UUID                      : 5d111111-0000-0000-0000-00000000cafe
+! LSP version               : lsp-rel-20250114-1341
+! VDB version               : 400
+! ----------------------------------------------------
+! 
+! Cisco Adaptive Security Appliance Software Version 9.20(2)32 
+! SSP Operating System Version 2.14(1.167)
+! 
+! Compiled on Mon 29-Jul-24 18:15 GMT by builders
+! System image file is "disk0:/installables/switch/fxos-k8-fp1k-lfbff.2.14.1.167.SPA"
+! Config file at boot was "startup-config"
+! 
+! Start-up time 20 secs
+! 
+! Hardware:   FPR-1010, 2581 MB RAM, CPU Atom C3000 series 2200 MHz, 1 CPU (4 cores)
+! 
+! Encryption hardware device : Cisco FP Crypto on-board accelerator (revision 0x11)
+!                              Driver version        : 4.12.0
+!                              Number of accelerators: 6
+! 
+!  1: Int: Internal-Data0/0    : address is 00a0.c900.0000, irq 10
+!  3: Ext: Management1/1       : address is 5c5a.c700.cafe, irq 0
+!  4: Int: Internal-Data1/1    : address is 0000.0100.0001, irq 0
+!  5: Int: Internal-Data1/2    : address is 0000.0300.0001, irq 0
+!  6: Int: Internal-Control1/1 : address is 0000.0001.0001, irq 0
+! 
+! Serial Number: JAD20000AAA
+! Configuration has not been modified since last system restart.
+! 
+:
+NGFW Version 7.4.2 
+!
+command-alias exec h help
+command-alias exec lo logout
+command-alias exec p ping
+command-alias exec s show
+terminal width 80
+hostname FPR-12345
+enable password ***** encrypted
+no asp load-balance per-packet
+! ...
+!
+interface Vlan1
+ no nameif
+ no cts manual
+ no security-level
+ vrf forwarding default
+ no ip address
+ delay 10
+!
+interface Ethernet1/1
+ description outside interface
+ no switchport
+ nameif OUTSIDE
+ no cts manual
+ security-level 0
+ vrf forwarding default
+ ip address 10.42.42.18 255.255.255.248 
+ delay 1
+!
+! ...
+interface Management1/1
+ speed auto
+ duplex auto
+ management-only
+ nameif management
+ cts manual
+  propagate sgt preserve-untag
+  policy static sgt disabled trusted
+ security-level 0
+ vrf forwarding default
+ delay 100
+!
+! ...
+snort preserve-connection
+snort multichannel-lb enable
+no dp-tcp-proxy
+Cryptochecksum:70000cafe00000000000effffaaaacd0

--- a/spec/model/data/firelinuxos#show_inventory_unsupported#simulation.yaml
+++ b/spec/model/data/firelinuxos#show_inventory_unsupported#simulation.yaml
@@ -1,0 +1,118 @@
+---
+init_prompt: |-
+    Last login: Thu Jul 10 09:11:54 UTC 2025 from 10.42.1.2 on pts/0
+    Successful login attempts for user 'oxidized' : 42
+    Last failed login: Thu Jul 10 09:21:42 UTC 2025 from 10.42.1.2 on ssh:notty
+    There was 1 failed login attempt since the last successful login.
+    Last login: Thu Jul 10 09:21:45 2025 from 10.42.1.2\r
+    
+    Copyright 2004-2024, Cisco and/or its affiliates. All rights reserved.\x20
+    Cisco is a registered trademark of Cisco Systems, Inc.\x20
+    All other trademarks are property of their respective owners.
+    
+    Cisco Firepower Extensible Operating System (FX-OS) v2.14.1 (build 167)
+    Cisco Firepower 1010 Threat Defense v7.4.2 (build 172)
+    
+    >\x20
+commands:
+  - "show version system\n": |-
+      show version system
+      -------------------[ FPR-12345 ]--------------------
+      Model                     : Cisco Firepower 1010 Threat Defense (78) Version 7.4.2 (Build 172)
+      UUID                      : 5d111111-0000-0000-0000-00000000cafe
+      LSP version               : lsp-rel-20250114-1341
+      VDB version               : 400
+      ----------------------------------------------------
+      
+      Cisco Adaptive Security Appliance Software Version 9.20(2)32\x20
+      SSP Operating System Version 2.14(1.167)
+      
+      Compiled on Mon 29-Jul-24 18:15 GMT by builders
+      System image file is \"disk0:/installables/switch/fxos-k8-fp1k-lfbff.2.14.1.167.SPA\"
+      Config file at boot was \"startup-config\"
+      
+      FPR-12345 up 40 days 21 hours
+      Start-up time 20 secs
+      
+      Hardware:   FPR-1010, 2581 MB RAM, CPU Atom C3000 series 2200 MHz, 1 CPU (4 cores)
+      
+      Encryption hardware device : Cisco FP Crypto on-board accelerator (revision 0x11)
+                                   Driver version        : 4.12.0
+                                   Number of accelerators: 6
+      
+       1: Int: Internal-Data0/0    : address is 00a0.c900.0000, irq 10
+       3: Ext: Management1/1       : address is 5c5a.c700.cafe, irq 0
+       4: Int: Internal-Data1/1    : address is 0000.0100.0001, irq 0
+       5: Int: Internal-Data1/2    : address is 0000.0300.0001, irq 0
+       6: Int: Internal-Control1/1 : address is 0000.0001.0001, irq 0
+      
+      Serial Number: JAD20000AAA
+      Configuration has not been modified since last system restart.
+      >\x20
+  - "show inventory\n": |-
+      show inventory
+      Syntax error: Illegal parameter
+      > show inventory\a
+  - "\x15\n": |-
+      \e[12D\e[J
+      >\x20
+  - "show running-config all\n": |-
+      show running-config all
+      : Saved
+      
+      :\x20
+      : Serial Number: JAD20000AAA
+      : Hardware:   FPR-1010, 2581 MB RAM, CPU Atom C3000 series 2200 MHz, 1 CPU (4 cores)
+      :
+      NGFW Version 7.4.2\x20
+      !
+      command-alias exec h help
+      command-alias exec lo logout
+      command-alias exec p ping
+      command-alias exec s show
+      terminal width 80
+      hostname FPR-12345
+      enable password ***** encrypted
+      no asp load-balance per-packet
+      ! ...
+      !
+      interface Vlan1
+       no nameif
+       no cts manual
+       no security-level
+       vrf forwarding default
+       no ip address
+       delay 10
+      !
+      interface Ethernet1/1
+       description outside interface
+       no switchport
+       nameif OUTSIDE
+       no cts manual
+       security-level 0
+       vrf forwarding default
+       ip address 10.42.42.18 255.255.255.248\x20
+       delay 1
+      !
+      ! ...
+      interface Management1/1
+       speed auto
+       duplex auto
+       management-only
+       nameif management
+       cts manual
+        propagate sgt preserve-untag
+        policy static sgt disabled trusted
+       security-level 0
+       vrf forwarding default
+       delay 100
+      !
+      ! ...
+      snort preserve-connection
+      snort multichannel-lb enable
+      no dp-tcp-proxy
+      Cryptochecksum:70000cafe00000000000effffaaaacd0
+      : end
+      >\x20
+  - "exit\n": |-
+      exit


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Firepowers have an unfriendly CLI. Instead of returning "command unknown" when show inventory isn't supported, it keeps the old command on the cli, so oxidized sends the next command and you get `show inventoryshow running-configuration`, which doen't work.

This PR wipes the last command on error, which fixes the problem in a nicer way than PR #3394.

It also updates the input debug messages to see directly send data in expects, which is helpful for debugging.

Fixes #3393
Fixes #3502
