### PR TITLE
feat(eos): add show version with volatile-field exclusions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ fortigate model for FortiGate firewalls. Be sure to check the
 - smartbyte: new model for SmartByte switches (@freddy36)
 
 ### Changed
+- eos: add `show version | no-more`; volatile fields (`Uptime`, `Free memory`) are excluded so they do not trigger spurious config-change events. (@shtern)
 - Refactored models: Use `keep_lines` and `reject_lines` in aosw, arubainstant, asa, efos, firelinuxos, fsos, ironware, mlnxos and perle to (@robertcheramy)
 - Refactor SSH and SCP into a common class SSHBase. Fixes #3597 (@robertcheramy)
 - Modified models to support store mode on significant changes: ios, fortios, perle (@robertcheramy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,6 @@ fortigate model for FortiGate firewalls. Be sure to check the
 - smartbyte: new model for SmartByte switches (@freddy36)
 
 ### Changed
-- eos: add `show version | no-more`; volatile fields (`Uptime`, `Free memory`) are excluded so they do not trigger spurious config-change events. (@shtern)
 - Refactored models: Use `keep_lines` and `reject_lines` in aosw, arubainstant, asa, efos, firelinuxos, fsos, ironware, mlnxos and perle to (@robertcheramy)
 - Refactor SSH and SCP into a common class SSHBase. Fixes #3597 (@robertcheramy)
 - Modified models to support store mode on significant changes: ios, fortios, perle (@robertcheramy)
@@ -24,6 +23,7 @@ fortigate model for FortiGate firewalls. Be sure to check the
 - fortigate: Add PSU & SFP inventory (@robertcheramy)
 - fortigate: move var fortios_autoupdate (deprecated) to fortigate_autoupdate (@robertcheramy)
 - netgear: extended login and pager detection to add support for GS728TPv2 and GS752TPv2 (@weberc)
+- eos: add `show version | no-more` to capture hardware identity information (serial, version, model). (@garryshtern)
 
 ### Fixed
 - VyOS: Only remove SNMP community, not route-maps. Fixes #3735 (@systeembeheerder)

--- a/lib/oxidized/model/eos.rb
+++ b/lib/oxidized/model/eos.rb
@@ -28,6 +28,11 @@ class EOS < Oxidized::Model
     comment cfg
   end
 
+  cmd 'show version | no-more' do |cfg|
+    cfg = cfg.reject_lines [/^Uptime:/, /^Free memory:/]
+    comment cfg
+  end
+
   cmd 'show running-config | no-more | exclude ! Time:' do |cfg|
     cfg
   end

--- a/spec/model/data/eos#DCS-7050CX3-32S_4.28.3M#output.txt
+++ b/spec/model/data/eos#DCS-7050CX3-32S_4.28.3M#output.txt
@@ -1,0 +1,36 @@
+! System information
+!   Model           : DCS-7050CX3-32S
+!   Serial Number   : JPE20000001
+!   Mfg Date       : 2021-08-12
+!   Hardware Rev    : 11.00
+! Arista DCS-7050CX3-32S
+! Hardware version:    11.00
+! Serial number:       JPE20000001
+! Hardware MAC address: 001c.7300.1234
+! System MAC address:  001c.7300.1234
+! Software image version: 4.28.3M
+! Architecture:           i686
+! Internal build version: 4.28.3M-29566553.4283M
+! Internal build ID:      e48e1c3b-f8e2-4b2d-a18d-f0ef78893a44
+! Internal build image:   mfgtest
+! Image format version:   3.0
+! Image optimization:     None
+! Total memory:           8164848 kB
+! Command: show running-config
+! Saved By: admin at 2024-01-01T00:00:00+00:00
+!
+! boot system flash:/EOS-4.28.3M.swi
+!
+hostname EOS-ROUTER
+!
+spanning-tree mode mstp
+!
+interface Ethernet1
+   description uplink
+!
+interface Management1
+   ip address 10.0.0.1/24
+!
+ip routing
+!
+end

--- a/spec/model/data/eos#DCS-7050CX3-32S_4.28.3M#simulation.yaml
+++ b/spec/model/data/eos#DCS-7050CX3-32S_4.28.3M#simulation.yaml
@@ -1,0 +1,54 @@
+---
+init_prompt: |-
+    EOS-ROUTER#
+commands:
+  - "show inventory | no-more\n": |-
+      show inventory | no-more
+      System information
+        Model           : DCS-7050CX3-32S
+        Serial Number   : JPE20000001
+        Mfg Date       : 2021-08-12
+        Hardware Rev    : 11.00
+      EOS-ROUTER#
+  - "show version | no-more\n": |-
+      show version | no-more
+      Arista DCS-7050CX3-32S
+      Hardware version:    11.00
+      Serial number:       JPE20000001
+      Hardware MAC address: 001c.7300.1234
+      System MAC address:  001c.7300.1234
+      Software image version: 4.28.3M
+      Architecture:           i686
+      Internal build version: 4.28.3M-29566553.4283M
+      Internal build ID:      e48e1c3b-f8e2-4b2d-a18d-f0ef78893a44
+      Internal build image:   mfgtest
+      Image format version:   3.0
+      Image optimization:     None
+      Uptime:                 5 weeks, 3 days, 4 hours and 22 minutes
+      Total memory:           8164848 kB
+      Free memory:            5637964 kB
+      EOS-ROUTER#
+  - "show running-config | no-more | exclude ! Time:\n": |-
+      show running-config | no-more | exclude ! Time:
+      ! Command: show running-config
+      ! Saved By: admin at 2024-01-01T00:00:00+00:00
+      !
+      ! boot system flash:/EOS-4.28.3M.swi
+      !
+      hostname EOS-ROUTER
+      !
+      spanning-tree mode mstp
+      !
+      interface Ethernet1
+         description uplink
+      !
+      interface Management1
+         ip address 10.0.0.1/24
+      !
+      ip routing
+      !
+      end
+      EOS-ROUTER#
+  - "exit\n": |-
+      exit
+      logout


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis
- [x] Tests added or adapted
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to CHANGELOG.md

## Description

Adds `show version | no-more` to the EOS model so that hardware identity
information (model, serial number, MAC addresses, software version, build
details) is captured alongside the running configuration.

The `Uptime` and `Free memory` lines are stripped with `reject_lines`
before the output is stored as a comment block. Without this exclusion
those two fields change on every poll cycle and would produce spurious
config-change events in git-based outputs.

Includes a device simulation fixture for a DCS-7050CX3-32S running
EOS 4.28.3M and the corresponding expected-output file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)