### PR TITLE
tplink: model fix and added TP-Link DeltaStream GPON OLT unit tests and model notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 ### Added
 - source/sql: support defining port in configuration. Closes #3853 (@ytti)
+- tplink: add simulation data and unit tests for the TP-Link DeltaStream DS-P7001-08 GPON OLT (@Vantomas)
 
 ### Changed
 - docker: set LANG=C.UTF-8. Fixes #3690 (@ytti)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - docker: set LANG=C.UTF-8. Fixes #3690 (@ytti)
+- tplink: use `\r\n` as the line terminator in pre_logout, required for the model unit tests to work (@Vantomas)
 
 ### Fixed
 - siklu: allow parenthesis in prompt. Fixes #3841 (@ytti)

--- a/docs/Model-Notes/TPLink.md
+++ b/docs/Model-Notes/TPLink.md
@@ -1,0 +1,75 @@
+# TP-Link Configuration
+
+The `tplink` model is used for TP-Link JetStream managed switches and the
+DeltaStream GPON OLT. The notes below apply to all of them.
+
+## SSH authentication: avoid public-key authentication
+
+Some TP-Link devices (the DeltaStream GPON OLT for example) **abort the SSH
+connection if the client attempts public-key authentication before the
+password**. By default net-ssh offers any key from the SSH agent or the default
+identity files first, so when the Oxidized host has SSH keys the device closes the
+connection before the password is ever tried:
+
+```text
+connection closed by remote host (Net::SSH::Disconnect)
+```
+
+This is why the same device may connect fine from one host (no SSH keys) and fail
+from another (keys present). Tell Oxidized to skip `publickey` with the
+`auth_methods` variable (see [SSH Auth Methods](../Inputs.md#ssh-auth-methods)).
+It can be set globally, by group, by model or by node, e.g. for every `tplink`
+device:
+
+```yaml
+models:
+  tplink:
+    vars:
+      auth_methods: ["none", "password"]
+```
+
+### Capturing a simulation with device2yaml.rb
+
+`extra/device2yaml.rb` has no `auth_methods` option, but net-ssh reads
+`~/.ssh/config`, so add a host block for the device to force password
+authentication:
+
+```text
+Host <device-ip>
+    PreferredAuthentications password
+    PubkeyAuthentication no
+```
+
+This CLI also submits a command only on a carriage return, so run device2yaml with
+`-n '\r\n'`; otherwise the commands are echoed but never executed.
+
+## Enable mode
+
+Devices such as the DeltaStream GPON OLT only expose their configuration in
+privileged (enable) mode. The model enters enable mode through the standard
+`enable` variable:
+
+- `enable: true` — switch to enable with **no** password (TP-Link devices enable
+  without a password by default).
+- `enable: <password>` — switch to enable and send `<password>` when prompted.
+
+Set it globally, per model or per node, e.g. in the configuration:
+
+```yaml
+models:
+  tplink:
+    vars:
+      enable: true
+```
+
+or as the 6th column of a CSV `router.db` line (the CSV source maps the string
+`true` to the boolean `true`):
+
+```text
+tplink-olt:tplink:10.0.0.1:admin:secret:true
+```
+
+Without the `enable` variable the model stays in user mode (`>`) and privileged
+commands return `Error: Bad command`.
+
+Back to [Model-Notes](README.md)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -180,6 +180,7 @@
 |Trango Systems      |Trango                        |[trango](/lib/oxidized/model/trango.rb)
 |TrueNAS             |TrueNAS                       |[truenas](/lib/oxidized/model/truenas.rb)
 |TPLink              |TPLink                        |[tplink](/lib/oxidized/model/tplink.rb)
+|                    |DeltaStream GPON OLT          |[tplink](/lib/oxidized/model/tplink.rb)          |@Vantomas        |[TPLink](Model-Notes/TPLink.md)|
 |                    |TL-SL5428                     |[edgecos](/lib/oxidized/model/edgecos.rb)
 |                    |TL-SL3428                     |[powerconnect](/lib/oxidized/model/powerconnect.rb)
 |Ubiquiti            |AirOS                         |[airos](/lib/oxidized/model/airos.rb)

--- a/lib/oxidized/model/tplink.rb
+++ b/lib/oxidized/model/tplink.rb
@@ -62,8 +62,8 @@ class TPLink < Oxidized::Model
     end
 
     pre_logout do
-      send "exit\r"
-      send "logout\r"
+      send "exit\r\n"
+      send "logout\r\n"
     end
   end
 end

--- a/spec/model/data/tplink#DS-P7001-08_1.0.0#output.txt
+++ b/spec/model/data/tplink#DS-P7001-08_1.0.0#output.txt
@@ -1,0 +1,179 @@
+!  System Location      - RT_02
+!  Contact Information  - EMAILREMOVED
+!  Hardware Version     - DS-P7001-08 1.0
+!  Software Version     - 1.0.0 Build 20210907 Rel.69162
+!  Bootloader Version   - TP-LINK BOOTUTIL(v1.0.0)
+!  Mac Address          - MA-CR-EM-OV-ED-00
+!  Serial Number        - SNREMOVED
+!  System Time          - <stripped>
+!DS-P7001-08
+vlan 1921
+ name "Klienti"
+hostname "RT_02-TPLink_OLT"
+location "RT_02"
+contact-info "EMAILREMOVED"
+serial_port baud_rate 38400
+logging host index 1 198.51.100.24 6
+system-time ntp UTC+01:00 198.51.100.3 192.0.2.163 12
+system-time dst predefined Europe
+user name admin privilege admin secret 5 PASSREMOVED
+no service reset-disable
+ip ssh server 
+spanning-tree
+spanning-tree mode rstp
+lldp
+ip route 0.0.0.0 0.0.0.0 198.51.100.129
+loopback-detection
+dba-profile profile-id 0 profile-name default type4 max 1024000
+dba-profile profile-id 10 profile-name dba-profile_10 type4 max 1024000
+ont-srvprofile gpon profile-id 0 profile-name default
+  mac-learning
+  native-vlan unconcern
+  multicast-mode unconcern
+  multicast-forward unconcern
+  ont-port eth adaptive 4
+  port priority-policy eth 1 unconcern
+  port igmp-forward eth 1 unconcern
+  port q-in-q eth 1 unconcern
+  port eth 1 max-mac-count unlimited
+  port priority-policy eth 2 unconcern
+  port igmp-forward eth 2 unconcern
+  port q-in-q eth 2 unconcern
+  port eth 2 max-mac-count unlimited
+  port priority-policy eth 3 unconcern
+  port igmp-forward eth 3 unconcern
+  port q-in-q eth 3 unconcern
+  port eth 3 max-mac-count unlimited
+  port priority-policy eth 4 unconcern
+  port igmp-forward eth 4 unconcern
+  port q-in-q eth 4 unconcern
+  port eth 4 max-mac-count unlimited
+  ont-port pots adaptive 2
+ont-srvprofile gpon profile-id 11 profile-name srv-profile_vlan1921
+  mac-learning
+  native-vlan concern
+  multicast-mode unconcern
+  multicast-forward unconcern
+  ont-port eth adaptive 4
+  port priority-policy eth 1 unconcern
+  port igmp-forward eth 1 unconcern
+  port q-in-q eth 1 unconcern
+  port eth 1 max-mac-count unlimited
+  port priority-policy eth 2 unconcern
+  port igmp-forward eth 2 unconcern
+  port q-in-q eth 2 unconcern
+  port eth 2 max-mac-count unlimited
+  port priority-policy eth 3 unconcern
+  port igmp-forward eth 3 unconcern
+  port q-in-q eth 3 unconcern
+  port eth 3 max-mac-count unlimited
+  port priority-policy eth 4 unconcern
+  port igmp-forward eth 4 unconcern
+  port q-in-q eth 4 unconcern
+  port eth 4 max-mac-count unlimited
+  ont-port pots adaptive 2
+ont-lineprofile gpon profile-id 0 profile-name default
+  no fec-upstream
+  mapping-mode vlan
+  omcc encrypt
+  tcont 1 dba-profile-id 0
+  gem add 1 tcont 1 encrypt enable
+  gem mapping 1 1 vlan-untag
+ont-lineprofile gpon profile-id 10 profile-name line-profile_10
+  fec-upstream
+  mapping-mode vlan
+  omcc encrypt
+  tcont 4 dba-profile-id 10
+  gem add 11 tcont 4 encrypt enable
+  gem mapping 11 1 vlan 1921
+service-port 1 config gpon 1/0/1 ont 0 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 2 config gpon 1/0/1 ont 0 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate adminstatus disable statistic-performance enable
+service-port 3 config gpon 1/0/1 ont 1 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 4 config gpon 1/0/1 ont 2 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 5 config gpon 1/0/1 ont 3 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 6 config gpon 1/0/1 ont 4 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 7 config gpon 1/0/1 ont 5 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 8 config gpon 1/0/1 ont 6 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 9 config gpon 1/0/1 ont 7 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate
+service-port 10 config gpon 1/0/1 ont 8 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 11 config gpon 1/0/1 ont 9 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 12 config gpon 1/0/1 ont 10 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 13 config gpon 1/0/1 ont 11 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 14 config gpon 1/0/1 ont 12 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 15 config gpon 1/0/1 ont 13 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 16 config gpon 1/0/1 ont 14 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 17 config gpon 1/0/1 ont 15 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+service-port 19 config gpon 1/0/1 ont 17 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable
+interface port-channel 1
+  switchport general allowed vlan 1921 tagged
+  spanning-tree
+interface gpon 1/0/1
+  downstream-fec
+  ont auto-auth authmode sn-auth
+  ont add 0 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 1 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 2 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 3 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 4 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 5 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 6 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 7 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 8 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 9 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 10 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 11 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 12 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 13 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 14 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 15 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont add 17 sn-auth TPLG-BA123456 desc "Klient" ont-lineprofile-id 10 ont-srvprofile-id 11
+  ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0
+  ont port attribute 0 eth 1 admin-status enable
+interface gpon 1/0/2
+  ont auto-auth authmode sn-auth
+  ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0
+interface gpon 1/0/3
+  ont auto-auth authmode sn-auth
+  ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0
+interface gpon 1/0/4
+  ont auto-auth authmode sn-auth
+  ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0
+interface gpon 1/0/5
+  ont auto-auth authmode sn-auth
+  ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0
+interface gpon 1/0/6
+  ont auto-auth authmode sn-auth
+  ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0
+interface gpon 1/0/7
+  ont auto-auth authmode sn-auth
+  ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0
+interface gpon 1/0/8
+  ont auto-auth authmode sn-auth
+  ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0
+interface management 1
+  ip address 192.168.1.1 255.255.255.0
+  ipv6 enable
+interface vlan 1
+  ip address 192.168.0.1 255.255.255.0
+  ipv6 enable
+  dpms interface-id 1
+interface vlan 1921
+  ip address 198.51.100.130 255.255.255.128
+  no ipv6 enable
+interface ten-gigabitEthernet 1/0/1
+  speed 1000
+  duplex full
+  switchport general allowed vlan 1921 tagged
+  spanning-tree
+  channel-group 1 mode active
+interface ten-gigabitEthernet 1/0/2
+  speed 1000
+  duplex full
+  switchport general allowed vlan 1921 tagged
+  spanning-tree
+  channel-group 1 mode active
+interface gigabitEthernet 1/0/3
+  switchport general allowed vlan 1921 tagged
+  spanning-tree
+  channel-group 1 mode active
+end

--- a/spec/model/data/tplink#DS-P7001-08_1.0.0#secret.yaml
+++ b/spec/model/data/tplink#DS-P7001-08_1.0.0#secret.yaml
@@ -1,0 +1,4 @@
+fail:
+  - 'PASSREMOVED'
+pass:
+  - 'user name admin privilege admin <secret hidden>'

--- a/spec/model/data/tplink#DS-P7001-08_1.0.0#simulation.yaml
+++ b/spec/model/data/tplink#DS-P7001-08_1.0.0#simulation.yaml
@@ -1,0 +1,285 @@
+---
+# NOTE: this simulation file was edited by hand. The ATOMS model unit tests
+# cannot inject node variables, so there is no way to set vars(:enable) and make
+# the model (macro :enable) issue "enable". The "enable" step is therefore
+# commented out below and init_prompt is the privileged "#" prompt, so the
+# privileged show commands can still be exercised by the test.
+command_newline: "\r\n"
+init_prompt: |-
+    \r
+    \rRT_02-TPLink_OLT#
+commands:
+#  - "enable\r\n": |-
+#      enable\r
+#      \r
+#      \rRT_02-TPLink_OLT#
+  - "terminal length 0\r\n": |-
+      terminal length 0\r
+      \r
+      \rRT_02-TPLink_OLT#
+  - "show system-info\r\n": |-
+      show system-info\r
+       System Description   - DeltaStream 8-Port Pizza-box GPON Optical Line Terminal\r
+       System Name          - RT_02-TPLink_OLT\r
+       System Location      - RT_02\r
+       Contact Information  - EMAILREMOVED\r
+       Hardware Version     - DS-P7001-08 1.0\r
+       Software Version     - 1.0.0 Build 20210907 Rel.69162\r
+       Bootloader Version   - TP-LINK BOOTUTIL(v1.0.0)\r
+       Mac Address          - MA-CR-EM-OV-ED-00\r
+       Serial Number        - SNREMOVED\r
+       System Time          - 2026-05-26 15:40:15\r
+       Running Time         - 325 day - 19 hour - 31 min - 29 sec\r
+      \r
+      \rRT_02-TPLink_OLT#
+  - "show running-config\r\n": |-
+      show running-config\r
+      !DS-P7001-08\r
+      #\r
+      vlan 1921\r
+       name \"Klienti\"\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      hostname \"RT_02-TPLink_OLT\"\r
+      location \"RT_02\"\r
+      contact-info \"EMAILREMOVED\"\r
+      serial_port baud_rate 38400\r
+      #\r
+      logging host index 1 198.51.100.24 6\r
+      #\r
+      system-time ntp UTC+01:00 198.51.100.3 192.0.2.163 12\r
+      system-time dst predefined Europe\r
+      #\r
+      #\r
+      #\r
+      user name admin privilege admin secret 5 PASSREMOVED\r
+      no service reset-disable\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      ip ssh server \r
+      #\r
+      #\r
+      spanning-tree\r
+      spanning-tree mode rstp\r
+      #\r
+      #\r
+      lldp\r
+      #\r
+      ip route 0.0.0.0 0.0.0.0 198.51.100.129\r
+      #\r
+      #\r
+      \r
+      #\r
+      #\r
+      loopback-detection\r
+      #\r
+      #\r
+      #\r
+      #\r
+      #\r
+      dba-profile profile-id 0 profile-name default type4 max 1024000\r
+      dba-profile profile-id 10 profile-name dba-profile_10 type4 max 1024000\r
+      ont-srvprofile gpon profile-id 0 profile-name default\r
+        mac-learning\r
+        native-vlan unconcern\r
+        multicast-mode unconcern\r
+        multicast-forward unconcern\r
+        ont-port eth adaptive 4\r
+        port priority-policy eth 1 unconcern\r
+        port igmp-forward eth 1 unconcern\r
+        port q-in-q eth 1 unconcern\r
+        port eth 1 max-mac-count unlimited\r
+        port priority-policy eth 2 unconcern\r
+        port igmp-forward eth 2 unconcern\r
+        port q-in-q eth 2 unconcern\r
+        port eth 2 max-mac-count unlimited\r
+        port priority-policy eth 3 unconcern\r
+        port igmp-forward eth 3 unconcern\r
+        port q-in-q eth 3 unconcern\r
+        port eth 3 max-mac-count unlimited\r
+        port priority-policy eth 4 unconcern\r
+        port igmp-forward eth 4 unconcern\r
+        port q-in-q eth 4 unconcern\r
+        port eth 4 max-mac-count unlimited\r
+        ont-port pots adaptive 2\r
+      #\r
+      ont-srvprofile gpon profile-id 11 profile-name srv-profile_vlan1921\r
+        mac-learning\r
+        native-vlan concern\r
+        multicast-mode unconcern\r
+        multicast-forward unconcern\r
+        ont-port eth adaptive 4\r
+        port priority-policy eth 1 unconcern\r
+        port igmp-forward eth 1 unconcern\r
+        port q-in-q eth 1 unconcern\r
+        port eth 1 max-mac-count unlimited\r
+        port priority-policy eth 2 unconcern\r
+        port igmp-forward eth 2 unconcern\r
+        port q-in-q eth 2 unconcern\r
+        port eth 2 max-mac-count unlimited\r
+        port priority-policy eth 3 unconcern\r
+        port igmp-forward eth 3 unconcern\r
+        port q-in-q eth 3 unconcern\r
+        port eth 3 max-mac-count unlimited\r
+        port priority-policy eth 4 unconcern\r
+        port igmp-forward eth 4 unconcern\r
+        port q-in-q eth 4 unconcern\r
+        port eth 4 max-mac-count unlimited\r
+        ont-port pots adaptive 2\r
+      #\r
+      ont-lineprofile gpon profile-id 0 profile-name default\r
+        no fec-upstream\r
+        mapping-mode vlan\r
+        omcc encrypt\r
+        tcont 1 dba-profile-id 0\r
+        gem add 1 tcont 1 encrypt enable\r
+        gem mapping 1 1 vlan-untag\r
+      #\r
+      ont-lineprofile gpon profile-id 10 profile-name line-profile_10\r
+        fec-upstream\r
+        mapping-mode vlan\r
+        omcc encrypt\r
+        tcont 4 dba-profile-id 10\r
+        gem add 11 tcont 4 encrypt enable\r
+        gem mapping 11 1 vlan 1921\r
+      #\r
+      #\r
+      service-port 1 config gpon 1/0/1 ont 0 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 2 config gpon 1/0/1 ont 0 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate adminstatus disable statistic-performance enable\r
+      service-port 3 config gpon 1/0/1 ont 1 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 4 config gpon 1/0/1 ont 2 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 5 config gpon 1/0/1 ont 3 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 6 config gpon 1/0/1 ont 4 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 7 config gpon 1/0/1 ont 5 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 8 config gpon 1/0/1 ont 6 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 9 config gpon 1/0/1 ont 7 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate\r
+      service-port 10 config gpon 1/0/1 ont 8 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 11 config gpon 1/0/1 ont 9 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 12 config gpon 1/0/1 ont 10 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 13 config gpon 1/0/1 ont 11 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 14 config gpon 1/0/1 ont 12 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 15 config gpon 1/0/1 ont 13 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 16 config gpon 1/0/1 ont 14 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 17 config gpon 1/0/1 ont 15 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      service-port 19 config gpon 1/0/1 ont 17 gem-id 11 svlan 1921 user-vlan 1921 tag-action translate statistic-performance enable\r
+      interface port-channel 1\r
+        switchport general allowed vlan 1921 tagged\r
+        spanning-tree\r
+      #\r
+      interface gpon 1/0/1\r
+        downstream-fec\r
+        ont auto-auth authmode sn-auth\r
+        ont add 0 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 1 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 2 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 3 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 4 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 5 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 6 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 7 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 8 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 9 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 10 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 11 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 12 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 13 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 14 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 15 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont add 17 sn-auth TPLG-BA123456 desc \"Klient\" ont-lineprofile-id 10 ont-srvprofile-id 11\r
+        ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0\r
+        ont port attribute 0 eth 1 admin-status enable\r
+      #\r
+      interface gpon 1/0/2\r
+        ont auto-auth authmode sn-auth\r
+        ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0\r
+      #\r
+      interface gpon 1/0/3\r
+        ont auto-auth authmode sn-auth\r
+        ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0\r
+      #\r
+      interface gpon 1/0/4\r
+        ont auto-auth authmode sn-auth\r
+        ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0\r
+      #\r
+      interface gpon 1/0/5\r
+        ont auto-auth authmode sn-auth\r
+        ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0\r
+      #\r
+      interface gpon 1/0/6\r
+        ont auto-auth authmode sn-auth\r
+        ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0\r
+      #\r
+      interface gpon 1/0/7\r
+        ont auto-auth authmode sn-auth\r
+        ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0\r
+      #\r
+      interface gpon 1/0/8\r
+        ont auto-auth authmode sn-auth\r
+        ont auto-auth rule 1 ont-lineprofile-id 0 ont-srvprofile-id 0\r
+      #\r
+      interface management 1\r
+        ip address 192.168.1.1 255.255.255.0\r
+        ipv6 enable\r
+      #\r
+      interface vlan 1\r
+        ip address 192.168.0.1 255.255.255.0\r
+        ipv6 enable\r
+        dpms interface-id 1\r
+      #\r
+      interface vlan 1921\r
+        ip address 198.51.100.130 255.255.255.128\r
+        no ipv6 enable\r
+      #\r
+      interface ten-gigabitEthernet 1/0/1\r
+        speed 1000\r
+        duplex full\r
+        switchport general allowed vlan 1921 tagged\r
+        spanning-tree\r
+        \r
+        channel-group 1 mode active\r
+      #\r
+      interface ten-gigabitEthernet 1/0/2\r
+        speed 1000\r
+        duplex full\r
+        switchport general allowed vlan 1921 tagged\r
+        spanning-tree\r
+        \r
+        channel-group 1 mode active\r
+      #\r
+      interface gigabitEthernet 1/0/3\r
+        switchport general allowed vlan 1921 tagged\r
+        spanning-tree\r
+        \r
+        channel-group 1 mode active\r
+      #\r
+      end\r
+      \r
+      \rRT_02-TPLink_OLT#
+  - "exit\r\n": |-
+      exit\r
+      \r
+      \rRT_02-TPLink_OLT>
+  - "logout\r\n": |-

--- a/spec/model/data/tplink#generic#prompt.yaml
+++ b/spec/model/data/tplink#generic#prompt.yaml
@@ -1,0 +1,10 @@
+pass:
+  - "RT_02-TPLink_OLT>"
+  - "RT_02-TPLink_OLT> "
+  - "RT_02-TPLink_OLT#"
+  - "\rRT_02-TPLink_OLT#"
+  - "TL-SG3210#"
+fail:
+  - "Password:"
+  - "Error: Bad command"
+  - "Press any key to continue (Q to quit)"


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Add model unit tests and model notes for the `tplink` model, validated against a **TP-Link DeltaStream DS-P7001-08 GPON OLT** (software `1.0.0`), plus a small `pre_logout` fix. 

**Changes**

- **tplink `pre_logout`**: Send `\r\n` in `pre_logout`. This is what lets the captured simulation match the model in the unit test.
- **Model unit tests** (`spec/model/data/tplink#...`): simulation, expected output, prompt and secret fixtures for the DeltaStream DS-P7001-08.
- **Model notes** (`docs/Model-Notes/TPLink.md`):
  - *SSH auth caveat* — some TP-Link devices abort the SSH connection if the client offers a public key before password, so an Oxidized host that has SSH keys gets the connection closed before the password is tried. Fix with `auth_methods: ["none", "password"]`.

**Note on the simulation file:** it starts at the privileged `#` prompt with the `enable` step commented out (explained in a header comment in the file). 
