### PR TITLE
fsos: set terminal width to 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ VyOS now has it's own Model and should be used for supported VyOS versions inste
 - eatonnetwork: Update for firmware v2.2.0 #3634 (@thanegill)
 - many models: fix redundant regular expressions (@cheramr)
 - timos: remove deprecated model timos. Use sros. #3617 (@cheramr)
+- fsos: set terminal width to 0. Fixes #3576 (@cheramr)
 
 ## [0.34.3 - 2025-08-05]
 This release fixes an issue preventing /node/show/<hostname> to work in oxidized-web.

--- a/lib/oxidized/model/fsos.rb
+++ b/lib/oxidized/model/fsos.rb
@@ -41,7 +41,7 @@ class FSOS < Oxidized::Model
   cfg :telnet, :ssh do
     post_login 'enable'
     post_login 'terminal length 0'
-    post_login 'terminal width 512'
+    post_login 'terminal width 0'
     pre_logout 'exit'
     pre_logout 'exit'
   end

--- a/spec/model/data/fsos#S3400-48T4SP_2.0.2J-120538#simulation.yaml
+++ b/spec/model/data/fsos#S3400-48T4SP_2.0.2J-120538#simulation.yaml
@@ -8,8 +8,8 @@ commands:
   "terminal length 0\n": |-
     terminal length 0
     FS-LAB-OXI#
-  "terminal width 512\n": |-
-    terminal width 512
+  "terminal width 0\n": |-
+    terminal width 0
     FS-LAB-OXI#
   "show version\n": |-
     show version


### PR DESCRIPTION


## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Reverts problematic width introduced in PR #3354

Close #3576
