### PR TITLE
Additional models, for additional Palo Alto models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - routeros: support store mode `on_significant` (@infabo)
 - model for Grandstream HT8xx (@mklopocki)
 - Add --support option to gather system diagnostics (@robertcheramy)
+- Added 3 new models for Palo Alto PanOS firewalls and Panorama firewall-management servers
 
 ### Changed
 - input/ssh: validate that cmd is a String. See #3700 (@robertcheramy)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -153,6 +153,9 @@
 |OPNsense            |                              |[opnsense](/lib/oxidized/model/opnsense.rb)
 |Palo Alto           |PanOS API                     |[panos_api](/lib/oxidized/model/panos_api.rb)    |                 |[PanOS_API](Model-Notes/PanOS_API.md)
 |                    |PanOS                         |[panos](/lib/oxidized/model/panos.rb)
+|                    |PanOS CLI XML                 |[panosxml](/lib/oxidized/model/panosxml.rb)      |@athompson-merlin |XML without needing API access
+|                    |Panorama XML                  |[panoramaxml](/lib/oxidized/model/panoramaxml.rb)      |@athompson-merlin |XML from Panorama CLI
+|                    |Panorama "set"                |[panoramaset](/lib/oxidized/model/panoramaset.rb)      |@athompson-merlin |"set" format from Panorama
 |[Perle](https://www.perle.com)|IOLAN Console Servers|[perle](/lib/oxidized/model/perle.rb)           |@robertcheramy
 |PLANET SG/SGS Switches|                            |[planet](/lib/oxidized/model/planet.rb)
 |pfSense             |                              |[pfsense](/lib/oxidized/model/pfsense.rb)

--- a/lib/oxidized/model/panoramaset.rb
+++ b/lib/oxidized/model/panoramaset.rb
@@ -1,0 +1,18 @@
+class PanoramaSet < Oxidized::Model
+
+  comment '! '
+
+  prompt /^[\w.@:()-]+[#>]\s?$/
+
+  cmd 'show' do |cfg|
+    cfg
+  end
+
+  cfg :ssh do
+    post_login 'set cli pager off'
+    post_login 'set cli config-output-format set'
+    post_login 'configure'
+    pre_logout 'exit'
+    pre_logout 'quit'
+  end
+end

--- a/lib/oxidized/model/panoramaxml.rb
+++ b/lib/oxidized/model/panoramaxml.rb
@@ -1,0 +1,18 @@
+class PanoramaXML < Oxidized::Model
+
+  comment '! '
+
+  prompt /^[\w.@:()-]+[#>]\s?$/
+
+  cmd 'show' do |cfg|
+    cfg
+  end
+
+  cfg :ssh do
+    post_login 'set cli pager off'
+    post_login 'set cli config-output-format xml'
+    post_login 'configure'
+    pre_logout 'exit'
+    pre_logout 'quit'
+  end
+end

--- a/lib/oxidized/model/panosxml.rb
+++ b/lib/oxidized/model/panosxml.rb
@@ -1,0 +1,22 @@
+require 'nokogiri'
+
+class PanOSXML < Oxidized::Model
+
+  comment '! '
+
+  prompt /^[\w.@:()-]+[#>]\s?$/
+
+  cmd 'show config running' do |cfg|
+    "<?xml version=\"1.0\"?>\n" +
+    Nokogiri::XML(
+        cfg.split("\n")[2..-2].join("\n")
+    ).at('/response/result/config').to_xml(indent: 2)
+  end
+
+  cfg :ssh do
+    post_login 'set cli pager off'
+    post_login 'set cli op-command-xml-output on'
+    post_login 'set cli config-output-format xml'
+    pre_logout 'quit'
+  end
+end


### PR DESCRIPTION
## Pre-Request Checklist
Not a dev, so no idea what rubocop or rake are.  (Obviously I can guess, but never seen them before.)  Learning one iota more about Ruby than I need to is *wildly* out of scope for me, but I still wanted to upstream these models if possible.

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
These three new models address two use cases the original Palo Alto models did not, (1) obtaining an XML output without needing to use the API, and (2) obtaining output in two different formats from the Panorama management server, which has slightly different syntax.  The "XML" format can be used (with some work) to restore a firewall, but is largely un-parseable; the "set" format is more useful for every other scenario as it's parseable and pasteable.