### PR TITLE
[eatonnetwork] Remove additional secrets introduced in firmware 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - input/http: bracket IPv6 URI. Fixes #3620 (@ytti)
 - tnsr: fixed prompt regex, sometimes --More-- pager is misplaced on older versions (@ClumsyAdmin)
+- eatonnetwork: Update for firmware v2.2.0 #3634 (@thanegill)
 
 ## [0.34.3 - 2025-08-05]
 This release fixes an issue preventing /node/show/<hostname> to work in oxidized-web.

--- a/lib/oxidized/model/eatonnetwork.rb
+++ b/lib/oxidized/model/eatonnetwork.rb
@@ -54,6 +54,11 @@ class EatonNetwork < Oxidized::Model
     json['features']['userAndSessionManagement']['data']['settings']['all']['1.0']['radius']['1.0']['settings']['connectivity']['primaryServer'].delete('secret')
     json['features']['userAndSessionManagement']['data']['settings']['all']['1.0']['radius']['1.0']['settings']['connectivity']['secondaryServer'].delete('secret')
 
+    # Added in frimware v2.2.0
+    json['features']['peripherals']['data']['dmeData']['ethernet']['ports'].each do |n|
+      n.dig('dot1x', 'peap', 'password') && n['dot1x']['peap'].delete('password')
+    end
+
     cfg = JSON.pretty_generate(json)
     cfg
   end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
