### PR TITLE
String refinements: introduce keep_lines and reject_lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- String refinements: introduce `keep_lines` and `reject_lines` methods (@robertcheramy)
 
 ### Changed
+- Refactored models: Use `keep_lines` and `reject_lines` in aosw, arubainstant, asa, efos, firelinuxos, fsos, ironware, mlnxos and perle to (@robertcheramy)
+
 
 ### Fixed
 - apc_aos: set comment to "; " to match comments in config.ini (@robertcheramy)

--- a/docs/Creating-Models.md
+++ b/docs/Creating-Models.md
@@ -60,6 +60,42 @@ A more fleshed out example can be found in the `IOS` and `JunOS` models.
 
 ## Typical Tasks and Solutions
 
+### Keep or Remove Lines Returned from a Command
+To make command output cleaner, you can remove unwanted lines or keep only
+specific ones.
+
+Most devices echo the executed command on the first line and display a
+prompt on the last line. To remove these for all commands, use
+[cut_both](Ruby-API.md#cut_both):
+```ruby
+  cmd :all do |cfg|
+    cfg.cut_both
+  end
+```
+
+If you want to keep only relevant lines, use
+[keep_lines](Ruby-API.md#keep_lines):
+```ruby
+  cmd 'show interfaces transceiver' do |cfg|
+    cfg = cfg.keep_lines [
+      'SFP Information',
+      /Vendor (Name|Serial Number)/
+    ]
+    comment cfg + "\n"
+  end
+```
+
+If you want to suppress specific lines,
+use [reject_lines](Ruby-API.md#reject_lines):
+```ruby
+  cmd 'show running-config' do |cfg|
+    cfg.reject_lines [
+      'System Up Time',
+      /Current .* Time:/
+    ]
+  end
+```
+
 ### Handling 'enable' mode
 The following code snippet demonstrates how to handle sending the 'enable'
 command and an enable password.

--- a/docs/Ruby-API.md
+++ b/docs/Ruby-API.md
@@ -29,6 +29,8 @@ The following objects exist in Oxidized.
     - [cut_tail](#cut_tail)
     - [cut_head](#cut_head)
     - [cut_both](#cut_both)
+    - [keep_lines](#keep_lines)
+    - [reject_lines](#reject_lines)
 
 ## Input
 
@@ -253,3 +255,9 @@ single line was present.
 
 Returns a multi-line string without the first and last lines, or an empty string
 if fewer than three lines were present.
+
+#### `keep_lines`
+Returns a multi-line string with only the lines matching any pattern (String or Regexp) given in an array.
+
+#### `reject_lines`
+Returns a multi-line string without the lines matching any pattern (String or Regexp) given in an array.

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -48,8 +48,11 @@ class AOSW < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    cfg = cfg.each_line.reject { |line| line.match(/(Switch|AP) uptime/i) || line.match(/Reboot Time and Cause/i) }
-    rstrip_cfg comment cfg.join
+    cfg = cfg.reject_lines [
+      /(Switch|AP) uptime/i,
+      /Reboot Time and Cause/i
+    ]
+    rstrip_cfg comment cfg
   end
 
   cmd 'show inventory' do |cfg|
@@ -77,15 +80,11 @@ class AOSW < Oxidized::Model
   end
 
   cmd 'show running-config' do |cfg|
-    out = []
-    cfg.each_line do |line|
-      next if line =~ /^controller config \d+$/
-      next if line =~ /^Building Configuration/
-
-      out << line.strip
-    end
-    out = out.join "\n"
-    out << "\n"
+    cfg = cfg.reject_lines [
+      /^controller config \d+$/,
+      /^Building Configuration/
+    ]
+    rstrip_cfg cfg
   end
 
   cfg :telnet do

--- a/lib/oxidized/model/arubainstant.rb
+++ b/lib/oxidized/model/arubainstant.rb
@@ -31,30 +31,21 @@ class ArubaInstant < Oxidized::Model
 
   # get software version
   cmd 'show version' do |cfg|
-    out = ''
-    cfg.each_line do |line|
-      next if line =~ /^(Switch|AP) uptime is /
-
-      next if line =~ /^Reboot Time and Cause/
-
-      out += line
-    end
-    comment out
+    cfg = cfg.reject_lines [
+      /^(Switch|AP) uptime is /,
+      /^Reboot Time and Cause/
+    ]
+    comment cfg
   end
 
   # Get serial number
   cmd 'show activate status' do |cfg|
-    out = ''
-    cfg.each_line do |line|
-      next if line =~ /^Activate /
-
-      next if line =~ /^Provision interval/
-
-      next if line =~ /^Cloud Activation Key/
-
-      out += line
-    end
-    comment out + "\n"
+    cfg = cfg.reject_lines [
+      /^Activate /,
+      /^Provision interval/,
+      /^Cloud Activation Key/
+    ]
+    comment cfg + "\n"
   end
 
   # Get controlled WLAN-AP

--- a/lib/oxidized/model/asa.rb
+++ b/lib/oxidized/model/asa.rb
@@ -32,13 +32,13 @@ class ASA < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    # avoid commits due to uptime / ixo-router01 up 2 mins 28 secs / ixo-router01 up 1 days 2 hours
-    cfg = cfg.each_line.reject { |line| line.match /(\s+up\s+\d+\s+)|(.*days.*)/ }
-    cfg = cfg.join
-    cfg.gsub! /^Configuration has not been modified since last system restart.*\n/, ''
-    cfg.gsub! /^Configuration last modified by.*\n/, ''
-    cfg.gsub! /^Start-up time.*\n/, ''
-    comment cfg
+    comment cfg.reject_lines [
+      # avoid commits due to uptime / ixo-router01 up 2 mins 28 secs / ixo-router01 up 1 days 2 hours
+      /(\s+up\s+\d+\s+)|(.*days.*)/,
+      /^Configuration has not been modified since last system restart.*/,
+      /^Configuration last modified by.*/,
+      /^Start-up time.*/
+    ]
   end
 
   cmd 'show inventory' do |cfg|

--- a/lib/oxidized/model/efos.rb
+++ b/lib/oxidized/model/efos.rb
@@ -19,11 +19,11 @@ class EFOS < Oxidized::Model
   end
 
   cmd 'show running-config' do |cfg|
-    cfg.each_line
-       .reject { |line| line.match(/System Up Time/) }
-       .reject { |line| line.match(/Current System Time:/) }
-       .reject { |line| line.match(/Current SNTP Synchronized Time:/) }
-       .join
+    cfg.reject_lines [
+      'System Up Time',
+      'Current System Time:',
+      'Current SNTP Synchronized Time:'
+    ]
   end
 
   cfg :telnet, :ssh do

--- a/lib/oxidized/model/firelinuxos.rb
+++ b/lib/oxidized/model/firelinuxos.rb
@@ -31,9 +31,7 @@ class FireLinuxOS < Oxidized::Model
   end
 
   cmd 'show version system' do |cfg|
-    cfg = cfg.each_line.reject { |line| line.match /(\s+up\s+\d+\s+)|(.*days.*)/ }
-    cfg = cfg.join
-    comment cfg
+    comment cfg.reject_lines [/(\s+up\s+\d+\s+)|(.*days.*)/]
   end
 
   cmd 'show inventory' do |cfg|

--- a/lib/oxidized/model/fsos.rb
+++ b/lib/oxidized/model/fsos.rb
@@ -22,9 +22,7 @@ class FSOS < Oxidized::Model
 
   cmd 'show version' do |cfg|
     # Remove uptime so the result doesn't change every time
-    cfg.gsub! /.*uptime is.*\n/, ''
-    cfg.gsub! /.*System uptime.*\n/, ''
-    comment cfg
+    comment cfg.reject_lines ['uptime is', 'System uptime']
   end
 
   cmd 'show running-config' do |cfg|

--- a/lib/oxidized/model/ironware.rb
+++ b/lib/oxidized/model/ironware.rb
@@ -22,9 +22,11 @@ class IronWare < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    cfg.gsub! /(^((.*)[Ss]ystem uptime(.*))$)/, '' # remove unwanted line system uptime
-    cfg.gsub! /(^((.*)[Tt]he system started at(.*))$)/, ''
-    cfg.gsub! /[Uu]p\s?[Tt]ime is .*/, ''
+    cfg = cfg.reject_lines [
+      /(^((.*)[Ss]ystem uptime(.*))$)/,
+      /(^((.*)[Tt]he system started at(.*))$)/,
+      /[Uu]p\s?[Tt]ime is .*/
+    ]
 
     comment cfg
   end

--- a/lib/oxidized/model/mlnxos.rb
+++ b/lib/oxidized/model/mlnxos.rb
@@ -15,10 +15,6 @@ class MLNXOS < Oxidized::Model
 
   cmd :all do |cfg|
     cfg.gsub! /.\x08/, '' # Remove Backspace char
-    cfg.gsub! /^CPU load averages:\s.+/, '' # Omit constantly changing CPU info
-    cfg.gsub! /^System memory:\s.+/, '' # Omit constantly changing memory info
-    cfg.gsub! /^Uptime:\s.+/, '' # Omit constantly changing uptime info
-    cfg.gsub! /.+Generated at\s\d+.+/, '' # Omit constantly changing generation time info
     cfg.lines.to_a[2..-3].join
   end
 
@@ -29,17 +25,25 @@ class MLNXOS < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    comment cfg
+    cfg = cfg.reject_lines [
+      /^CPU load averages:\s.+/, # Omit constantly changing CPU info
+      /^System memory:\s.+/,     # Omit constantly changing memory info
+      /^Uptime:\s.+/             # Omit constantly changing uptime info
+    ]
+    comment cfg + "\n"
   end
 
   cmd 'show inventory' do |cfg|
-    comment cfg
+    comment cfg + "\n"
   end
 
   cmd 'enable'
 
   cmd 'show running-config' do |cfg|
-    cfg
+    cfg.reject_lines [
+      # Omit constantly changing generation time info
+      /.+Generated at\s\d+.+/
+    ]
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/netgear.rb
+++ b/lib/oxidized/model/netgear.rb
@@ -58,7 +58,7 @@ class Netgear < Oxidized::Model
     comment cfg
   end
   cmd 'show running-config' do |cfg|
-    cfg.gsub! /(System Up Time\s+).*/, '\\1 <removed>'
+    cfg.gsub! /(System Up Time:?\s+).*/, '\\1 <removed>'
     cfg.gsub! /(Current SNTP Synchronized Time:).*/, '\\1 <removed>'
     cfg.gsub! /(Current System Time:).*/, '\\1 <removed>'
     cfg

--- a/lib/oxidized/model/perle.rb
+++ b/lib/oxidized/model/perle.rb
@@ -17,13 +17,12 @@ class Perle < Oxidized::Model
   end
 
   cmd 'show interfaces transceiver' do |cfg|
-    out = []
-    cfg.each_line do |line|
-      out << line if line =~ /SFP Information/
-      out << line if line =~ /Vendor Name/
-      out << line if line =~ /Vendor Serial Number/
-    end
-    comment out.join + "\n"
+    cfg = cfg.keep_lines [
+      'SFP Information',
+      'Vendor Name',
+      'Vendor Serial Number'
+    ]
+    comment cfg + "\n"
   end
 
   cmd 'show running-config'

--- a/lib/refinements.rb
+++ b/lib/refinements.rb
@@ -32,6 +32,24 @@ module Refinements
       # rubocop:enable Naming/MemoizedInstanceVariableName
     end
 
+    # keeps lines matching any pattern (String or Regexp)
+    def keep_lines(patterns)
+      each_line.select do |line|
+        patterns.any? do |pattern|
+          pattern.is_a?(Regexp) ? line =~ pattern : line.include?(pattern)
+        end
+      end.join
+    end
+
+    # remove lines matching any pattern (String or Regexp)
+    def reject_lines(patterns)
+      each_line.reject do |line|
+        patterns.any? do |pattern|
+          pattern.is_a?(Regexp) ? line =~ pattern : line.include?(pattern)
+        end
+      end.join
+    end
+
     # Initializes the String instance variables from another String instance
     # when the given str is an instance of String with Oxidized refinements applied
     def init_from_string(str = '')

--- a/spec/model/data/aosw#Aruba7210_8.10.0.7#output.txt
+++ b/spec/model/data/aosw#Aruba7210_8.10.0.7#output.txt
@@ -116,7 +116,7 @@ controller 10.42.0.2 role active
 controller 10.42.0.3 role standby
 !
 ap system-profile "AP-PROFILE"
-session-acl ""
+    session-acl ""
 lms-ip 10.42.0.52
 bkup-lms-ip 10.42.0.53
 ap-console-password "AAAAAAAAAABBBBBBBBBB"

--- a/spec/model/data/ironware#ICX7150-48Z-HPOE#output.txt
+++ b/spec/model/data/ironware#ICX7150-48Z-HPOE#output.txt
@@ -51,11 +51,6 @@
 !     2 GB code flash memory
 !     1 GB DRAM
 ! 
-! 
-! 
-! 
-! 
-! 
 ! The system : started=cold start   
 ! My stack unit ID = 1, bootup role = active
 ! 

--- a/spec/model/data/mlnxos#Onyx_3.9.2504#output.txt
+++ b/spec/model/data/mlnxos#Onyx_3.9.2504#output.txt
@@ -8,13 +8,11 @@
 ## 
 ## Product model:     x86onie
 ## 
-## 
-## 
 ## Number of CPUs:    2
 ## 
 ## Module           Part Number        Serial Number        Asic Rev.    HW Rev.
+## 
 ## Running database "initial"
-
 ## Hostname: 
 ## Product release: 3.9.2504
 ##

--- a/spec/model/data/netgear#GS752TPP_6.0.10.14#output.txt
+++ b/spec/model/data/netgear#GS752TPP_6.0.10.14#output.txt
@@ -19,7 +19,7 @@ SYSTEM CONFIG FILE ::= BEGIN
 ! System Name: 19sw011
 ! MAC Address: FF:FF:FF:FF:FF:FF
 ! Serial Number: 0XX000XXX000X
-! System Up Time: 123 days, 21 hours, 50 mins, 5 secs
+! System Up Time:  <removed>
 !
 !
 !

--- a/spec/refinements_spec.rb
+++ b/spec/refinements_spec.rb
@@ -2,7 +2,6 @@ require_relative 'spec_helper'
 require 'refinements'
 
 describe Refinements do
-  let(:all) { ["1\n2\n3\n"] }
   using Refinements
 
   describe '#init' do
@@ -120,6 +119,50 @@ describe Refinements do
       # :@type is always nil
       _(str2.instance_variable_get(:@type)).must_be_nil
       _(str1.instance_variable_get(:@type)).must_be_nil
+    end
+  end
+
+  describe '#keep_lines' do
+    before do
+      @text = String.new(
+        "Line 1 example\n" \
+        "Line 2 apple banana...\n" \
+        "Line 3\n" \
+        "Line 4\n"
+      )
+    end
+    it 'keeps lines with mixed strings and regexps' do
+      cfg = @text.keep_lines [
+        'ine 1',
+        /\S\sbanana/,
+        'example'
+      ]
+      _(cfg).must_equal(
+        "Line 1 example\n" \
+        "Line 2 apple banana...\n"
+      )
+    end
+  end
+
+  describe '#reject_lines' do
+    before do
+      @text = String.new(
+        "Line 1 example\n" \
+        "Line 2 apple banana...\n" \
+        "Line 3\n" \
+        "Line 4\n"
+      )
+    end
+    it 'rejects lines with mixed strings and regexps' do
+      cfg = @text.reject_lines [
+        'ine 1',
+        /\S\sbanana/,
+        'example'
+      ]
+      _(cfg).must_equal(
+        "Line 3\n" \
+        "Line 4\n"
+      )
     end
   end
 end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Every time I create or modify a model, I end up reinventing the wheel when deciding how to suppress or keep some lines in the output. There are many different ways to do this, resulting in duplicated and inconsistent code across our models.

This PR introduces the methods `keep_lines` and `reject_lines` in the String refinements. These methods will hopefully allow us to  concentrate on the intend in the models, not on (re-)implementing code.

This PR also refactors the code in models that have test data (simulation file). I prefer not to touch models without test data because I cannot guarantee that they will work after it.

@ytti is this PR OK for you?