### PR TITLE
fix: hide power voltage values on aruba aoscx devices

### DIFF
--- a/lib/oxidized/model/aoscx.rb
+++ b/lib/oxidized/model/aoscx.rb
@@ -1,49 +1,21 @@
 class Aoscx < Oxidized::Model
-  # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+[#> ] ), which ends the line
-  # telnet switches may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), followed by the prompt, followed
-  # by at least 3 other vt100 characters
-  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+[#> ] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
+  # HP ArubaOS-CX (AOS-CX) model for Oxidized
+  # Tested on CX 6200, 6300, 6400, and 8400 series switches
 
+  prompt /^([\w.-]+# )$/
   comment '! '
 
-  # replace next line control sequence with a new line
-  expect /(\e\[1M\e\[\??\d+(;\d+)*[A-Za-z]\e\[1L)|(\eE)/ do |data, re|
-    data.gsub re, "\n"
-  end
-
-  # replace all used vt100 control sequences
-  expect /\e\[\??\d+(;\d+)*[A-Za-z]/ do |data, re|
-    data.gsub re, ''
-  end
-
-  expect /Press any key to continue(\e\[\??\d+(;\d+)*[A-Za-z])*$/ do
-    send ' '
-    ""
-  end
-
-  expect /Enter switch number/ do
-    send "\n"
-    ""
-  end
-
   cmd :all do |cfg|
-    # Removed: cfg = cfg.cut_both
-    cfg = cfg.gsub(/^\r/, '')
-    # Additional filtering for elder switches sending vt100 control chars via telnet
-    cfg.gsub!(/\e\[\??\d+(;\d+)*[A-Za-z]/, '')
-    # Additional filtering for power usage reporting which obviously changes over time
-    cfg.gsub!(/^(.*AC [0-9]{3}V\/?([0-9]{3}V)?) *([0-9]{1,3}) (.*)/, '\\1 <removed> \\4')
-    cfg
+    cfg.each_line.to_a[1..-2].join
   end
 
   cmd :secret do |cfg|
-    cfg.gsub!(/^(snmp-server community) \S+(.*)/, '\\1 <secret hidden> \\2')
-    cfg.gsub!(/^(snmp-server host \S+) \S+(.*)/, '\\1 <secret hidden> \\2')
-    cfg.gsub!(/^(radius-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2')
-    cfg.gsub!(/^(radius-server key).*/, '\\1 <configuration removed>')
-    cfg.gsub!(/^(tacacs-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2')
-    cfg.gsub!(/^(tacacs-server key).*/, '\\1 <secret hidden>')
+    cfg.gsub!(/^(snmp-server community) .+/, '\\1 <hidden>')
+    cfg.gsub!(/^(radius-server key) .+/, '\\1 <hidden>')
+    cfg.gsub!(/^(tacacs-server key) .+/, '\\1 <hidden>')
+    cfg.gsub!(/^(password manager) .+/, '\\1 <hidden>')
+    cfg.gsub!(/^(password) .+/, '\\1 <hidden>')
+    cfg.gsub!(/(user-password encrypted) .+/, '\\1 <hidden>')
     cfg
   end
 
@@ -51,90 +23,78 @@ class Aoscx < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show environment' do |cfg|
-    # === Mask volatile power sections with stable placeholders ===
-
-    # Devices that echo the subcommand header:
-    cfg.gsub!(
-        /^\s*show environment power-supply input-voltage.*?(?=^\s*show\s|\Z)/mi,
-        "show environment power-supply input-voltage\n<hidden>\n"
-    )
-    cfg.gsub!(
-        /^\s*show environment power-consumption.*?(?=^\s*show\s|\Z)/mi,
-        "show environment power-consumption\n<hidden>\n"
-    )
-
-    # Devices that don't echo the subcommand header; use the “Averaging Period” anchors:
-    cfg.gsub!(
-        /^\s*Input Voltage Averaging Period\s*:.*?(?=^\s*\S|\Z)/mi,
-        "show environment power-supply input-voltage\n<hidden>\n"
-    )
-    cfg.gsub!(
-        /^\s*Power Consumption Averaging Period\s*:.*?(?=^\s*\S|\Z)/mi,
-        "show environment power-consumption\n<hidden>\n"
-    )
-
-    # === Mask temperatures within 'show environment temperature' ===
-    # Replace numeric temps inside that subsection only (e.g., "40.50 C" -> "<hidden>")
-    cfg.gsub!(/(^\s*show environment temperature.*?)(?=^\s*show\s|\Z)/mi) do |section|
-        section.gsub(/(\s)-?\d+(?:\.\d+)?\s*[CF]\b/i, '\1<hidden>')
-    end
-
-    # === Mask fan speed state and RPMs within fan-related subsections ===
-    # Covers: 'show environment fan', 'fans', 'fan-tray'
-    cfg.gsub!(/(^\s*show environment (?:fan(?:s|-tray)?).*?)(?=^\s*show\s|\Z)/mi) do |section|
-        s = section.dup
-
-        # 1) Mask common speed/state words (keeps airflow 'front-to-back' as-is)
-        s.gsub!(/\b(normal|high|low|slow|fast|medium|auto)\b/i, '<speed>')
-
-        # 2) Mask explicit "1234 rpm" forms
-        s.gsub!(/\b\d{3,6}\s*rpm\b/i, '<rpm>')
-
-        # 3) Mask trailing numeric RPM at end-of-line table column (e.g., "... ok      9600")
-        s.gsub!(/(^.*?\s)(\d{3,6})\s*$/i, '\1<rpm>')
-
-        s
-    end
-
-    # Tidy up extra blank lines
-    cfg.gsub!(/\n{3,}/, "\n\n")
-
+  cmd 'show system' do |cfg|
     comment cfg
   end
 
-  cmd 'show module' do |cfg|
+  cmd 'show running-config' do |cfg|
+    cfg
+  end
+
+  cmd 'show environment temperature' do |cfg|
     comment cfg
   end
 
-  cmd 'show interface transceiver' do |cfg|
+  cmd 'show environment fan' do |cfg|
     comment cfg
   end
 
-  cmd 'show system | exclude "Up Time" | exclude "CPU" | exclude "Memory"' do |cfg|
+  cmd 'show environment power-supply' do |cfg|
     comment cfg
   end
 
-  cmd 'show running-config'
-
-  cfg :telnet do
-    username /Username:/
-    password /Password:/
+  cmd 'show system power-supply' do |cfg|
+    comment cfg
   end
 
-  cfg :telnet, :ssh do
-    # preferred way to handle additional passwords
-    if vars :enable
-      post_login do
-        send "enable\n"
-        cmd vars(:enable)
-      end
-    end
-    post_login 'no page'
-    pre_logout "exit"
+  cmd 'show interface transceiver details' do |cfg|
+    comment cfg
   end
 
   cfg :ssh do
-    pty_options(chars_wide: 1000)
+    pre_logout 'exit'
+  end
+
+  pre do
+    cmds = [
+      'show environment power-supply input-voltage',
+      'show environment power-consumption',
+      'show system power-supply input-voltage',
+      'show system power-consumption'
+    ]
+    cmds.each do |cmd|
+      run_cmd(cmd)
+    end
+  end
+
+  cmd :all do |cfg|
+    cfg.gsub!(
+      /^\s*show environment power-supply input-voltage.*?(?=^\s*show\s|\Z)/mi,
+      ''
+    )
+    cfg.gsub!(
+      /^\s*show environment power-consumption.*?(?=^\s*show\s|\Z)/mi,
+      ''
+    )
+    cfg.gsub!(
+      /^\s*Input Voltage Averaging Period\s*:.*?(?=^\s*\S|\Z)/mi,
+      ''
+    )
+    cfg.gsub!(
+      /^\s*Power Consumption Averaging Period\s*:.*?(?=^\s*\S|\Z)/mi,
+      ''
+    )
+    cfg
+  end
+
+  cmd :all do |section|
+    section.gsub(/(\s)-?\d+(?:\.\d+)?\s*[CF]\b/i, '\1<hidden>')
+  end
+
+  cmd :all do |section|
+    s = section.dup
+    s.gsub!(/^(.+uptime is).+$/, '\\1 <hidden>')
+    s.gsub!(/^(.+temperature is).+$/, '\\1 <hidden>')
+    s
   end
 end


### PR DESCRIPTION
## Description
Adjusts the Aruba AOS-CX config to change the Voltage Input values from a frequently changing numbers to <hidden> blocks.

This stops frequent commits for minor voltage and temperature changes