### PR TITLE
Hide SNMP secrets for Procurve

### DIFF
--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -44,7 +44,7 @@ class Procurve < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community) \S+(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^(snmp-server host \S+) \S+(.*)/, '\\1 <secret hidden> \\2'
-    cfg.gsub! /^(radius-server host \S+ (key|encrypted-key)) \S+(.*)/, '\\1 <secret hidden>'
+    cfg.gsub! /^(radius-server host \S+ (?:key|encrypted-key)) \S+$/, '\\1 <secret hidden>'
     cfg.gsub! /^(radius-server key).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(tacacs-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^(tacacs-server key).*/, '\\1 <secret hidden>'

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -44,10 +44,11 @@ class Procurve < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community) \S+(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^(snmp-server host \S+) \S+(.*)/, '\\1 <secret hidden> \\2'
-    cfg.gsub! /^(radius-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(radius-server host \S+ (key|encrypted-key)) \S+(.*)/, '\\1 <secret hidden>'
     cfg.gsub! /^(radius-server key).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(tacacs-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^(tacacs-server key).*/, '\\1 <secret hidden>'
+    cfg.gsub! /(encrypt-cred) \S+(.*)/, '\\1 <secret hidden>'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Hide SNMP secrets for Procurve
