### PR TITLE
Fix apc_aos not timing out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## HEAD
+## HEAD [Unreleased]
 
 ### Fixed
 - SSH raises error when closing closed connection. Fixes #3583 (@ytti)
 - Config vars will not fall back to less specific. Fixes #3536 (@ytti)
+- input/scp: make Net::SCP::Error produce a warning, not a crashfile (@robertcheramy)
+
 
 ## [0.34.1 - 2025-07-18]
 This release contains small fixes and will include the new version of oxidized-web (0.17.0) in the docker container.
@@ -20,6 +22,7 @@ This release contains small fixes and will include the new version of oxidized-w
 - input/ssh: hide Net::SSH errors and only display fatal logs unless input.debug = true. Fixes: #3574 (@robertcheramy)
 - junos: fix unfrozen literal strings (@robertcheramy)
 - spec/model: fix unfrozen literal strings and set a default prompt (@robertcheramy)
+
 
 ## [0.34.0 - 2025-07-15]
 :warning: This release introduces a [new logging system](docs/Configuration.md#logging),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## HEAD [Unreleased]
+### Added
+- Absolute time limit for a fetch job (default: 300 seconds) (@robertcheramy)
 
 ### Fixed
 - SSH raises error when closing closed connection. Fixes #3583 (@ytti)
 - Config vars will not fall back to less specific. Fixes #3536 (@ytti)
-- input/scp: make Net::SCP::Error produce a warning, not a crashfile (@robertcheramy)
+- input/scp: make common errors produce a warning, not a crashfile (@robertcheramy)
+- input/scp: implement timeouts. Fixes #3590 (@robertcheramy, @ytti)
 
 
 ## [0.34.1 - 2025-07-18]

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -46,6 +46,24 @@ The above strips out snmp community strings from your saved configs.
 
 **NOTE:** Removing secrets reduces the usefulness as a full configuration backup, but it may make sharing configs easier.
 
+## Timeout and Time limit
+You can configure when oxidized will `timeout` while fetching a configuration
+(default: 20 seconds), and how much absolute time (`timelimit`) the fetching
+is allowed to last (default: 300 seconds, or 5 minutes):
+
+* `timeout`: Maximum time to wait for a single operation during config fetching.
+  Not every input module has an implemented timeout.
+* `timelimit`: Maximum total time allowed for the entire fetch job. It is
+  independent of input modules and will always be enforced.
+
+If `timelimit`is reached, the fetch job will be killed and will produce a
+warning. The job status will be set to `timelimit`.
+
+```yaml
+timeout: 20
+timelimit: 300
+```
+
 ## Advanced Configuration
 
 Below is an advanced example configuration.
@@ -73,6 +91,7 @@ threads: 30 # maximum number of threads
 # true - always use the maximum number of threads
 use_max_threads: false
 timeout: 20
+timelimit: 300
 retries: 3
 prompt: !ruby/regexp /^([\w.@-]+[#>]\s?)$/
 crash:
@@ -215,7 +234,7 @@ models:
     password: pass
 ```
 
-### Options (credentials, vars, etc.) precedence:
+## Options (credentials, vars, etc.) precedence:
 From least to most important:
 - global options
 - model specific options

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -1,30 +1,11 @@
 # Configuration
 
-## Debugging
-
-In case a model plugin doesn't work correctly (ios, procurve, etc.), you can
-enable live debugging of SSH/Telnet sessions. Just add a `debug` option
-containing the value true to the `input` section. The log files will be created
-depending on the parent directory of the logfile option.
-
-The following example will log an active ssh/telnet session
-`/home/oxidized/.config/oxidized/log/<IP-Address>-<PROTOCOL>`. The file will be
-truncated on each consecutive ssh/telnet session, so you need to put a `tailf`
-or `tail -f` on that file!
-
-```yaml
-log: /home/oxidized/.config/oxidized/log
-
-# ...
-
-input:
-  default: ssh, telnet
-  debug: true
-  ssh:
-    secure: false
-  http:
-    ssl_verify: true
-```
+## Modules
+The configuration of each module is described in its respective sub-configuration file:
+* [Inputs.md](Inputs.md)
+* [Outputs.md](Outputs.md)
+* [Sources.md](Sources.md)
+* [Hooks.md](Hooks.md)
 
 ## Privileged mode
 
@@ -64,144 +45,6 @@ As a partial example from ios.rb:
 The above strips out snmp community strings from your saved configs.
 
 **NOTE:** Removing secrets reduces the usefulness as a full configuration backup, but it may make sharing configs easier.
-
-## Disabling SSH exec channels
-
-Oxidized uses exec channels to make information extraction simpler, but there
-are some situations where this doesn't work well, e.g. configuring devices. This
-feature can be turned off by setting the `ssh_no_exec`
-variable.
-
-```yaml
-vars:
-  ssh_no_exec: true
-```
-
-## Disabling SSH keepalives
-
-Oxidized SSH input makes use of SSH keepalives to prevent timeouts from slower
-devices and to quickly tear down stale sessions in larger deployments. There
-have been reports of SSH keepalives breaking compatibility with certain OS
-types. They can be disabled using the `ssh_no_keepalive` variable on a per-node
-basis (by specifying it in the source) or configured application-wide.
-
-```yaml
-vars:
-  ssh_no_keepalive: true
-```
-
-## SSH Auth Methods
-
-By default, Oxidized registers the following auth methods: `none`, `publickey` and `password`. However you can configure this globally, by groups, models or nodes.
-
-```yaml
-vars:
-  auth_methods: [ "none", "publickey", "password", "keyboard-interactive" ]
-```
-
-## Public Key Authentication with SSH
-
-Instead of password-based login, Oxidized can make use of key-based SSH
-authentication.
-
-You can tell Oxidized to use one or more private keys globally, or specify the
-key to be used on a per-node basis. The latter can be done by mapping the
-`ssh_keys` variable through the active source.
-
-Global:
-
-```yaml
-vars:
-  ssh_keys: "~/.ssh/id_rsa"
-```
-
-Per-Node:
-
-```yaml
-# ...
-map:
-  name: 0
-  model: 1
-vars_map:
-  enable: 2
-  ssh_keys: 3
-# ...
-```
-
-If you are using a non-standard path, especially when copying the private key
-via a secured channel, make sure that the permissions are set correctly:
-
-```bash
-foo@bar:~$ ls -la ~/.ssh/
-total 20
-drwx------ 2 oxidized oxidized 4096 Mar 13 17:03 .
-drwx------ 5 oxidized oxidized 4096 Mar 13 21:40 ..
--r-------- 1 oxidized oxidized  103 Mar 13 17:03 authorized_keys
--rw------- 1 oxidized oxidized  399 Mar 13 17:02 id_ed25519
--rw-r--r-- 1 oxidized oxidized   94 Mar 13 17:02 id_ed25519.pub
-```
-
-Finally, multiple private keys can be specified as an array of file paths, such
-as `["~/.ssh/id_rsa", "~/.ssh/id_another_rsa"]`.
-
-## SSH Proxy Command
-
-Oxidized can `ssh` through a proxy as well. To do so we just need to set
-`ssh_proxy` variable with the proxy host information and optionally set the
-`ssh_proxy_port` with the SSH port if it is not listening on port 22.
-
-This can be provided on a per-node basis by mapping the proper fields from your
-source.
-
-An example for a `csv` input source that maps the 4th field as the `ssh_proxy`
-value and the 5th field as `ssh_proxy_port`.
-
-```yaml
-# ...
-map:
-  name: 0
-  model: 1
-vars_map:
-  enable: 2
-  ssh_proxy: 3
-  ssh_proxy_port: 4
-# ...
-```
-
-## SSH enabling legacy algorithms
-
-When connecting to older firmware over SSH, it is sometimes necessary to enable
-legacy/disabled settings like KexAlgorithms, HostKeyAlgorithms, MAC or the
-Encryption.
-
-These settings can be provided on a per-node basis by mapping the ssh_kex,
-ssh_host_key, ssh_hmac and the ssh_encryption fields from you source.
-
-```yaml
-# ...
-map:
-  name: 0
-  model: 1
-vars_map:
-  enable: 2
-  ssh_kex: 3
-  ssh_host_key: 4
-  ssh_hmac: 5
-  ssh_encryption: 6
-# ...
-```
-
-## FTP Passive Mode
-
-Oxidized uses ftp passive mode by default. Some devices require passive mode to
-be disabled. To do so, we can set `input.ftp.passive` to false - this will make
-use of FTP active mode.
-
-```yaml
-input:
-  ftp:
-    passive: false
-```
 
 ## Advanced Configuration
 

--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -1,0 +1,205 @@
+# Inputs
+## Index
+* Configuration
+  * [SSH](#ssh)
+  * [SCP](#scp)
+  * [FTP](#ftp)
+  * telnet
+  * http
+  * tftp
+  * exec
+* [Debugging](#debugging)
+
+## SSH
+### Disabling SSH exec channels
+
+Oxidized uses exec channels to make information extraction simpler, but there
+are some situations where this doesn't work well, e.g. configuring devices. This
+feature can be turned off by setting the `ssh_no_exec`
+variable.
+
+```yaml
+vars:
+  ssh_no_exec: true
+```
+
+### Disabling SSH keepalives
+
+Oxidized SSH input makes use of SSH keepalives to prevent timeouts from slower
+devices and to quickly tear down stale sessions in larger deployments. There
+have been reports of SSH keepalives breaking compatibility with certain OS
+types. They can be disabled using the `ssh_no_keepalive` variable on a per-node
+basis (by specifying it in the source) or configured application-wide.
+
+```yaml
+vars:
+  ssh_no_keepalive: true
+```
+
+### SSH Auth Methods
+
+By default, Oxidized registers the following auth methods: `none`, `publickey` and `password`. However you can configure this globally, by groups, models or nodes.
+
+```yaml
+vars:
+  auth_methods: [ "none", "publickey", "password", "keyboard-interactive" ]
+```
+
+### Public Key Authentication with SSH
+
+Instead of password-based login, Oxidized can make use of key-based SSH
+authentication.
+
+You can tell Oxidized to use one or more private keys globally, or specify the
+key to be used on a per-node basis. The latter can be done by mapping the
+`ssh_keys` variable through the active source.
+
+Global:
+
+```yaml
+vars:
+  ssh_keys: "~/.ssh/id_rsa"
+```
+
+Per-Node:
+
+```yaml
+# ...
+map:
+  name: 0
+  model: 1
+vars_map:
+  enable: 2
+  ssh_keys: 3
+# ...
+```
+
+If you are using a non-standard path, especially when copying the private key
+via a secured channel, make sure that the permissions are set correctly:
+
+```bash
+foo@bar:~$ ls -la ~/.ssh/
+total 20
+drwx------ 2 oxidized oxidized 4096 Mar 13 17:03 .
+drwx------ 5 oxidized oxidized 4096 Mar 13 21:40 ..
+-r-------- 1 oxidized oxidized  103 Mar 13 17:03 authorized_keys
+-rw------- 1 oxidized oxidized  399 Mar 13 17:02 id_ed25519
+-rw-r--r-- 1 oxidized oxidized   94 Mar 13 17:02 id_ed25519.pub
+```
+
+Finally, multiple private keys can be specified as an array of file paths, such
+as `["~/.ssh/id_rsa", "~/.ssh/id_another_rsa"]`.
+
+### SSH Proxy Command
+
+Oxidized can `ssh` through a proxy as well. To do so we just need to set
+`ssh_proxy` variable with the proxy host information and optionally set the
+`ssh_proxy_port` with the SSH port if it is not listening on port 22.
+
+This can be provided on a per-node basis by mapping the proper fields from your
+source.
+
+An example for a `csv` input source that maps the 4th field as the `ssh_proxy`
+value and the 5th field as `ssh_proxy_port`.
+
+```yaml
+# ...
+map:
+  name: 0
+  model: 1
+vars_map:
+  enable: 2
+  ssh_proxy: 3
+  ssh_proxy_port: 4
+# ...
+```
+
+### SSH enabling legacy algorithms
+
+When connecting to older firmware over SSH, it is sometimes necessary to enable
+legacy/disabled settings like KexAlgorithms, HostKeyAlgorithms, MAC or the
+Encryption.
+
+These settings can be provided on a per-node basis by mapping the ssh_kex,
+ssh_host_key, ssh_hmac and the ssh_encryption fields from you source.
+
+```yaml
+# ...
+map:
+  name: 0
+  model: 1
+vars_map:
+  enable: 2
+  ssh_kex: 3
+  ssh_host_key: 4
+  ssh_hmac: 5
+  ssh_encryption: 6
+# ...
+```
+
+### Custom SSH port
+Set the variable `ssh_port` to the desired value (default is 22).
+
+### SSH Host key verification
+With the configuration `secure', you can set the ssh key verification:
+- `true`: strict host verification, looking up the known host files
+- `false` (default): disable host verification, accept any ssh key
+
+```
+input:
+  ssh:
+    secure: true
+```
+
+## SCP
+### SSH Host key verification (SCP)
+Same as for [SSH host key verification](#ssh-host-key-verification)
+
+```
+input:
+  scp:
+    secure: true
+```
+
+### Custom SCP port
+Set the variable `ssh_port` to the desired value (default is 22).
+
+## FTP
+### FTP Passive Mode
+
+Oxidized uses ftp passive mode by default. Some devices require passive mode to
+be disabled. To do so, we can set `input.ftp.passive` to false - this will make
+use of FTP active mode.
+
+```yaml
+input:
+  ftp:
+    passive: false
+```
+
+
+## Debugging
+
+In case a model plugin doesn't work correctly (ios, procurve, etc.), you can
+enable live debugging of SSH/Telnet sessions. Just add a `debug` option
+containing the value true to the `input` section. The log files will be created
+depending on the parent directory of the logfile option.
+
+The following example will log an active ssh/telnet session
+`/home/oxidized/.config/oxidized/log/<IP-Address>-<PROTOCOL>`. The file will be
+truncated on each consecutive ssh/telnet session, so you need to put a `tailf`
+or `tail -f` on that file!
+
+```yaml
+log: /home/oxidized/.config/oxidized/log
+
+# ...
+
+input:
+  default: ssh, telnet
+  debug: true
+  ssh:
+    secure: false
+  http:
+    ssl_verify: true
+```

--- a/lib/oxidized/config.rb
+++ b/lib/oxidized/config.rb
@@ -32,6 +32,7 @@ module Oxidized
       asetus.default.threads       = 30
       asetus.default.use_max_threads = false
       asetus.default.timeout       = 20
+      asetus.default.timelimit     = 300
       asetus.default.retries       = 3
       asetus.default.prompt        = /^([\w.@-]+[#>]\s?)$/
       asetus.default.next_adds_job = false            # if true, /next adds job, so device is fetched immmeiately

--- a/lib/oxidized/input/scp.rb
+++ b/lib/oxidized/input/scp.rb
@@ -6,12 +6,8 @@ module Oxidized
 
   class SCP < Input
     RESCUE_FAIL = {
-      debug: [
-        # Net::SSH::Disconnect,
-      ],
-      warn:  [
-        # RuntimeError,
-        # Net::SSH::AuthenticationFailed,
+      warn: [
+        Net::SCP::Error
       ]
     }.freeze
     include Input::CLI

--- a/lib/oxidized/input/scp.rb
+++ b/lib/oxidized/input/scp.rb
@@ -6,10 +6,15 @@ module Oxidized
 
   class SCP < Input
     RESCUE_FAIL = {
-      warn: [
+      debug: [
+        Net::SSH::Disconnect,
+        Net::SSH::ConnectionTimeout
+      ],
+      warn:  [
         Net::SCP::Error,
         Net::SSH::HostKeyUnknown,
-        Net::SSH::AuthenticationFailed
+        Net::SSH::AuthenticationFailed,
+        Timeout::Error
       ]
     }.freeze
     include Input::CLI
@@ -48,7 +53,9 @@ module Oxidized
 
     def cmd(file)
       logger.debug "SCP: #{file} @ #{@node.name}"
-      @ssh.scp.download!(file)
+      Timeout.timeout(Oxidized.config.timeout) do
+        @ssh.scp.download!(file)
+      end
     end
 
     def send(my_proc)
@@ -62,7 +69,11 @@ module Oxidized
     private
 
     def disconnect
-      @ssh.close
+      Timeout.timeout(Oxidized.config.timeout) do
+        @ssh.close
+      end
+    rescue Timeout::Error
+      logger.debug "#{@node.name} timed out while disconnecting"
     ensure
       @log.close if Oxidized.config.input.debug?
     end

--- a/lib/oxidized/input/ssh.rb
+++ b/lib/oxidized/input/ssh.rb
@@ -162,7 +162,7 @@ module Oxidized
       ssh_opts[:host_key]   = vars(:ssh_host_key).split(/,\s*/)   if vars(:ssh_host_key)
       ssh_opts[:hmac]       = vars(:ssh_hmac).split(/,\s*/)       if vars(:ssh_hmac)
 
-      # Use our logger for Net:SSH
+      # Use our logger for Net::SSH
       ssh_logger = SemanticLogger[Net::SSH]
       ssh_logger.level = Oxidized.config.input.debug? ? :debug : :fatal
       ssh_opts[:logger] = ssh_logger

--- a/lib/oxidized/job.rb
+++ b/lib/oxidized/job.rb
@@ -7,13 +7,21 @@ module Oxidized
     def initialize(node)
       @node = node
       @start = Time.now.utc
-      self.name = "Oxidized::Job '#{@node.name}'"
+      self.name = "Job '#{@node.name}'"
       super do
-        logger.debug "Starting fetching process for #{@node.name} at #{Time.now.utc}"
-        @status, @config = @node.run
-        @end             = Time.now.utc
-        @time            = @end - @start
-        logger.debug "Config fetched for #{@node.name} at #{@end}"
+        logger.debug "Starting fetching process for #{@node.name}"
+        begin
+          Timeout.timeout(Oxidized.config.timelimit) do
+            @status, @config = @node.run
+          end
+          logger.debug "Config fetched for #{@node.name}"
+        rescue Timeout::Error
+          logger.warn "Job timelimit reached for #{@node.name}"
+          @status = :timelimit
+        ensure
+          @end  = Time.now.utc
+          @time = @end - @start
+        end
       end
     end
   end

--- a/spec/job_spec.rb
+++ b/spec/job_spec.rb
@@ -1,0 +1,39 @@
+require_relative 'spec_helper'
+require 'oxidized/job'
+
+describe Oxidized::Job do
+  before(:each) do
+    Oxidized.asetus = Asetus.new
+    Oxidized.config.timelimit = 300
+  end
+  it "gets a status :timelimit when the job timelimit is reached" do
+    node = mock("Oxidized::Node")
+    node.expects(:name).returns("SW123").times(3)
+    node.expects(:run).raises(Timeout::Error)
+
+    Oxidized::Job.logger.expects(:warn).with('Job timelimit reached for SW123')
+
+    job = Oxidized::Job.new(node)
+    job.join
+
+    _(job.status).must_equal :timelimit
+    _(job.config).must_be_nil
+  end
+
+  it "gets a status :success when fetching was OK" do
+    node = mock("Oxidized::Node")
+    node.expects(:name).returns("SW123").times(3)
+    node.expects(:run).returns([:success, "config-data"])
+
+    start_time = Time.now.utc
+    job = Oxidized::Job.new(node)
+    job.join
+    end_time = Time.now.utc
+
+    _(job.status).must_equal :success
+    _(job.config).must_equal "config-data"
+    _(job.start).must_be_close_to start_time, 1
+    _(job.end).must_be_close_to end_time, 1
+    _(job.time).must_be :>=, 0
+  end
+end

--- a/spec/node_spec.rb
+++ b/spec/node_spec.rb
@@ -3,6 +3,7 @@ require_relative 'spec_helper'
 describe Oxidized::Node do
   before(:each) do
     Oxidized.asetus = Asetus.new
+    Oxidized.config.timelimit = 300
 
     Oxidized::Node.any_instance.stubs(:resolve_repo)
     Oxidized::Node.any_instance.stubs(:resolve_output)


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
When fetching APC UPS-Systems (Model apc_aos), some scp connection do not timeout and the fetch job does'nt close. This results in all fetch jobs being blocked and oxidized does not fetch any configurations anymore.

To sove this Issue, this PR implements:
- timeouts for input/scp
- an absolute timelimit for fetch jobs (300 seconds = 5 Minutes, this is configurable)

Closes #3590
