### PR TITLE
Update ipos.rb

### DIFF
--- a/lib/oxidized/model/ipos.rb
+++ b/lib/oxidized/model/ipos.rb
@@ -4,7 +4,7 @@ class IPOS < Oxidized::Model
   # Ericsson SSR (IPOS)
   # Redback SE (SEOS)
 
-  prompt /^([\[\]\w.@-]+[#:>]\s?)$/
+  prompt /\r?([\[\]\w.@-]+[#:>]\s?)$/
   comment '! '
 
   cmd 'show chassis' do |cfg|
@@ -19,7 +19,7 @@ class IPOS < Oxidized::Model
     comment cfg.cut_tail
   end
 
-  cmd 'show configuration' do |cfg|
+  cmd 'show running-config' do |cfg|
     # SEOS regularly adds some odd line breaks in random places
     # when showing the config, triggering changes.
     cfg.gsub! "\r\n", "\n"
@@ -52,7 +52,7 @@ class IPOS < Oxidized::Model
   end
 
   cfg :telnet, :ssh do
-    post_login 'terminal length 0'
+    post_login 'paginate false'
     if vars :enable
       post_login do
         cmd "enable"
@@ -61,7 +61,6 @@ class IPOS < Oxidized::Model
     end
     pre_logout do
       send "exit\n"
-      send "n\n"
     end
   end
 end


### PR DESCRIPTION
Fixes of command syntax for Ericsson EPG. Tested it successfully on version mentioned bellow.

#show version 

Ericsson IPOS Version IPOS-22.3.1.1.13p4-Release
Built by ciflash@seroius08993 Mon Aug 01 06:23:54 CEST 2022 Copyright (C) 1998-2022, Ericsson AB. All rights reserved. Operating System version is Linux 4.19.97-00205-g42d09a9 System Bootstrap version is OpenFirmware  3.0.2.70  PRODUCTION RELEASE Installed minikernel version is v4.19.97-00183-g54c6a0a Router Up Time -  2 days, 7 hours 14 minutes 5 seconds

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fixes of command syntax. Not on latest possible version.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
