### PR TITLE
Set Rake::TestTask to `verbose = false`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - aoscx: use oxidized filtering instead of "show system | exclude...". (@robertcheramy)
 - input/*: rewrite debug logging; remove unused logging; input/ssh: write a YAML simulation file (@robertcheramy)
 - truenas: capture app, replication, cloudsync configurations without constant changes. See #3795 (@neilschelly)
+- Set Rake::TestTask to `verbose = false` since the behavior changed with rake 13.4.2 (@robertcheramy)
 
 ### Fixed
 - VyOS: detect community string in SNMP traps. Fixes: #3793 (@nicolasberens)

--- a/Rakefile
+++ b/Rakefile
@@ -30,7 +30,7 @@ task :test do
     t.ruby_opts = ['-W:deprecated']
     # Don't display ambiguity warning between regexp and division in models
     t.warning = false
-    t.verbose = true
+    t.verbose = false
   end
 end
 


### PR DESCRIPTION


## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

The behavior changed with rake 13.4.2, t.verbose was ignored before.