### PR TITLE
ios: keep motherboard information in show version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - input/ssh: validate that cmd is a String. See #3700 (@robertcheramy)
 - junos: changed "show system license" regex to reduce notification noise for PTX routers. See #3794 (@ctomkow)
+- ios: keep motherboard information in show version. Closes #3798 (@robertcheramy)
 
 ### Fixed
 - VyOS: detect community string in SNMP traps. Fixes: #3793 (@nicolasberens)

--- a/lib/oxidized/model/ios.rb
+++ b/lib/oxidized/model/ios.rb
@@ -112,6 +112,8 @@ class IOS < Oxidized::Model
         comments << "CPU:#{slave} #{cpu}#{cpuxtra}#{slaveslot}"
       end
 
+      comments << line.chomp if line.start_with?('Motherboard')
+
       comments << "Image: #{Regexp.last_match(1)}" if line =~ /^System image file is "([^"]*)"$/
     end
     comments << "\n"

--- a/spec/model/data/ios#C9200L-24P-4G_17.09.04a#output.txt
+++ b/spec/model/data/ios#C9200L-24P-4G_17.09.04a#output.txt
@@ -8,6 +8,9 @@
 ! Processor ID: JAE24FFFFFF
 ! CPU: ARM64
 ! Memory: nvram 2048K
+! Motherboard Assembly Number        : 77-22222-00
+! Motherboard Serial Number          : JAE24FFFFFF
+! Motherboard Revision Number        : A0
 ! 
 ! VTP: VTP Version capable             : 1 to 3
 ! VTP: VTP version running             : 1


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Closes #3798