### PR TITLE
Separate model for TMOS when using AAA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - routeros: support store mode `on_significant` (@infabo)
 - model for Grandstream HT8xx (@mklopocki)
 - Add --support option to gather system diagnostics (@robertcheramy)
+- Add `tmos_aaa` model for F5 TMOS devices using AAA authentication
 
 ### Changed
 - input/ssh: validate that cmd is a String. See #3700 (@robertcheramy)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - routeros: support store mode `on_significant` (@infabo)
 - model for Grandstream HT8xx (@mklopocki)
 - Add --support option to gather system diagnostics (@robertcheramy)
-- Add `tmos_aaa` model for F5 TMOS devices using AAA authentication
+- Add `tmos_aaa` model for F5 TMOS devices using AAA authentication (@martinberg)
 
 ### Changed
 - input/ssh: validate that cmd is a String. See #3700 (@robertcheramy)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -92,6 +92,7 @@
 |                    |XOS, ExtremeWare              |[xos](/lib/oxidized/model/xos.rb)
 |F5                  |F5OS                          |[tmos](/lib/oxidized/model/f5os.rb)
 |                    |TMOS                          |[tmos](/lib/oxidized/model/tmos.rb)
+|                    |TMOS with AAA                 |[tmos](/lib/oxidized/model/tmos_aaa.rb)
 |Fiberstore (fs.com) |S3400                         |[fsos](/lib/oxidized/model/fsos.rb)              |                 |[FSOS](Model-Notes/FSOS.md)
 |                    |S3800                         |[gcombnps](/lib/oxidized/model/gcombnps.rb)
 |                    |S3900                         |[edgecos](/lib/oxidized/model/edgecos.rb)

--- a/lib/oxidized/model/tmos_aaa.rb
+++ b/lib/oxidized/model/tmos_aaa.rb
@@ -1,0 +1,59 @@
+class TMOS < Oxidized::Model
+  using Refinements
+
+  comment '# '
+
+  cmd :secret do |cfg|
+    cfg.gsub!(/^([\s\t]*)secret \S+/, '\1secret <secret removed>')
+    cfg.gsub!(/^([\s\t]*\S*)password \S+/, '\1password <secret removed>')
+    cfg.gsub!(/^([\s\t]*\S*)passphrase \S+/, '\1passphrase <secret removed>')
+    cfg.gsub!(/community \S+/, 'community <secret removed>')
+    cfg.gsub!(/community-name \S+/, 'community-name <secret removed>')
+    cfg.gsub!(/^([\s\t]*\S*)encrypted \S+$/, '\1encrypted <secret removed>')
+    cfg
+  end
+
+  cmd('tmsh -q show sys version') { |cfg| comment cfg }
+
+  cmd('tmsh -q show sys software') { |cfg| comment cfg }
+
+  cmd 'tmsh -q show sys hardware field-fmt' do |cfg|
+    cfg.gsub!(/fan-speed (\S+)/, '')
+    cfg.gsub!(/temperature (\S+)/, '')
+    cfg.gsub!(/humidity (\S+)/, '')
+    comment cfg
+  end
+
+  cmd('cat /config/bigip.license') { |cfg| comment cfg }
+
+  cmd 'tmsh -q list' do |cfg|
+    cfg.gsub!(/state (up|down|checking|irule-down)/, '')
+    cfg.gsub!(/errors (\d+)/, '')
+    cfg.gsub!(/^\s+bandwidth-bps (\d+)/, '')
+    cfg.gsub!(/^\s+bandwidth-cps (\d+)/, '')
+    cfg.gsub!(/^\s+bandwidth-pps (\d+)\n/, '')
+    cfg.gsub!(/^\s*\S*encrypted \S+\n/, '')
+    cfg
+  end
+
+  cmd('tmsh -q list net route all') { |cfg| comment cfg }
+
+  cmd('/bin/ls --full-time --color=never /config/ssl/ssl.crt') { |cfg| comment cfg }
+
+  cmd('/bin/ls --full-time --color=never /config/ssl/ssl.key') { |cfg| comment cfg }
+
+  cmd 'tmsh -q show running-config sys db all-properties' do |cfg|
+    cfg.gsub!(/sys db configsync.localconfigtime {[^}]+}/m, '')
+    cfg.gsub!(/sys db gtm.configtime {[^}]+}/m, '')
+    cfg.gsub!(/sys db ltm.configtime {[^}]+}/m, '')
+    comment cfg
+  end
+
+  cmd('[ -d "/config/zebos" ] && cat /config/zebos/*/ZebOS.conf') { |cfg| comment cfg }
+
+  cmd('cat /config/partitions/*/bigip*.conf') { |cfg| comment cfg }
+
+  cfg :ssh do
+    exec true # don't run shell, run each command in exec channel
+  end
+end

