### PR TITLE
Add secret detection support for SNMP traps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - input/ssh: validate that cmd is a String. See #3700 (@robertcheramy)
 
 ### Fixed
-
+- VyOS: detect community string in SNMP traps. Fixes: #3793 (@nicolasberens)
 
 ## [0.36.0 - 2026-03-31]
 ### Release Notes

--- a/lib/oxidized/model/vyos.rb
+++ b/lib/oxidized/model/vyos.rb
@@ -16,6 +16,7 @@ class Vyos < Oxidized::Model
     cfg.gsub! /secret (\S+).*/, 'secret <secret removed>'
     cfg.gsub! /password (\S+).*/, 'password <secret removed>'
     cfg.gsub! /snmp community (\S+)/, 'snmp community <secret removed>'
+    cfg.gsub! /snmp trap-target ([^\s\\]*) community (\S+)/, 'snmp trap-target \1 community <secret removed>'
     cfg.gsub! /preshared-key (\S+).*/, 'preshared-key <secret removed>'
     cfg.gsub! /private key (\S+).*/, 'private key <secret removed>'
     cfg.gsub! /private-key (\S+).*/, 'private-key <secret removed>'

--- a/spec/model/data/vyos#Supermicro_1.4.3#output.txt
+++ b/spec/model/data/vyos#Supermicro_1.4.3#output.txt
@@ -56,6 +56,7 @@ set service ntp server 10.10.10.1
 set service snmp community snmppublic authorization 'ro'
 set service snmp contact 'user@example.com'
 set service snmp oid-enable 'ip-route-table'
+set service snmp trap-target 10.10.10.10 community 'snmppublic'
 set service ssh port '22'
 set system config-management commit-revisions '20'
 set system conntrack expect-table-size '2048'

--- a/spec/model/data/vyos#Supermicro_1.4.3#simulation.yaml
+++ b/spec/model/data/vyos#Supermicro_1.4.3#simulation.yaml
@@ -66,6 +66,7 @@ commands:
       set service snmp community snmppublic authorization 'ro'
       set service snmp contact 'user@example.com'
       set service snmp oid-enable 'ip-route-table'
+      set service snmp trap-target 10.10.10.10 community 'snmppublic'
       set service ssh port '22'
       set system config-management commit-revisions '20'
       set system conntrack expect-table-size '2048'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->
Closes Issue #3793 

This Change adds support to detect SNMP community strings in the Vyos config.

It also extends the tests so this regression will get caught in the future.
<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
