### PR TITLE
Update ios.rb

### DIFF
--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -144,9 +144,8 @@ class IOS < Oxidized::Model
           /^! (Last|No) configuration change (at|since)(?!.*\d+ by \S+$)/
         ]
       end
-      cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]*\n*(
-                    (?: [^\n]*\n*)*
-                    tunnel mpls traffic-eng auto-bw)/mx, '\1'
+      # This removes 'bandwidth X' only if 'auto-bw' is configured in the same interface
+      cfg.gsub! /^ (tunnel mpls traffic-eng bandwidth [^\n]*)\n((?: [^\n]*\n)* tunnel mpls traffic-eng auto-bw)/, '\2'
       # get rid of values of custom SNMP OID's
       cfg.gsub! /^(\s+expression) \d+$/, '\\1 <value removed>'
       cfg


### PR DESCRIPTION
Replace:
cfg.gsub! /^ tunnel mpls traffic-eng bandwidth[^\n]*\n*(
              (?: [^\n]*\n*)*
              tunnel mpls traffic-eng auto-bw)/mx, '\1'

by:
## This removes 'bandwidth X' only if 'auto-bw' is configured in the same interface
      cfg.gsub! /^ (tunnel mpls traffic-eng bandwidth [^\n]*)\n((?: [^\n]*\n)* tunnel mpls traffic-eng auto-bw)/, '\2'

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
