### PR TITLE
tpink: use `\r\n` when sending commands and set `terminal length 0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - linuxgeneric: fix prompt, telnet username and clean ANSI Escape Codes (@robertcheramy)
 - cumulus: fix prompt (make : and space optional). Fixes #3812 (@robertcheramy)
 - dlinknexgen: NULL byte handling. Fixes #3816 (@ziotibia81)
+- tpink: use `\r\n` when sending commands and set `terminal length 0`. Fixes #3804 (@robertcheramy)
 
 
 ## [0.36.0 - 2026-03-31]

--- a/docs/Creating-Models.md
+++ b/docs/Creating-Models.md
@@ -189,7 +189,7 @@ The macro (with defaults) implements following code:
       if vars(:enable) == true
         cmd "enable"
       elsif vars(:enable)
-        cmd "enable", /^[pP]assword:/
+        cmd "enable", /password/i
         cmd vars(:enable)
       end
     end

--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -48,19 +48,17 @@ class TPLink < Oxidized::Model
     lines[0..lines.index("end\n")].join
   end
 
+  macro :enable, regex: /^[pP]assword:/
+
   cfg :telnet, :ssh do
     username /^User ?[nN]ame:/
     password /^\r?Password:/
+    newline "\r\n"
   end
 
   cfg :telnet, :ssh do
     post_login do
-      if vars(:enable) == true
-        cmd "enable"
-      elsif vars(:enable)
-        cmd "enable", /^[pP]assword:/
-        cmd vars(:enable)
-      end
+      cmd 'terminal length 0'
     end
 
     pre_logout do


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Closes #3804
