### PR TITLE
Reintroduce support for Ruby 3.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -19,14 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['3.1', '3.2', '3.3', '3.4', 'ruby-head']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', 'ruby-head']
     continue-on-error: ${{ matrix.ruby-version == 'ruby-head' }}
 
     steps:
     - uses: actions/checkout@v6
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - h3c: fix overly permissive prompt regexp causing false matches. Fixes #3673 (@robertcheramy)
 - extra/device2yaml.rb: fix \r being removed at end of line (@robertcheramy)
 - perle: remove trailing \r (the device sends \r\r\n) (@robertcheramy)
+- Reintroduce support for Ruby 3.0. Fixes #3688 (@robertcheramy)
 
 
 ## [0.35.0 - 2025-12-04]

--- a/README.md
+++ b/README.md
@@ -73,8 +73,7 @@ Check out the [Oxidized TREX 2014 presentation](http://youtu.be/kBQ_CTUuqeU?t=3h
 ## Installation
 
 ### Debian and Ubuntu
-
-Debian "buster" or newer and Ubuntu 17.10 (artful) or newer are recommended. On Ubuntu, begin by enabling the `universe`
+Debian 12 "bookworm" or newer and Ubuntu 22.04 (Jammy Jellyfish) or newer are recommended. On Ubuntu, begin by enabling the `universe`
 repository (required for libssh2-1-dev):
 
 ```shell
@@ -129,7 +128,7 @@ gem install oxidized-script # Script-based input/output extensions
 ```
 
 ### FreeBSD
-These installation instructions have been tested on FreeBSD 14.2, but
+> :warning: These installation instructions have been tested on FreeBSD 14.2, but
 oxidized itself has not been tested on it.
 
 First install ruby and rubyXX-gems (Find out the name of the package with `pkg search gems`):

--- a/lib/oxidized/hook.rb
+++ b/lib/oxidized/hook.rb
@@ -15,9 +15,9 @@ module Oxidized
     end
 
     # HookContext is passed to each hook. It can contain anything related to the
-    # event in question. At least it contains the event name
-    # The argument keyword_init: true is needed for ruby < 3.2 and can be
-    # dropped with the support of ruby 3.1
+    # event in question. It contains at least the event name.
+    # The argument keyword_init: true is needed to force an initialization with
+    # keyword arguments and allow a different argument order
     HookContext = Struct.new(:event, :node, :job, :commitref, keyword_init: true)
 
     # RegisteredHook is a container for a Hook instance

--- a/oxidized.gemspec
+++ b/oxidized.gemspec
@@ -18,18 +18,20 @@ Gem::Specification.new do |s|
 
   s.metadata['rubygems_mfa_required'] = 'true'
 
-  s.required_ruby_version = '>= 3.1'
+  # Ruby version strategy
+  #
+  # We try to keep the minimum version of Ruby to match supported LTS versions
+  # of common Linux distributions, as long as the maintenance effort remains
+  # reasonable.
+  s.required_ruby_version = '>= 3.0'
 
   # Gemspec strategy
   #
   # For dependency and optional dependencies, we try to set the minimal
-  # dependency lower than the Ubuntu Noble or Debian Bookworm package version,
+  # dependency lower or equal to the Debian 13 "Trixie" package version,
   # so that native packages can be used.
-  # We limit the maximal version so that dependabot can warn about new versions
-  # and we can test them before activating them in Oxidized.
-  #
-  # development dependencies are set to the latest minor version of a library
-  # and updated after having tested them
+  # We limit the maximal minor version so that dependabot can warn about new
+  # major versions and we can test them before activating them in Oxidized.
 
   s.add_dependency 'asetus',               '~> 0.4'
   s.add_dependency 'bcrypt_pbkdf',         '~> 1.0'
@@ -41,25 +43,26 @@ Gem::Specification.new do |s|
   s.add_dependency 'net-telnet',           '~> 0.2'
   s.add_dependency 'psych',                '~> 5.0'
   s.add_dependency 'rugged',               '~> 1.6'
-  s.add_dependency 'semantic_logger',      '~> 4.17.0'
+  s.add_dependency 'semantic_logger',      '~> 4.17'
   s.add_dependency 'slop',                 '~> 4.6'
-  s.add_dependency 'syslog',               '~> 0.3.0'
-  s.add_dependency 'syslog_protocol',      '~> 0.9.2'
+  s.add_dependency 'syslog',               '~> 0.3'
+  s.add_dependency 'syslog_protocol',      '~> 0.9'
 
-  # ruby-git 4.0 requests ruby >= 3.2, we stick to ruby >= 3.1 (Ubuntu Noble/Debian Bookworm)
-  s.add_development_dependency 'git',                 '>= 2.0', '< 3.2.0'
-  s.add_development_dependency 'minitest',            '~> 5.27.0'
-  s.add_development_dependency 'mocha',               '~> 3.0'
-  s.add_development_dependency 'pry',                 '~> 0.15.0'
-  s.add_development_dependency 'rake',                '~> 13.0'
-  s.add_development_dependency 'rubocop',             '~> 1.82.0'
-  s.add_development_dependency 'rubocop-minitest',    '~> 0.38.0'
-  s.add_development_dependency 'rubocop-rake',        '~> 0.7.0'
-  s.add_development_dependency 'rubocop-sequel',      '~> 0.4.0'
-  s.add_development_dependency 'simplecov',           '~> 0.22.0'
+  s.add_development_dependency 'minitest',         '>= 5.18', '<7'
+  s.add_development_dependency 'mocha',            '>= 2.1', '<4'
+  s.add_development_dependency 'pry',              '~> 0.15'
+  s.add_development_dependency 'rake',             '~> 13.0'
+  # Rubocop introduces new rules in minor versions, so we limit automatic
+  # updates to patches
+  s.add_development_dependency 'rubocop',          '~> 1.82.0'
+  s.add_development_dependency 'rubocop-minitest', '~> 0.38.0'
+  s.add_development_dependency 'rubocop-rake',     '~> 0.7.0'
+  s.add_development_dependency 'rubocop-sequel',   '~> 0.4.0'
+  s.add_development_dependency 'simplecov',        '~> 0.22'
 
   # Dependencies on optional libraries, used for unit tests & development
-  s.add_development_dependency 'net-tftp',            '~> 0.1.0'
-  s.add_development_dependency 'oxidized-web',        '>= 0.17.1'
-  s.add_development_dependency 'sequel',              '>= 5.63.0', '< 5.100.0'
+  s.add_development_dependency 'git',              '>= 2.0', '< 5'
+  s.add_development_dependency 'net-tftp',         '~> 0.1.0'
+  s.add_development_dependency 'oxidized-web',     '>= 0.17.1'
+  s.add_development_dependency 'sequel',           '>= 5.63.0', '< 6'
 end

--- a/spec/hook_spec.rb
+++ b/spec/hook_spec.rb
@@ -1,0 +1,22 @@
+require_relative 'spec_helper'
+require 'oxidized/job'
+
+describe Oxidized::HookManager::HookContext do
+  it "takes arguments in the specified order" do
+    data = { event: "event", node: "node", job: "job", commitref: "#ABCD" }
+    hc = Oxidized::HookManager::HookContext.new(data)
+    _(hc.event).must_equal "event"
+    _(hc.to_h).must_equal data
+  end
+  it "takes arguments in a different order" do
+    data = { node: "node", job: "job", commitref: "#ABCD", event: "event" }
+    hc = Oxidized::HookManager::HookContext.new(data)
+    _(hc.event).must_equal "event"
+    _(hc.to_h).must_equal data
+  end
+  it "takes one argument and set the other to nil" do
+    hc = Oxidized::HookManager::HookContext.new(node: "node")
+    _(hc.node).must_equal "node"
+    _(hc.event).must_be_nil
+  end
+end

--- a/spec/model/atoms.rb
+++ b/spec/model/atoms.rb
@@ -6,8 +6,15 @@ class ATOMS
 
   # Returns a list of all tests matching the data files under ATOMS::DIRECTORY
   def self.all
+    if Test.respond_to?(:subclasses)
+      test_classes = [Test, TestPassFail].flat_map(&:subclasses)
+    else
+      # Backward compatibility for Ruby 3.0
+      test_classes = [TestOutput, TestPrompt, TestSecret, TestSignificantChange]
+    end
+
     # enumerates through the subclasses of Test (TestPrompt, TestOutput...)
-    [Test, TestPassFail].map(&:subclasses).flatten.map do |test|
+    test_classes.flat_map do |test|
       get(test, test::GLOB) if test::GLOB
     end.flatten.compact
   end

--- a/spec/output/git_helper.rb
+++ b/spec/output/git_helper.rb
@@ -51,8 +51,8 @@ class DiffMock
     @deltas = deltas
   end
 
-  def each_delta(&)
-    @deltas.each(&)
+  def each_delta(&block)
+    @deltas.each(&block)
   end
 end
 
@@ -82,7 +82,7 @@ class WalkerMock
 
   def push(*); end
 
-  def each(&)
-    @repo.commits.reverse_each(&)
+  def each(&block)
+    @repo.commits.reverse_each(&block)
   end
 end

--- a/spec/output/git_spec.rb
+++ b/spec/output/git_spec.rb
@@ -9,9 +9,9 @@ describe Oxidized::Output::Git do
       # Default value in most tests
       Oxidized.config.output.git.single_repo = true
 
-      @mock_node = Minitest::Mock.new
-      @mock_node.expect(:repo, '/tmp/oxidized.git')
-      @mock_node.expect(:name, 'switch-42')
+      @mock_node = mock("Oxidized::Node")
+      @mock_node.expects(:repo).returns('/tmp/oxidized.git')
+      @mock_node.expects(:name).returns('switch-42')
 
       @git = Oxidized::Output::Git.new
     end
@@ -28,7 +28,7 @@ describe Oxidized::Output::Git do
 
     it 'takes the group into accout when simple_repo=true' do
       # node.name will be needed a second time
-      @mock_node.expect(:name, 'switch-42')
+      @mock_node.expects(:name).returns('switch-42')
       result = @git.send(:yield_repo_and_path, @mock_node, 'testgroup')
       _(result).must_equal ['/tmp/oxidized.git', 'testgroup/switch-42']
     end


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Close #3688
Add a unit test for Struct.new, as I was wrong about the need for keyword_init.
Set minimal version of minitest for support of ruby 3.0 and fix minitest 6.0.1
Update code for Ruby 3.0
