### PR TITLE
Update fsos.rb

### DIFF
--- a/lib/oxidized/model/fsos.rb
+++ b/lib/oxidized/model/fsos.rb
@@ -2,7 +2,7 @@ class FSOS < Oxidized::Model
   # Fiberstore / fs.com
   using Refinements
   comment '! '
-  prompt /^([\w.@()-]+[#>]\s?)$/
+  prompt /^([\w.@\-\/\(\)]+[#>]\s?)$/
 
   # Handle paging
   expect /^ --More--.*$/ do |data, re|


### PR DESCRIPTION
Change in the prompt to allow backup of FS.com switches deployed in stack configurations, where the hostname contains a "/".

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis
- [ ] Tests added or adapted
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

FSOS switches deployed in stack mode may expose hostnames containing a forward slash (e.g. `SWITCH03/04#`).  
The existing prompt regular expression did not match this format, causing Oxidized to fail prompt detection and abort the backup process with `PromptUndetect`.

This change extends the allowed character set in the FSOS prompt regex to include `/`, ensuring compatibility with both standalone and stacked devices without affecting existing behavior.