### PR TITLE
input/ssh: hide Net::SSH errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+- input/ssh: hide Net::SSH errors and only display fatal logs unless input.debug = true. Fixes: #3574 (@robertcheramy)
 
 
 ## [0.34.0 - 2025-07-15]

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -164,7 +164,7 @@ module Oxidized
 
       # Use our logger for Net:SSH
       ssh_logger = SemanticLogger[Net::SSH]
-      ssh_logger.level = Oxidized.config.input.debug? ? :debug : :error
+      ssh_logger.level = Oxidized.config.input.debug? ? :debug : :fatal
       ssh_opts[:logger] = ssh_logger
 
       ssh_opts


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Revert to the log level of 0.33.0 for Net::SSH (:fatal, which is the default level of Net::SSH).

I could have disabled the use of ssh-agent with use_agent = false, but I'm not sure if someone uses an ssh-agent with oxidized. If we want to see the errors of Net::SSH when input.debug = false, we'll have to test if an agent is configured before opening a connection.

Fixes: #3574