### PR TITLE
zynos: fix overly permissive regular expression range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - sixwind: New model to support 6WIND Virtual Service Router (@hcaldicott)
 - model for saos10 (@penfold1972)
 
-
 ### Changed
 - remove uri in commit-archive location for EdgeOS. Fixed #3525 (@systeembeheerder)
 - acos: remove free storage amount from show version. Fixes #3492 (@991jo)
@@ -48,6 +47,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - tmos: remove deprecated secrets (@rouven0)
 - log an error when no suitable input is found for a node. Fixes: #3346 (@robertcheramy)
 - firelinuxos: fix timeout on syntax error. Fixes #3393, #3502 (@robertcheramy)
+- zynos: fix overly permissive regular expression range. Fixes code scanning
+  alert 19 / See Issue #3513 (@robertcheramy)
 
 
 ## [0.33.0 - 2025-03-26]

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -1,9 +1,9 @@
 class ZyNOS < Oxidized::Model
   using Refinements
 
-  prompt /^([\w.@()-<]+[#>]\s?)$/
+  prompt /^([\w.@()\-<]+[#>]\s?)$/
   # if there is something you can not identify after prompt, uncomment next line and comment previous line
-  # prompt /^([\w.@()-<]+[#>]\s?).*$/
+  # prompt /^([\w.@()\-<]+[#>]\s?).*$/
 
   comment '! '
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
code scanning  alert 19 / See Issue #3513