### PR TITLE
Aoscx: hide negative environment temperature

### DIFF
--- a/lib/oxidized/model/aoscx.rb
+++ b/lib/oxidized/model/aoscx.rb
@@ -58,7 +58,7 @@ class Aoscx < Oxidized::Model
     end
 
     with_section(cfg, 'temperature') do |content|
-      content.gsub!(/^(.*) \d+\.\d+ C (.*)$/, '\\1 <hidden>\\2')
+      content.gsub!(/^(.*) \-?\d+\.\d+ C (.*)$/, '\\1 <hidden>\\2')
     end
     comment cfg
   end

--- a/lib/oxidized/model/aoscx.rb
+++ b/lib/oxidized/model/aoscx.rb
@@ -58,7 +58,7 @@ class Aoscx < Oxidized::Model
     end
 
     with_section(cfg, 'temperature') do |content|
-      content.gsub!(/^(.*) \-?\d+\.\d+ C (.*)$/, '\\1 <hidden>\\2')
+      content.gsub!(/^(.*) -?\d+\.\d+ C (.*)$/, '\\1 <hidden>\\2')
     end
     comment cfg
   end

--- a/spec/model/data/aoscx#6000-48G_PL.10.13.0005#simulation.yaml
+++ b/spec/model/data/aoscx#6000-48G_PL.10.13.0005#simulation.yaml
@@ -64,7 +64,7 @@ commands:
     1/1-PHY-33-40                   line-card-module     53.00 C    normal
     1/1-PHY-41-48                   line-card-module     58.00 C    normal
     
-    1/1-Inlet-Air                   management-module    22.62 C    normal
+    1/1-Inlet-Air                   management-module    -2.62 C    normal
     1/1-Switch-ASIC-Internal        management-module    48.00 C    normal
     1/1-Switch-CPU-1                management-module    47.50 C    normal
     1/1-Switch-CPU-2                management-module    49.25 C    normal


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

show environment temperature can display negative values. extendend regex for a possible negative value

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
