### PR TITLE
Add debian dependency on libzstd-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ add-apt-repository universe
 Install the dependencies:
 
 ```shell
-apt install ruby ruby-dev libsqlite3-dev libssl-dev pkg-config cmake libssh2-1-dev libicu-dev zlib1g-dev g++ libyaml-dev
+apt install ruby ruby-dev libsqlite3-dev libssl-dev pkg-config cmake libssh2-1-dev libicu-dev zlib1g-dev g++ libyaml-dev libzstd-dev
 ```
 
 Finally, install Oxidized:


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Add libzstd-dev in the debian dependencies in the installation instructions.

Closes: #3636