--- a/lib/oxidized/model/tmos_aaa.rb
+++ b/lib/oxidized/model/tmos_aaa.rb
@@ -1,6 +1,10 @@
 class TMOS < Oxidized::Model
   using Refinements
 
+  # Use this model if you have AAA configured in tmos
+  # See https://github.com/ytti/oxidized/issues/437
+  # F5 KB: https://my.f5.com/manage/s/article/K28660000
+
   comment '# '
 
   cmd :secret do |cfg|
@@ -13,20 +17,20 @@ class TMOS < Oxidized::Model
     cfg
   end
 
-  cmd('tmsh -q show sys version') { |cfg| comment cfg }
+  cmd('run /util bash -c "tmsh -q show sys version"') { |cfg| comment cfg }
 
-  cmd('tmsh -q show sys software') { |cfg| comment cfg }
+  cmd('run /util bash -c "tmsh -q show sys software"') { |cfg| comment cfg }
 
-  cmd 'tmsh -q show sys hardware field-fmt' do |cfg|
+  cmd 'run /util bash -c "tmsh -q show sys hardware field-fmt"' do |cfg|
     cfg.gsub!(/fan-speed (\S+)/, '')
     cfg.gsub!(/temperature (\S+)/, '')
     cfg.gsub!(/humidity (\S+)/, '')
     comment cfg
   end
 
-  cmd('cat /config/bigip.license') { |cfg| comment cfg }
+  cmd('run /util bash -c "cat /config/bigip.license"') { |cfg| comment cfg }
 
-  cmd 'tmsh -q list' do |cfg|
+  cmd 'run /util bash -c "tmsh -q list"' do |cfg|
     cfg.gsub!(/state (up|down|checking|irule-down)/, '')
     cfg.gsub!(/errors (\d+)/, '')
     cfg.gsub!(/^\s+bandwidth-bps (\d+)/, '')
@@ -36,22 +40,22 @@ class TMOS < Oxidized::Model
     cfg
   end
 
-  cmd('tmsh -q list net route all') { |cfg| comment cfg }
+  cmd('run /util bash -c "tmsh -q list net route all"') { |cfg| comment cfg }
 
-  cmd('/bin/ls --full-time --color=never /config/ssl/ssl.crt') { |cfg| comment cfg }
+  cmd('run /util bash -c "/bin/ls --full-time --color=never /config/ssl/ssl.crt"') { |cfg| comment cfg }
 
-  cmd('/bin/ls --full-time --color=never /config/ssl/ssl.key') { |cfg| comment cfg }
+  cmd('run /util bash -c "/bin/ls --full-time --color=never /config/ssl/ssl.key"') { |cfg| comment cfg }
 
-  cmd 'tmsh -q show running-config sys db all-properties' do |cfg|
+  cmd 'run /util bash -c "tmsh -q show running-config sys db all-properties"' do |cfg|
     cfg.gsub!(/sys db configsync.localconfigtime {[^}]+}/m, '')
     cfg.gsub!(/sys db gtm.configtime {[^}]+}/m, '')
     cfg.gsub!(/sys db ltm.configtime {[^}]+}/m, '')
     comment cfg
   end
 
-  cmd('[ -d "/config/zebos" ] && cat /config/zebos/*/ZebOS.conf') { |cfg| comment cfg }
+  cmd('run /util bash -c "[ -d "/config/zebos" ] && cat /config/zebos/*/ZebOS.conf"') { |cfg| comment cfg }
 
-  cmd('cat /config/partitions/*/bigip*.conf') { |cfg| comment cfg }
+  cmd('run /util bash -c "cat /config/partitions/*/bigip*.conf"') { |cfg| comment cfg }
 
   cfg :ssh do
     exec true # don't run shell, run each command in exec channel


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Modify existing tmos.rb as a new model to be able to run bash commands.
This is needed when using AAA on a F5 device due to it not allowing bash shell for a remote user.
See #437 for earlier Oxidized issue and https://my.f5.com/manage/s/article/K28660000 for F5 docs.

I have not ran any tests or code analysis but can try to do so if this seems like a viable approach.
