### PR TITLE
Fix fetch config at start when interval is 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ fortigate model for FortiGate firewalls. Be sure to check the
 - Reintroduce support for Ruby 3.0. Fixes #3688 (@robertcheramy)
 - githubrepo: fix authentication with ssh-agent not working. Fixes #3420 (@robertcheramy)
 - fastiron: adjust prompt to account for stacks, remove time from stack output. Fixes #3106 (@ManoftheSea)
+- interval: fix fetching device configuration at oxidized start when interval is 0. Fixes #3746 (@tgr229)
 
 
 ## [0.35.0 - 2025-12-04]

--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -82,7 +82,7 @@ a regular expression.
 username: oxidized
 password: S3cr3tx
 model: junos
-interval: 3600 #interval in seconds
+interval: 3600 #interval in seconds, when 0 is configured no fetch config is done at initial start and after
 log: ~/.config/oxidized/log
 debug: false
 threads: 30 # maximum number of threads

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -8,8 +8,9 @@ module Oxidized
     include SemanticLogger::Loggable
 
     attr_reader :name, :ip, :model, :input, :output, :group, :auth, :prompt, :timeout, :vars, :last, :repo
-    attr_accessor :running, :user, :email, :msg, :from, :stats, :retry, :err_type, :err_reason
+    attr_accessor :running, :user, :email, :msg, :from, :stats, :retry, :err_type, :err_reason, :nexted
     alias running? running
+    alias nexted? nexted
 
     # opt is a hash with the node parameters given in the source (:name, :group, :ip...)
     def initialize(opt)
@@ -34,6 +35,7 @@ module Oxidized
       @repo = resolve_repo opt
       @err_type = nil
       @err_reason = nil
+      @nexted = false
 
       # model instance needs to access node instance
       @model.node = self

--- a/lib/oxidized/nodes.rb
+++ b/lib/oxidized/nodes.rb
@@ -88,6 +88,8 @@ module Oxidized
         n.from = opt['from']
         # set last job to nil so that the node is picked for immediate update
         n.last = nil
+        # set nexted to true so that the node will not be skipped with interval 0
+        n.nexted = true
         put n
         jobs.increment if Oxidized.config.next_adds_job?
       end

--- a/lib/oxidized/worker.rb
+++ b/lib/oxidized/worker.rb
@@ -23,10 +23,10 @@ module Oxidized
                      "#{@jobs_done} of #{@nodes.size}"
         # ask for next node in queue non destructive way
         nextnode = @nodes.first
+        break if Oxidized.config.interval.zero? and not nextnode.nexted?
+        nextnode.nexted = false
         unless nextnode.last.nil?
-          # Set unobtainable value for 'last' if interval checking is disabled
-          last = Oxidized.config.interval.zero? ? Time.now.utc + 10 : nextnode.last.end
-          break if last + Oxidized.config.interval > Time.now.utc
+          break if nextnode.last.end + Oxidized.config.interval > Time.now.utc
         end
         # shift nodes and get the next node
         node = @nodes.get


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
With interval 0, a fetch continue to be done at service start. Fetch should not be executed when service is starting with interval 0. Interval 0 should disable fetching device.

The PR corrects implementation of interval 0.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
Closes issue #3746 