### PR TITLE
remove redundant dependency on bundler producing a CI failure on ruby-head

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fsos: set terminal width to 0. Fixes #3576 (@robertcheramy)
 - aoscx: rework environmental data anonymization. Fixes #3568 (@robertcheramy, inspired by PR #3653 by @martadams89)
 - netgear: fix prompt issues caused by ANSI escape codes. Fixes #3287 (@robertcheramy)
+- remove redundant dependency on bundler producing a CI failure on ruby-head (@robertcheramy)
 
 
 ## [0.34.3 - 2025-08-05]

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -46,7 +46,6 @@ Gem::Specification.new do |s|
   s.add_dependency 'syslog',               '~> 0.3.0'
   s.add_dependency 'syslog_protocol',      '~> 0.9.2'
 
-  s.add_development_dependency 'bundler',             '~> 2.2'
   # ruby-git 4.0 requests ruby >= 3.2, we stick to ruby >= 3.1 (Ubuntu Noble/Debian Bookworm)
   s.add_development_dependency 'git',                 '>= 2.0', '< 3.2.0'
   s.add_development_dependency 'minitest',            '~> 5.26.0'


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
CI test fails on ruby-head because of the development dependency on bundler.
We do not need bundler as a development dependency, it comes with the operating system.