### PR TITLE
Slackdiff: Make Slack file upload respect a configured HTTP proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## HEAD
 
+### Changed
+- slackdiff: Attempt to join the channel if Errors::NotInChannel is encountered (@varesa)
+
 ### Fixed
 - SSH raises error when closing closed connection. Fixes #3583 (@ytti)
 - Config vars will not fall back to less specific. Fixes #3536 (@ytti)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - SSH raises error when closing closed connection. Fixes #3583 (@ytti)
 - Config vars will not fall back to less specific. Fixes #3536 (@ytti)
+- slackdiff: Respect the HTTP proxy configuration while uploading the file (@varesa)
 
 ## [0.34.1 - 2025-07-18]
 This release contains small fixes and will include the new version of oxidized-web (0.17.0) in the docker container.

--- a/docs/Hooks.md
+++ b/docs/Hooks.md
@@ -249,7 +249,7 @@ Your AWS credentials should be stored in `~/.aws/credentials`.
 
 ## Hook type: slackdiff
 
-The `slackdiff` hook posts colorized config diffs to a [Slack](https://www.slack.com) channel of your choice. It only triggers for `post_store` events.
+The `slackdiff` hook posts colorized config diffs to a [Slack](https://www.slack.com) channel of your choice. It only triggers for `post_store` events. The used output must be capable of generating a diff. E.g. file output is not usable while git/gitcrypt will work.
 
 You will need to manually install the `slack-ruby-client` gem on your system:
 
@@ -270,7 +270,7 @@ hooks:
     channel: "CHANNEL_ID"
 ```
 
-The token parameter is a Slack API token that can be generated following [this tutorial](https://api.slack.com/tutorials/tracks/getting-a-token).  Until Slack stops supporting them, legacy tokens can also be used.
+The token parameter is a Slack API token that can be generated following [this tutorial](https://api.slack.com/tutorials/tracks/getting-a-token).  Until Slack stops supporting them, legacy tokens can also be used. If the token has channels:join permission, the bot will attempt to automatically join the configured channel if necessary.
 
 Optionally you can disable snippets and post a formatted message, for instance linking to a commit in a git repo. Named parameters `%{node}`, `%{group}`, `%{model}` and `%{commitref}` are available.
 

--- a/lib/oxidized/hook/slackdiff.rb
+++ b/lib/oxidized/hook/slackdiff.rb
@@ -31,8 +31,15 @@ class SlackDiff < Oxidized::Hook
       id:    upload_dest[:file_id],
       title: title
     }]
-    client.files_completeUploadExternal(channel_id: channel,
-                                        files:      files.to_json)
+    begin
+      client.files_completeUploadExternal(channel_id: channel,
+                                          files:      files.to_json)
+    rescue Slack::Web::Api::Errors::NotInChannel
+      logger.info "Not in specified channel, attempting to join"
+      client.conversations_join(channel: channel)
+      client.files_completeUploadExternal(channel_id: channel,
+                                          files:      files.to_json)
+    end
   end
 
   def run_hook(ctx)

--- a/lib/oxidized/hook/slackdiff.rb
+++ b/lib/oxidized/hook/slackdiff.rb
@@ -11,14 +11,20 @@ class SlackDiff < Oxidized::Hook
     raise KeyError, 'hook.channel is required' unless cfg.has_key?('channel')
   end
 
-  def slack_upload(client, title, content, channel)
+  def slack_upload(client, title, content, channel, proxy)
     logger.info "Posting diff as snippet to #{channel}"
     upload_dest = client.files_getUploadURLExternal(filename:     "change",
                                                     length:       content.length,
                                                     snippet_type: "diff")
     file_uri = URI.parse(upload_dest[:upload_url])
 
-    http = Net::HTTP.new(file_uri.host, file_uri.port)
+    proxy_uri = URI.parse(proxy) if proxy
+    proxy_address = proxy_uri ? proxy_uri.host : :ENV
+    proxy_port = proxy_uri&.port
+    proxy_user = proxy_uri&.user
+    proxy_pass = proxy_uri&.password
+
+    http = Net::HTTP.new(file_uri.host, file_uri.port, proxy_address, proxy_port, proxy_user, proxy_pass)
     http.use_ssl = true
 
     request = Net::HTTP::Post.new(file_uri.request_uri, { Host: file_uri.host })
@@ -60,7 +66,7 @@ class SlackDiff < Oxidized::Hook
       unless diff == "no diffs"
         title = "#{ctx.node.name} #{ctx.node.group} #{ctx.node.model.class.name.to_s.downcase}"
         content = diff[:patch].lines.to_a[4..-1].join
-        slack_upload(client, title, content, cfg.channel)
+        slack_upload(client, title, content, cfg.channel, cfg.has_key?('proxy') ? cfg.proxy : nil)
       end
     end
     # message custom formatted - optional


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
  - slackdiff has no existing tests at the moment, and the fact that the hook heavily leans on other infrastructure (slack, a HTTP proxy) I don't think my skills as someone touching Ruby for the second time in their life are quite up to the task of figuring out the required mocks/scaffolding.
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

The new slack file upload API introduced by commit b92e6208365fdb6983dc69f50810b27a3ef1e206 to replace the deprecated API which was not available to new users (see issue #3189) introduced a new HTTP call that was not using the provided proxy configuration and broke environments where a proxy was necessary.

This commit fixes the regression reported in the issue #3534 by using the same proxy setting for the new HTTP POST request to `https://files.slack.com/`

Closes issue #3534 

A minor related change:

I was unable to figure out why the slack app I created in a sandbox workspace did not show up in the list of apps I could invite into a channel, so in order to actually get the bot to post anything to the channel, I made the bot attempt to automatically join the channel if an upload fails due to the bot not being in the channel. I can split that into a separate PR, but since it is a minor change, I hope this will be good enough.

## Testing

Three scenarios have been tested with a dummy device, a git output and a sandbox slack organization:

### No proxy

No regresssions are visible when testing without a proxy in the config:
```
2025-07-24 16:45:10.297957 I [5870:200] Oxidized::Worker -- Configuration updated for /test
2025-07-24 16:45:10.298056 I [5870:200] SlackDiff -- Connecting to slack
2025-07-24 16:45:10.580717 I [5870:200] SlackDiff -- Connected
2025-07-24 16:45:10.582302 I [5870:200] SlackDiff -- Posting diff as snippet to C09756V8TGA
2025-07-24 16:45:11.777906 I [5870:200] SlackDiff -- Finished
```

### With a proxy

Before the change it could be seen from proxy logs that three HTTP requests were made through the proxy:
```
2025-07-24 15:53:18.045 7f5203e006c0 Request: slack.com:443/
2025-07-24 15:53:18.427 7f5203e006c0 Request: slack.com:443/
2025-07-24 15:53:19.198 7f5203e006c0 Request: slack.com:443/
```

After the change four requests are seen:
```
2025-07-24 16:07:38.059 7f5203e006c0 Request: slack.com:443/
2025-07-24 16:07:38.437 7f52034006c0 Request: slack.com:443/
2025-07-24 16:07:38.887 7f52034006c0 Request: files.slack.com:443/
2025-07-24 16:07:39.347 7f52034006c0 Request: slack.com:443/
```

And the request succeeds:
```
2025-07-24 16:47:51.341099 I [6454:200] Oxidized::Worker -- Configuration updated for /test
2025-07-24 16:47:51.341194 I [6454:200] SlackDiff -- Connecting to slack
2025-07-24 16:47:51.781547 I [6454:200] SlackDiff -- Connected
2025-07-24 16:47:51.783480 I [6454:200] SlackDiff -- Posting diff as snippet to C09756V8TGA
2025-07-24 16:47:53.388813 I [6454:200] SlackDiff -- Finished
```

### Bot not in channel

If the bot is not in the channel, the bot will attempt to join the channel and retry the request:
```
2025-07-24 16:49:01.960397 I [6649:200] Oxidized::Worker -- Configuration updated for /test
2025-07-24 16:49:01.960506 I [6649:200] SlackDiff -- Connecting to slack
2025-07-24 16:49:02.503192 I [6649:200] SlackDiff -- Connected
2025-07-24 16:49:02.505366 I [6649:200] SlackDiff -- Posting diff as snippet to C09756VJHBL
2025-07-24 16:49:03.849792 I [6649:200] SlackDiff -- Not in specified channel, attempting to join
2025-07-24 16:49:05.076074 I [6649:200] SlackDiff -- Finished
```

Causing 2 extra requests:
```
2025-07-24 16:49:02.038 7f52034006c0 Request: slack.com:443/
2025-07-24 16:49:02.591 7f52034006c0 Request: slack.com:443/
2025-07-24 16:49:02.950 7f5203e006c0 Request: files.slack.com:443/
2025-07-24 16:49:03.426 7f5203e006c0 Request: slack.com:443/
2025-07-24 16:49:03.912 7f5203e006c0 Request: slack.com:443/
2025-07-24 16:49:04.381 7f5203e006c0 Request: slack.com:443/
```
