### PR TITLE
zynos: fix overly permissive regular expression range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - log an error when no suitable input is found for a node. Fixes: #3346 (@robertcheramy)
 - firelinuxos: fix timeout on syntax error. Fixes #3393, #3502 (@robertcheramy)
 - zynos: fix overly permissive regular expression range. Fixes code scanning
-  alert 18 / See Issue #3513 (@robertcheramy)
+  alert 18 and 19/ See Issue #3513 (@robertcheramy)
 - aosw: fix polynomial regular expression. Fixes code scanning
   alert 36 / See Issue #3513 (@robertcheramy)
 

--- a/lib/oxidized/model/zynos.rb
+++ b/lib/oxidized/model/zynos.rb
@@ -21,7 +21,7 @@ class ZyNOS < Oxidized::Model
   end
 
   # ignore copyright motd
-  expect /^(Copyright .*)\n^([\w.@()-<]+[#>]\s?)$/ do
+  expect /^(Copyright .*)\n^([\w.@()\-<]+[#>]\s?)$/ do
     send '\n'
     ""
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fixes code scanning alert 19 / See Issue #3513
