### PR TITLE
apc_aos: set comment to "; "

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+- apc_aos: set comment to "; " to match comments in config.ini (@robertcheramy)
 
 
 ## [0.35.0 - 2025-12-04]

--- a/lib/oxidized/model/apc_aos.rb
+++ b/lib/oxidized/model/apc_aos.rb
@@ -1,6 +1,8 @@
 class Apc_aos < Oxidized::Model # rubocop:disable Naming/ClassAndModuleCamelCase
   using Refinements
 
+  comment '; '
+
   cmd 'config.ini' do |cfg|
     cfg.gsub!(/^; Configuration file, generated on.*\n/, '')
     cfg


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Comments produced by metadata used the default comment string (`# `) and did not match the comments in `config.ini` (`;`).
