### PR TITLE
Fix "undefined method `[]' for nil" when only extensions: configured (#3607)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - remove redundant dependency on bundler producing a CI failure on ruby-head (@robertcheramy)
 - nxos: use "show inventory" when "show inventory all" is not supported. Fixes #3657 (@robertcheramy)
 - arubainstant: handle spaces/parentheses in AP names and add Zone column. Fixes #3611 (@iRomanyshyn, @robertcheramy)
+- core: fix "undefined method `[]' for nil" when only extensions: configured. Fixes: #3607 (@robertcheramy)
 
 
 ## [0.34.3 - 2025-08-05]

--- a/lib/oxidized/core.rb
+++ b/lib/oxidized/core.rb
@@ -40,7 +40,8 @@ module Oxidized
           '"extensions.oxidized-web" and remove "rest" from the configuration'
         )
         configuration = Oxidized.config.rest
-      elsif Oxidized.config.extensions['oxidized-web'].load?
+      elsif Oxidized.config.extensions &&
+            Oxidized.config.extensions['oxidized-web']&.load?
         # This comment stops rubocop complaining about Style/IfUnlessModifier
         configuration = Oxidized.config.extensions['oxidized-web']
       end

--- a/spec/core_spec.rb
+++ b/spec/core_spec.rb
@@ -1,0 +1,73 @@
+require_relative 'spec_helper'
+require 'oxidized/core'
+require 'oxidized/web'
+
+describe Oxidized::Core do
+  before do
+    Oxidized.asetus = Asetus.new
+
+    Oxidized::Manager.expects(:new)
+    Oxidized.stubs(:mgr=)
+
+    Oxidized::HookManager.expects(:from_config)
+    Oxidized.stubs(:hooks=)
+
+    @mock_nodes = mock('Oxidized::Nodes')
+    @mock_nodes.expects(:empty?).returns(false)
+    Oxidized::Nodes.expects(:new).returns(@mock_nodes)
+
+    Oxidized::Worker.expects(:new)
+    Oxidized::Signals.expects(:register_signal)
+  end
+
+  describe '#initialize' do
+    it 'runs when extensions not configured' do
+      Oxidized::Core.any_instance.expects(:run)
+
+      Oxidized::Core.new(nil)
+    end
+
+    it 'runs when only extensions configured' do
+      Oxidized.config.extensions = nil
+      Oxidized::Core.any_instance.expects(:run)
+
+      Oxidized::Core.new(nil)
+    end
+    it 'runs when only extensions.oxidized-web configured' do
+      Oxidized.config.extensions = Asetus::ConfigStruct.new(
+        {
+          "oxidized-web" => nil
+        }
+      )
+      Oxidized::Core.any_instance.expects(:run)
+      Oxidized::Core.any_instance.expects(:require).with('oxidized/web').never
+
+      Oxidized::Core.new(nil)
+    end
+    it 'wont run oxidized-web when load = false' do
+      Oxidized.config.extensions = Asetus::ConfigStruct.new(
+        {
+          "oxidized-web" => { "load" => false }
+        }
+      )
+      Oxidized::Core.any_instance.expects(:run)
+      Oxidized::Core.any_instance.expects(:require).with('oxidized/web').never
+
+      Oxidized::Core.new(nil)
+    end
+    it 'runs oxidized-web when load = true' do
+      Oxidized.config.extensions = Asetus::ConfigStruct.new(
+        {
+          "oxidized-web" => { "load" => true }
+        }
+      )
+      Oxidized::Core.any_instance.expects(:require).with('oxidized/web')
+      mock_web = mock('Oxidized::API::Web')
+      mock_web.expects(:run)
+      Oxidized::API::Web.expects(:new).returns(mock_web)
+      Oxidized::Core.any_instance.expects(:run)
+
+      Oxidized::Core.new(nil)
+    end
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Insufficient checks for nil caused an error when only the line `extentions:` was configured.

Closes: #3607