### PR TITLE
procurve: add model spec, fix secret redaction, simplify the model, rstrip comments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - procurve: rstrip trailing whitespace from commented command sections; add `String#rstrip_lines` refinement (@thanegill)
+- procurve: remove ANSI escape codes with `clean :escape_codes` and simplify the prompt regexp (@thanegill)
 
 ### Fixed
 - procurve: hide the SNMP community on `snmp-server host <ip> community "<name>"` lines (@thanegill)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 ### Added
+- procurve: model unit test (@thanegill)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 
 ### Fixed
+- procurve: hide the SNMP community on `snmp-server host <ip> community "<name>"` lines (@thanegill)
+- procurve: hide local user password hashes (`password ... sha1 "<hash>"`) when remove_secret is true (@thanegill)
 
 ## [0.37.0 - 2026-05-20]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - procurve: model unit test (@thanegill)
 
 ### Changed
+- procurve: rstrip trailing whitespace from commented command sections; add `String#rstrip_lines` refinement (@thanegill)
 
 ### Fixed
 - procurve: hide the SNMP community on `snmp-server host <ip> community "<name>"` lines (@thanegill)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Changed
 - procurve: rstrip trailing whitespace from commented command sections; add `String#rstrip_lines` refinement (@thanegill)
 - procurve: remove ANSI escape codes with `clean :escape_codes` and simplify the prompt regexp (@thanegill)
+- procurve: redact the additional credentials exposed by `include-credentials` / `encrypt-credentials`, with unit tests (@thanegill)
 
 ### Fixed
 - procurve: hide the SNMP community on `snmp-server host <ip> community "<name>"` lines (@thanegill)

--- a/docs/Model-Notes/HPEAruba.md
+++ b/docs/Model-Notes/HPEAruba.md
@@ -30,3 +30,8 @@ Older Devices like [ProCurve](/lib/oxidized/model/procurve.rb) or 3Com/Comware
 are listed under the Vendor "HP" in the
 [Supported OS Types](/docs/Supported-OS-Types.md) list.
 
+HPE Aruba switches running ArubaOS-Switch (the line that succeeded ProCurve -
+e.g. the 2530, 2540, 2920, 2930F/2930M, 3810 and 5400R series) also use the
+[procurve](/lib/oxidized/model/procurve.rb) model, even though they are branded
+"Aruba".
+

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -114,7 +114,7 @@
 |Hirschmann          |Classic                       |[hirschmann](/lib/oxidized/model/hirschmann.rb)
 |                    |HiOS                          |[hios](/lib/oxidized/model/hios.rb)
 |HP                  |Comware (HP A-series, H3C, 3Com)|[comware](/lib/oxidized/model/comware.rb)      |@robertcheramy   |[Comware](Model-Notes/Comware.md)
-|                    |Procurve                      |[procurve](/lib/oxidized/model/procurve.rb)      |@robertcheramy
+|                    |Procurve                      |[procurve](/lib/oxidized/model/procurve.rb)      |@robertcheramy, @thanegill
 |                    |BladeSystem (Onboard Administrator)|[hpebladesystem](/lib/oxidized/model/hpebladesystem.rb)
 |                    |MSA                           |[hpemsa](/lib/oxidized/model/hpemsa.rb)
 |                    |MSM (Wireless Controller)     |[hpmsm](/lib/oxidized/model/hpmsm.rb)

--- a/lib/oxidized/model/adtran.rb
+++ b/lib/oxidized/model/adtran.rb
@@ -6,7 +6,7 @@ class Adtran < Oxidized::Model
   prompt /([\w.@-]+[#>]\s?)$/
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[2..-2].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+    cfg.delete("\r").cut_both(2, 1).rstrip_lines
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/aosw.rb
+++ b/lib/oxidized/model/aosw.rb
@@ -52,31 +52,31 @@ class AOSW < Oxidized::Model
       /(Switch|AP) uptime/i,
       /Reboot Time and Cause/i
     ]
-    rstrip_cfg comment cfg
+    clean_comment cfg
   end
 
   cmd 'show inventory' do |cfg|
     # Don't show for unsupported devices (IAP and MAS)
     cfg = "" if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/
-    rstrip_cfg clean cfg
+    clean(cfg).rstrip_lines
   end
 
   cmd 'show slots' do |cfg|
     # Don't show for unsupported devices (IAP and MAS)
     cfg = "" if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/
-    rstrip_cfg comment cfg
+    clean_comment cfg
   end
 
   cmd 'show license' do |cfg|
     # Don't show for unsupported devices (IAP and MAS)
     cfg = "" if cfg =~ /(Invalid input detected at '\^' marker|Parse error)/
-    rstrip_cfg comment cfg
+    clean_comment cfg
   end
 
   cmd 'show license passphrase' do |cfg|
     # Don't show for unsupported devices (IAP and MAS)
     cfg = "" if cfg.match /(Invalid input detected at '\^' marker|Parse error)/
-    rstrip_cfg comment cfg
+    clean_comment cfg
   end
 
   cmd 'show running-config' do |cfg|
@@ -84,7 +84,7 @@ class AOSW < Oxidized::Model
       /^controller config \d+$/,
       /^Building Configuration/
     ]
-    rstrip_cfg cfg
+    cfg.rstrip_lines
   end
 
   cfg :telnet do
@@ -105,13 +105,8 @@ class AOSW < Oxidized::Model
     pre_logout 'exit'
   end
 
-  def rstrip_cfg(cfg)
-    out = []
-    cfg.each_line do |line|
-      out << line.rstrip
-    end
-    out = out.join "\n"
-    out << "\n"
+  def clean_comment(lines)
+    comment(lines).rstrip_lines
   end
 
   def clean(cfg)

--- a/lib/oxidized/model/c4cmts.rb
+++ b/lib/oxidized/model/c4cmts.rb
@@ -7,7 +7,7 @@ class C4CMTS < Oxidized::Model
   comment  '! '
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+    cfg.delete("\r").cut_both.rstrip_lines
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/coriantgroove.rb
+++ b/lib/oxidized/model/coriantgroove.rb
@@ -6,7 +6,7 @@ class CoriantGroove < Oxidized::Model
   prompt /^(\w+@.*>\s*)$/
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-3].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+    cfg.delete("\r").cut_both(1, 2).rstrip_lines
   end
 
   cmd 'show inventory' do |cfg|

--- a/lib/oxidized/model/dlink.rb
+++ b/lib/oxidized/model/dlink.rb
@@ -13,7 +13,7 @@ class Dlink < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[2..-2].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+    cfg.delete("\r").cut_both(2, 1).rstrip_lines
   end
 
   cmd 'show switch' do |cfg|

--- a/lib/oxidized/model/dlinknextgen.rb
+++ b/lib/oxidized/model/dlinknextgen.rb
@@ -9,7 +9,7 @@ class DlinkNextGen < Oxidized::Model
 
   cmd :all do |cfg|
     cfg.gsub!("\0", "") # Remove NULL bytes that cause Git to detect the file as binary
-    cfg.each_line.to_a[2..-2].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+    cfg.delete("\r").cut_both(2, 1).rstrip_lines
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/enterasys.rb
+++ b/lib/oxidized/model/enterasys.rb
@@ -14,7 +14,7 @@ class Enterasys < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[2..-3].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+    cfg.delete("\r").cut_both(2, 2).rstrip_lines
   end
 
   cmd 'show system hardware' do |cfg|

--- a/lib/oxidized/model/hpebladesystem.rb
+++ b/lib/oxidized/model/hpebladesystem.rb
@@ -12,7 +12,7 @@ class HPEBladeSystem < Oxidized::Model
   # end
 
   cmd :all do |cfg|
-    cfg = cfg.delete("\r").each_line.to_a[0..-1].map { |line| line.rstrip }.join("\n") + "\n"
+    cfg = cfg.delete("\r").rstrip_lines
     cfg.cut_tail
   end
 

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -12,7 +12,7 @@ class JunOS < Oxidized::Model
     cfg = cfg.cut_both if screenscrape
     cfg.gsub!(/  scale-subscriber (\s+)(\d+)/, '  scale-subscriber                <count>')
     cfg.gsub!(/VMX-BANDWIDTH\s+(\d+) (.*)/, 'VMX-BANDWIDTH                  <count> \2')
-    cfg.lines.map { |line| line.rstrip }.join("\n") + "\n"
+    cfg.rstrip_lines
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/mtrlrfs.rb
+++ b/lib/oxidized/model/mtrlrfs.rb
@@ -9,7 +9,7 @@ class Mtrlrfs < Oxidized::Model
   cmd :all do |cfg|
     # xos inserts leading \r characters and other trailing white space.
     # this deletes extraneous \r and trailing white space.
-    cfg.each_line.to_a[1..-2].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+    cfg.delete("\r").cut_both.rstrip_lines
   end
 
   cmd 'show version' do |cfg|

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -1,25 +1,25 @@
 class Procurve < Oxidized::Model
   using Refinements
 
-  # previous command is repeated followed by "\eE", which sometimes ends up on last line
-  # ssh switches prompt may start with \r, followed by the prompt itself, regex ([\w\s.-]+[#>] ), which ends the line
-  # telnet switches may start with various vt100 control characters, regex (\e\[24;[0-9][hH]), followed by the prompt, followed
-  # by at least 3 other vt100 characters
-  prompt /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
+  # The prompt is the device name followed by '#' or '>' and a
+  # space, optionally preceded by a carriage return on ssh.
+  prompt /(^\r)?([\w\s.-]+[#>] )$/
 
   comment '! '
 
-  # replace next line control sequence with a new line
+  # These sequences are line breaks in the terminal stream: \e[1M...\e[1L is a
+  # delete-line/insert-line redraw and \eE is NEL (next line). They must be
+  # converted to newlines, not stripped, or the surrounding text concatenates.
+  # This has to run before clean :escape_codes, which would otherwise remove the
+  # \e[1M / \e[1L sequences (and does not match \eE at all).
   expect /(\e\[1M\e\[\??\d+(;\d+)*[A-Za-z]\e\[1L)|(\eE)/ do |data, re|
     data.gsub re, "\n"
   end
 
-  # replace all used vt100 control sequences
-  expect /\e\[\??\d+(;\d+)*[A-Za-z]/ do |data, re|
-    data.gsub re, ''
-  end
+  # remove all other vt100 control sequences
+  clean :escape_codes
 
-  expect /Press any key to continue(\e\[\??\d+(;\d+)*[A-Za-z])*$/ do
+  expect /Press any key to continue$/ do
     send "\n"
     ""
   end
@@ -32,8 +32,6 @@ class Procurve < Oxidized::Model
   cmd :all do |cfg|
     cfg = cfg.cut_both
     cfg = cfg.gsub /^\r/, ''
-    # Additional filtering for elder switches sending vt100 control chars via telnet
-    cfg.gsub! /\e\[\??\d+(;\d+)*[A-Za-z]/, ''
     # Additional filtering for power usage reporting which obviously changes over time
     cfg.gsub! /^(.*AC [0-9]{3}V\/?([0-9]{3}V)?) *([0-9]{1,3}) (.*)/, '\\1 <removed> \\4'
     # Remove failed commands that are not supported on all models
@@ -71,16 +69,13 @@ class Procurve < Oxidized::Model
 
   # not supported on all models
   cmd 'show system-information' do |cfg|
-    cfg = cfg.split("\n")[0..-8].join("\n")
+    cfg = cfg.cut_tail(7)
     clean_comment cfg
   end
 
   # not supported on all models
   cmd 'show system information' do |cfg|
-    cfg = cfg.each_line.reject do |line|
-      line.match /(.*CPU.*)|(.*Up Time.*)|(.*Total.*)|(.*Free.*)|(.*Lowest.*)|(.*Missed.*)/
-    end
-    cfg = cfg.join
+    cfg = cfg.reject_lines ['CPU', 'Up Time', 'Total', 'Free', 'Lowest', 'Missed']
     clean_comment cfg
   end
 

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -54,25 +54,25 @@ class Procurve < Oxidized::Model
   end
 
   cmd 'show version' do |cfg|
-    comment cfg
+    clean_comment cfg
   end
 
   cmd 'show modules' do |cfg|
-    comment cfg
+    clean_comment cfg
   end
 
   cmd 'show interfaces transceiver' do |cfg|
-    comment cfg
+    clean_comment cfg
   end
 
   cmd 'show flash' do |cfg|
-    comment cfg
+    clean_comment cfg
   end
 
   # not supported on all models
   cmd 'show system-information' do |cfg|
     cfg = cfg.split("\n")[0..-8].join("\n")
-    comment cfg
+    clean_comment cfg
   end
 
   # not supported on all models
@@ -81,7 +81,7 @@ class Procurve < Oxidized::Model
       line.match /(.*CPU.*)|(.*Up Time.*)|(.*Total.*)|(.*Free.*)|(.*Lowest.*)|(.*Missed.*)/
     end
     cfg = cfg.join
-    comment cfg
+    clean_comment cfg
   end
 
   cmd 'show running-config'
@@ -107,5 +107,9 @@ class Procurve < Oxidized::Model
 
   cfg :ssh do
     pty_options(chars_wide: 1000)
+  end
+
+  def clean_comment(lines)
+    comment(lines).rstrip_lines
   end
 end

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -20,7 +20,7 @@ class Procurve < Oxidized::Model
   end
 
   expect /Press any key to continue(\e\[\??\d+(;\d+)*[A-Za-z])*$/ do
-    send ' '
+    send "\n"
     ""
   end
 
@@ -98,7 +98,9 @@ class Procurve < Oxidized::Model
       end
     end
     post_login 'no page'
-    pre_logout "logout\ny\nn"
+    pre_logout 'logout'
+    pre_logout 'y'
+    pre_logout 'n'
   end
 
   cfg :ssh do

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -43,7 +43,9 @@ class Procurve < Oxidized::Model
 
   cmd :secret do |cfg|
     cfg.gsub! /^(snmp-server community) \S+(.*)/, '\\1 <secret hidden> \\2'
-    cfg.gsub! /^(snmp-server host \S+) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(snmp-server host \S+)( community)? \S+(.*)/, '\\1\\2 <secret hidden>\\3'
+    # local user password hashes; the quoted hash may wrap onto the next line
+    cfg.gsub! /(sha1\s+)"\S+"/, '\\1"<secret hidden>"'
     cfg.gsub! /^(radius-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^(radius-server key).*/, '\\1 <configuration removed>'
     cfg.gsub! /^(tacacs-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'

--- a/lib/oxidized/model/procurve.rb
+++ b/lib/oxidized/model/procurve.rb
@@ -39,15 +39,44 @@ class Procurve < Oxidized::Model
     cfg
   end
 
+  # Most of these credentials only appear in the running-config when
+  # include-credentials (and/or encrypt-credentials) is enabled; see the
+  # ArubaOS-Switch Access Security Guide. encrypt-credentials renames the
+  # plaintext keyword to an encrypted- variant (key -> encrypted-key, etc.) and
+  # stores an AES blob in place of the cleartext/hashed value.
   cmd :secret do |cfg|
+    # SNMPv1 community names
     cfg.gsub! /^(snmp-server community) \S+(.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^(snmp-server host \S+)( community)? \S+(.*)/, '\\1\\2 <secret hidden>\\3'
-    # local user password hashes; the quoted hash may wrap onto the next line
-    cfg.gsub! /(sha1\s+)"\S+"/, '\\1"<secret hidden>"'
-    cfg.gsub! /^(radius-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
-    cfg.gsub! /^(radius-server key).*/, '\\1 <configuration removed>'
-    cfg.gsub! /^(tacacs-server host \S+ key) \S+(.*)/, '\\1 <secret hidden> \\2'
-    cfg.gsub! /^(tacacs-server key).*/, '\\1 <secret hidden>'
+    # SNMPv3 user authentication and privacy passwords
+    cfg.gsub! /( auth (?:md5|sha)) "[^"]*"/, '\\1 "<secret hidden>"'
+    cfg.gsub! /( priv (?:des|aes)) "[^"]*"/, '\\1 "<secret hidden>"'
+
+    # encrypt-credentials master pre-shared-key. Must run before the local
+    # password rule below, whose plaintext "..." pattern would also match it.
+    cfg.gsub! /^(encrypt-credentials pre-shared-key (?:plaintext|hex)) \S+(.*)/, '\\1 <secret hidden>\\2'
+    # local manager/operator/port-access and aaa local-user password values;
+    # the quoted value may wrap onto the next line. hash-type: plaintext|sha1|sha256
+    cfg.gsub! /((?:plaintext|sha1|sha256)\s+)"[^"]*"/, '\\1"<secret hidden>"'
+    # encrypt-credentials form: encrypted-password <role> [user-name "x"] <blob>
+    cfg.gsub! /^(encrypted-password \S+(?: user-name "[^"]*")?) \S+(.*)/, '\\1 <secret hidden>\\2'
+
+    # RADIUS/TACACS shared secrets (key or encrypt-credentials encrypted-key)
+    cfg.gsub! /^(radius-server host \S+ (?:encrypted-)?key) \S+(.*)/, '\\1 <secret hidden>\\2'
+    cfg.gsub! /^(radius-server (?:encrypted-)?key).*/, '\\1 <configuration removed>'
+    cfg.gsub! /^(tacacs-server host \S+ (?:encrypted-)?key) \S+(.*)/, '\\1 <secret hidden>\\2'
+    cfg.gsub! /^(tacacs-server (?:encrypted-)?key).*/, '\\1 <secret hidden>'
+
+    # key-chain (routing protocol authentication) key material; rendered as a
+    # nested block, so key-string / encrypted-key sit on their own indented line
+    cfg.gsub! /^(\s*key-string) .*/, '\\1 <secret hidden>'
+    cfg.gsub! /^(\s*encrypted-key) \S+(.*)/, '\\1 <secret hidden>\\2'
+    # 802.1X supplicant shared secret
+    cfg.gsub! /^(aaa port-access .* (?:secret|encrypted-secret)) \S+(.*)/, '\\1 <secret hidden>\\2'
+    # SNTP authentication key
+    cfg.gsub! /^(sntp authentication .* (?:key-value|encrypted-key)) \S+(.*)/, '\\1 <secret hidden>\\2'
+    # MACsec pre-shared CAK (ckn is the key name, cak/encrypted-cak the secret)
+    cfg.gsub! /^(\s*mode pre-shared-key ckn \S+ (?:encrypted-)?cak) \S+(.*)/, '\\1 <secret hidden>\\2'
     cfg
   end
 

--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -11,7 +11,7 @@ class RouterOS < Oxidized::Model
       cfg.gsub! /^\r+(.+)/, '\1'
       cfg.gsub! /([^\r]*)\r+$/, '\1'
     end
-    cfg.lines.map { |line| line.rstrip }.join("\n") + "\n" # strip trailing whitespace
+    cfg.rstrip_lines # strip trailing whitespace
   end
 
   cmd '/system resource print' do |cfg|

--- a/lib/oxidized/model/xos.rb
+++ b/lib/oxidized/model/xos.rb
@@ -9,7 +9,7 @@ class XOS < Oxidized::Model
   cmd :all do |cfg|
     # xos inserts leading \r characters and other trailing white space.
     # this deletes extraneous \r and trailing white space.
-    cfg.each_line.to_a[1..-2].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+    cfg.delete("\r").cut_both.rstrip_lines
   end
 
   cmd :secret do |cfg|

--- a/lib/oxidized/model/zhoneolt.rb
+++ b/lib/oxidized/model/zhoneolt.rb
@@ -20,7 +20,7 @@ class ZhoneOLT < Oxidized::Model
   end
 
   cmd :all do |cfg|
-    cfg.each_line.to_a[1..-2].map { |line| line.delete("\r").rstrip }.join("\n") + "\n"
+    cfg.delete("\r").cut_both.rstrip_lines
   end
 
   cmd 'swversion' do |cfg|

--- a/lib/refinements.rb
+++ b/lib/refinements.rb
@@ -41,6 +41,11 @@ module Refinements
       end.join
     end
 
+    # right strip whitespaces from each line
+    def rstrip_lines
+      each_line.map(&:rstrip).join("\n") + "\n"
+    end
+
     # remove lines matching any pattern (String or Regexp)
     def reject_lines(patterns)
       each_line.reject do |line|

--- a/spec/model/data/procurve#2930M-48G-PoE+_JL322A_WC.16.11.0028#output.txt
+++ b/spec/model/data/procurve#2930M-48G-PoE+_JL322A_WC.16.11.0028#output.txt
@@ -1,0 +1,124 @@
+! 
+! Image stamp:   
+!  /ws/swbuildm/rel_beluru_qaoff/code/build/lvm(swbuildm_rel_beluru_qaoff_rel_belu
+! ru)
+!                 Nov 10 2025 02:09:28
+!                 WC.16.11.0028
+!                 530
+! Boot Image:     Secondary
+! 
+! Boot ROM Version:    WC.17.02.0007
+! Active Boot ROM:     Primary
+! 
+! 
+!  Status and Counters - Module Information
+! 
+!   Chassis: 2930M-48G-PoE+  JL322A         Serial Number:   XXXXXXXXXX
+! 
+! 
+!   Slot  Module Description                         Serial Number    Status    
+!   ----- ------------------------------------------ ---------------- ----------
+!   A     Aruba JL083A 4p 10GbE SFP+ Module          XXXXXXXXXX       Up        
+! 
+! 
+! 
+! Transceiver Technical Information:
+! 
+!                      Product      Serial             Part
+!  Port    Type        Number       Number             Number
+!  ------- ----------- ------------ ------------------ ----------
+!  A1      SFP+SR      J9150A       XXXXXXXXXXX        1990-4065 
+! 
+! * third-party transceiver
+! Image             Size (bytes) Date     Version 
+! ----------------- ------------ -------- --------------
+! Primary Image    :    30266808 04/15/25 WC.16.11.0025        
+! Secondary Image  :    30279595 11/10/25 WC.16.11.0028       
+! 
+! Boot ROM Version 
+! ----------------
+! Primary Boot ROM Version   : WC.17.02.0007
+! Secondary Boot ROM Version : WC.17.02.0007
+! 
+! Default Boot Image   : Secondary
+! Default Boot ROM     : Primary
+! 
+! 
+!  Status and Counters - General System Information
+! 
+!   System Name        : XXXXXXXXX                                       
+!   System Contact     : xxxxxxxx@xxxxxxxx.xxx
+!   System Location    : XXXXXXXXX
+! 
+!   MAC Age Time (sec) : 300    
+! 
+!   Time Zone          : -480 
+!   Daylight Time Rule : Continental-US-and-Canada 
+! 
+!   Software revision  : WC.16.11.0028        Base MAC Addr      : aaaaaa-aaaaaa 
+!    
+!   ROM Version        : WC.17.02.0007        Serial Number      : XXXXXXXXXX  
+! 
+! 
+! 
+
+Running configuration:
+
+; JL322A Configuration Editor; Created on release #WC.16.11.0028
+; Ver #14:67.6f.f8.1d.9b.3f.bf.bb.ef.7c.59.fc.6b.fb.9f.fc.ff.ff.37.ef:44
+
+hostname "XXXXXXXXX"
+module 1 type jl322a
+flexible-module A type JL083A
+console baud-rate 9600
+console idle-timeout 3600
+console idle-timeout serial-usb 3600
+no cdp run
+fault-finder duplex-mismatch-fdx sensitivity high
+logging command
+include-credentials
+password operator user-name "operator" sha1
+ "1111111111111111111111111111111111111111"
+password manager user-name "manager" sha1
+ "1111111111111111111111111111111111111111"
+time daylight-time-rule continental-us-and-canada
+time timezone -480
+ip default-gateway 10.12.123.1
+ip dns domain-name "example.org"
+ip ssh filetransfer
+interface A1
+   name "CORE-1/11"
+   exit
+snmp-server community "public" operator
+snmp-server host 10.12.123.83 community "public" trap-level critical
+snmpv3 engineid "00:00:00:0b:00:00:aa:aa:aa:aa:aa:aa"
+aaa authorization commands local
+aaa authentication ssh enable public-key
+aaa authentication local-user "oxidized-backup" group "backup" password sha1
+ "2222222222222222222222222222222222222222"
+oobm
+   interface disable
+   no ip address
+   exit
+lldp top-change-notify 1-48,A1-A4
+lldp enable-notification 1-48,A1-A4
+vlan 1
+   name "DEFAULT_VLAN"
+   no untagged A1
+   untagged 1-48,A2-A4
+   no ip address
+   exit
+vlan 254
+   untagged A1
+   ip address 10.12.123.122 255.255.255.0
+   exit
+allow-unsupported-transceiver
+no tftp client
+no tftp server
+no autorun
+no dhcp config-file-update
+no dhcp image-file-update
+no dhcp tr69-acs-url
+activate software-update disable
+activate provision disable
+

--- a/spec/model/data/procurve#2930M-48G-PoE+_JL322A_WC.16.11.0028#output.txt
+++ b/spec/model/data/procurve#2930M-48G-PoE+_JL322A_WC.16.11.0028#output.txt
@@ -1,66 +1,67 @@
-! 
-! Image stamp:   
+!
+! Image stamp:
 !  /ws/swbuildm/rel_beluru_qaoff/code/build/lvm(swbuildm_rel_beluru_qaoff_rel_belu
 ! ru)
 !                 Nov 10 2025 02:09:28
 !                 WC.16.11.0028
 !                 530
 ! Boot Image:     Secondary
-! 
+!
 ! Boot ROM Version:    WC.17.02.0007
 ! Active Boot ROM:     Primary
-! 
-! 
+!
+!
 !  Status and Counters - Module Information
-! 
+!
 !   Chassis: 2930M-48G-PoE+  JL322A         Serial Number:   XXXXXXXXXX
-! 
-! 
-!   Slot  Module Description                         Serial Number    Status    
+!
+!
+!   Slot  Module Description                         Serial Number    Status
 !   ----- ------------------------------------------ ---------------- ----------
-!   A     Aruba JL083A 4p 10GbE SFP+ Module          XXXXXXXXXX       Up        
-! 
-! 
-! 
+!   A     Aruba JL083A 4p 10GbE SFP+ Module          XXXXXXXXXX       Up
+!
+!
+!
 ! Transceiver Technical Information:
-! 
+!
 !                      Product      Serial             Part
 !  Port    Type        Number       Number             Number
 !  ------- ----------- ------------ ------------------ ----------
-!  A1      SFP+SR      J9150A       XXXXXXXXXXX        1990-4065 
-! 
+!  A1      SFP+SR      J9150A       XXXXXXXXXXX        1990-4065
+!
 ! * third-party transceiver
-! Image             Size (bytes) Date     Version 
+! Image             Size (bytes) Date     Version
 ! ----------------- ------------ -------- --------------
-! Primary Image    :    30266808 04/15/25 WC.16.11.0025        
-! Secondary Image  :    30279595 11/10/25 WC.16.11.0028       
-! 
-! Boot ROM Version 
+! Primary Image    :    30266808 04/15/25 WC.16.11.0025
+! Secondary Image  :    30279595 11/10/25 WC.16.11.0028
+!
+! Boot ROM Version
 ! ----------------
 ! Primary Boot ROM Version   : WC.17.02.0007
 ! Secondary Boot ROM Version : WC.17.02.0007
-! 
+!
 ! Default Boot Image   : Secondary
 ! Default Boot ROM     : Primary
-! 
-! 
+!
+
+!
 !  Status and Counters - General System Information
-! 
-!   System Name        : XXXXXXXXX                                       
+!
+!   System Name        : XXXXXXXXX
 !   System Contact     : xxxxxxxx@xxxxxxxx.xxx
 !   System Location    : XXXXXXXXX
-! 
-!   MAC Age Time (sec) : 300    
-! 
-!   Time Zone          : -480 
-!   Daylight Time Rule : Continental-US-and-Canada 
-! 
-!   Software revision  : WC.16.11.0028        Base MAC Addr      : aaaaaa-aaaaaa 
-!    
-!   ROM Version        : WC.17.02.0007        Serial Number      : XXXXXXXXXX  
-! 
-! 
-! 
+!
+!   MAC Age Time (sec) : 300
+!
+!   Time Zone          : -480
+!   Daylight Time Rule : Continental-US-and-Canada
+!
+!   Software revision  : WC.16.11.0028        Base MAC Addr      : aaaaaa-aaaaaa
+!
+!   ROM Version        : WC.17.02.0007        Serial Number      : XXXXXXXXXX
+!
+!
+!
 
 Running configuration:
 

--- a/spec/model/data/procurve#2930M-48G-PoE+_JL322A_WC.16.11.0028#secret.yaml
+++ b/spec/model/data/procurve#2930M-48G-PoE+_JL322A_WC.16.11.0028#secret.yaml
@@ -1,0 +1,12 @@
+# Secret-redaction tests for the Procurve model.
+# Run with remove_secret; the strings are matched as regexps against the output.
+fail:
+  # SNMP community must be hidden on both the community and host lines
+  - 'community "public"'
+  # local user password hashes must not leak
+  - '1111111111111111111111111111111111111111'
+  - '2222222222222222222222222222222222222222'
+pass:
+  - 'snmp-server community <secret hidden>'
+  - 'snmp-server host \S+ community <secret hidden>'
+  - 'sha1\s+"<secret hidden>"'

--- a/spec/model/data/procurve#2930M-48G-PoE+_JL322A_WC.16.11.0028#simulation.yaml
+++ b/spec/model/data/procurve#2930M-48G-PoE+_JL322A_WC.16.11.0028#simulation.yaml
@@ -1,0 +1,174 @@
+---
+init_prompt: |-
+    Aruba JL322A 2930M-48G-PoE+ Switch\r\r
+    Software revision WC.16.11.0028\r\r
+    \r\r
+     (C) Copyright 2025 Hewlett Packard Enterprise Development LP\r
+    \r
+                          RESTRICTED RIGHTS LEGEND\r
+     Confidential computer software. Valid license from Hewlett Packard Enterprise\r
+     Development LP required for possession, use or copying. Consistent with FAR\r
+     12.211 and 12.212, Commercial Computer Software, Computer Software\r
+     Documentation, and Technical Data for Commercial Items are licensed to the\r
+     U.S. Government under vendor's standard commercial license.\r
+    \r
+    \e[1;13r\e[1;1H\e[24;1HPress any key to continue\e[13;1H\e[?25h\e[24;27H
+commands:
+  - "\n": |-
+      \e[?6l\e[1;24r\e[?7h\e[2J\e[1;1H\e[1920;1920H\e[6n\e[1;1HYour previous successful login (as manager) was on 2026-06-09 12:53:55     \r
+       from 10.12.123.2\r
+      \e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HXXXXXXXXX# \e[24;1H\e[24;12H\e[24;1H\e[?25h\e[24;12H
+  - "no page\n": |-
+      \e[24;12Hno page\e[24;12H\e[?25h\e[24;19H\e[1;0H\e[1M\e[24;1H\e[1L\e[24;19H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[1;24r\e[24;1H\e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HXXXXXXXXX# \e[24;1H\e[24;12H\e[24;1H\e[?25h\e[24;12H
+  - "show version\n": |-
+      \e[24;12Hshow versi\e[24;12H\e[?25h\e[24;22H\e[24;22Hon\e[24;22H\e[?25h\e[24;24H\e[1;0H\e[1M\e[24;1H\e[1L\e[24;24H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[1;24r\e[24;1H\r
+      Image stamp:   \r
+       /ws/swbuildm/rel_beluru_qaoff/code/build/lvm(swbuildm_rel_beluru_qaoff_rel_belu\r
+      ru)\r
+                      Nov 10 2025 02:09:28\r
+                      WC.16.11.0028\r
+                      530\r
+      Boot Image:     Secondary\r
+      \r
+      Boot ROM Version:    WC.17.02.0007\r
+      Active Boot ROM:     Primary\r
+      \r
+      \e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HXXXXXXXXX# \e[24;1H\e[24;12H\e[24;1H\e[?25h\e[24;12H
+  - "show modules\n": |-
+      \e[24;12Hshow modul\e[24;12H\e[?25h\e[24;22H\e[24;22Hes\e[24;22H\e[?25h\e[24;24H\e[1;0H\e[1M\e[24;1H\e[1L\e[24;24H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[1;24r\e[24;1H\r
+       Status and Counters - Module Information\r
+      \r
+        Chassis: 2930M-48G-PoE+  JL322A         Serial Number:   XXXXXXXXXX\r
+      \r
+      \r
+        Slot  Module Description                         Serial Number    Status    \r
+        ----- ------------------------------------------ ---------------- ----------\r
+        A     Aruba JL083A 4p 10GbE SFP+ Module          XXXXXXXXXX       Up        \r
+      \r
+      \r
+      \e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HXXXXXXXXX# \e[24;1H\e[24;12H\e[24;1H\e[?25h\e[24;12H
+  - "show interfaces transceiver\n": |-
+      \e[24;12Hshow inter\e[24;12H\e[?25h\e[24;22H\e[24;22Hfaces tran\e[24;22H\e[?25h\e[24;32H\e[24;32Hsceiver\e[24;32H\e[?25h\e[24;39H\e[1;0H\e[1M\e[24;1H\e[1L\e[24;39H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[1;24r\e[24;1H\r
+      Transceiver Technical Information:\r
+      \r
+                           Product      Serial             Part\r
+       Port    Type        Number       Number             Number\r
+       ------- ----------- ------------ ------------------ ----------\r
+       A1      SFP+SR      J9150A       XXXXXXXXXXX        1990-4065 \r
+      \r
+      * third-party transceiver\r
+      \e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HXXXXXXXXX# \e[24;1H\e[24;12H\e[24;1H\e[?25h\e[24;12H
+  - "show flash\n": |-
+      \e[24;12Hshow flash\e[24;12H\e[?25h\e[24;22H\e[1;0H\e[1M\e[24;1H\e[1L\e[24;22H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[1;24r\e[24;1HImage             Size (bytes) Date     Version \r
+      ----------------- ------------ -------- --------------\r
+      Primary Image    :    30266808 04/15/25 WC.16.11.0025        \r
+      Secondary Image  :    30279595 11/10/25 WC.16.11.0028       \r
+      \r
+      Boot ROM Version \r
+      ----------------\r
+      Primary Boot ROM Version   : WC.17.02.0007\r
+      Secondary Boot ROM Version : WC.17.02.0007\r
+      \r
+      Default Boot Image   : Secondary\r
+      Default Boot ROM     : Primary\r
+      \r
+      \e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HXXXXXXXXX# \e[24;1H\e[24;12H\e[24;1H\e[?25h\e[24;12H
+  - "show system-information\n": |-
+      \e[24;12Hshow syste\e[24;12H\e[?25h\e[24;22H\e[24;22Hm-informat\e[24;22H\e[?25h\e[24;32H\e[24;32Hion\e[24;32H\e[?25h\e[24;35H\e[1;0H\e[1M\e[24;1H\e[1L\e[24;35H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[1;24r\e[24;1HInvalid input: system-information\r
+      \e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HXXXXXXXXX# \e[24;1H\e[24;12H\e[24;1H\e[?25h\e[24;12H
+  - "show system information\n": |-
+      \e[24;12Hshow syste\e[24;12H\e[?25h\e[24;22H\e[24;22Hm informat\e[24;22H\e[?25h\e[24;32H\e[24;32Hion\e[24;32H\e[?25h\e[24;35H\e[1;0H\e[1M\e[24;1H\e[1L\e[24;35H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[1;24r\e[24;1H\r
+       Status and Counters - General System Information\r
+      \r
+        System Name        : XXXXXXXXX                                       \r
+        System Contact     : xxxxxxxx@xxxxxxxx.xxx\r
+        System Location    : XXXXXXXXX\r
+      \r
+        MAC Age Time (sec) : 300    \r
+      \r
+        Time Zone          : -480 \r
+        Daylight Time Rule : Continental-US-and-Canada \r
+      \r
+        Software revision  : WC.16.11.0028        Base MAC Addr      : aaaaaa-aaaaaa \r
+         \r
+        ROM Version        : WC.17.02.0007        Serial Number      : XXXXXXXXXX  \r
+      \r
+        Up Time            : 89 days              Memory   - Total   : 333,443,584 \r
+        CPU Util (%)       : 0                               Free    : 170,530,252 \r
+      \r
+        IP Mgmt  - Pkts Rx : 28,098,956           Packet   - Total   : 6600        \r
+                   Pkts Tx : 26,876,607           Buffers    Free    : 4320        \r
+                                                             Lowest  : 4275        \r
+                                                             Missed  : 0           \r
+      \e[24;1H\e[2K\e[24;1H\e[1;24r\e[24;1H\r
+      \e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HXXXXXXXXX# \e[24;1H\e[24;12H\e[24;1H\e[?25h\e[24;12H
+  - "show running-config\n": |-
+      \e[24;12Hshow runni\e[24;12H\e[?25h\e[24;22H\e[24;22Hng-config\e[24;22H\e[?25h\e[24;31H\e[1;0H\e[1M\e[24;1H\e[1L\e[24;31H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[1;24r\e[24;1H\r
+      Running configuration:\r
+      \r
+      ; JL322A Configuration Editor; Created on release #WC.16.11.0028\r
+      ; Ver #14:67.6f.f8.1d.9b.3f.bf.bb.ef.7c.59.fc.6b.fb.9f.fc.ff.ff.37.ef:44\r
+      \r
+      hostname \"XXXXXXXXX\"\r
+      module 1 type jl322a\r
+      flexible-module A type JL083A\r
+      console baud-rate 9600\r
+      console idle-timeout 3600\r
+      console idle-timeout serial-usb 3600\r
+      no cdp run\r
+      \e[24;1H\e[2K\e[24;1H\e[1;24r\e[24;1Hfault-finder duplex-mismatch-fdx sensitivity high\r
+      logging command\r
+      include-credentials\r
+      password operator user-name \"operator\" sha1\r
+       \"1111111111111111111111111111111111111111\"\r
+      password manager user-name \"manager\" sha1\r
+      \e[24;1H\e[2K\e[24;1H\e[1;24r\e[24;1H \"1111111111111111111111111111111111111111\"\r
+      time daylight-time-rule continental-us-and-canada\r
+      time timezone -480\r
+      ip default-gateway 10.12.123.1\r
+      ip dns domain-name \"example.org\"\r
+      ip ssh filetransfer\r
+      interface A1\r
+         name \"CORE-1/11\"\r
+      \e[24;1H\e[2K\e[24;1H\e[1;24r\e[24;1H   exit\r
+      snmp-server community \"public\" operator\r
+      snmp-server host 10.12.123.83 community \"public\" trap-level critical\r
+      snmpv3 engineid \"00:00:00:0b:00:00:aa:aa:aa:aa:aa:aa\"\r
+      aaa authorization commands local\r
+      aaa authentication ssh enable public-key\r
+      aaa authentication local-user \"oxidized-backup\" group \"backup\" password sha1\r
+       \"2222222222222222222222222222222222222222\"\r
+      oobm\r
+         interface disable\r
+         no ip address\r
+         exit\r
+      \e[24;1H\e[2K\e[24;1H\e[1;24r\e[24;1Hlldp top-change-notify 1-48,A1-A4\r
+      lldp enable-notification 1-48,A1-A4\r
+      vlan 1\r
+         name \"DEFAULT_VLAN\"\r
+         no untagged A1\r
+         untagged 1-48,A2-A4\r
+         no ip address\r
+         exit\r
+      vlan 254\r
+         untagged A1\r
+         ip address 10.12.123.122 255.255.255.0\r
+         exit\r
+      allow-unsupported-transceiver\r
+      no tftp client\r
+      no tftp server\r
+      no autorun\r
+      no dhcp config-file-update\r
+      no dhcp image-file-update\r
+      no dhcp tr69-acs-url\r
+      \e[24;1H\e[2K\e[24;1H\e[1;24r\e[24;1Hactivate software-update disable\r
+      activate provision disable\r
+      \r
+      \e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HXXXXXXXXX# \e[24;1H\e[24;12H\e[24;1H\e[?25h\e[24;12H
+  - "logout\n": |-
+      \e[24;12Hlogout\e[24;12H\e[?25h\e[24;18H\e[1;0H\e[1M\e[24;1H\e[1L\e[24;18H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[1;24r\e[24;1H\e[1;24r\e[24;1H\e[24;1H\e[2K\e[24;1H\e[?25h\e[24;1H\e[24;1HDo you want to log out (y/n)? \e[24;1H\e[24;31H\e[24;1H\e[?25h\e[24;31H
+  - "y\n": |-
+  # The switch closes the session right after 'y' (logout confirmed, nothing to
+  # save), so device2yaml captured no response for the model's final pre_logout
+  # 'n'. This entry exists only to match the "n\n" the model still transmits.
+  - "n\n": |-

--- a/spec/model/data/procurve#encrypt-credentials#output.txt
+++ b/spec/model/data/procurve#encrypt-credentials#output.txt
@@ -1,0 +1,37 @@
+! Image stamp: SYNTHETIC
+! Slot A: synthetic module
+! No transceivers present
+! Primary Image : synthetic
+! Status and Counters - General System Information
+! System Name : secrets-sw
+! System Contact :
+! Status and Counters - General System Information
+! System Name : secrets-sw
+Running configuration:
+
+; JL322A Configuration Editor; Created on release #WC.16.11.0028
+
+hostname "secrets-sw"
+include-credentials
+encrypt-credentials
+encrypt-credentials pre-shared-key plaintext "masterpskvalue01"
+encrypted-password manager user-name "manager" U2FsdGVkX1MGRpwManager00000=
+encrypted-password operator user-name "operator" U2FsdGVkX1MGRpwOperator0000=
+snmp-server community "public" operator
+snmpv3 user "snmpadmin" auth sha "authpasshash0001" priv aes "privpasshash0001"
+radius-server host 10.0.0.20 encrypted-key "U2FsdGVkX1RADhostkey000000="
+radius-server encrypted-key "U2FsdGVkX1RADglobalkey0000="
+tacacs-server host 10.0.0.21 encrypted-key "U2FsdGVkX1TAChostkey000000="
+tacacs-server encrypted-key "U2FsdGVkX1TACglobalkey0000="
+sntp authentication key-id 1 authentication-mode md5 encrypted-key "U2FsdGVkX1SNTPkeyvalue0000="
+aaa port-access supplicant 1 identity "supp-user" encrypted-secret "U2FsdGVkX1SUPPsecret000000="
+key-chain "ospf-auth"
+   key 1
+      encrypted-key "U2FsdGVkX1KEYchain0000000="
+      exit
+   exit
+interface A2
+   macsec
+      mode pre-shared-key ckn 37c9c2c45ddd encrypted-cak "U2FsdGVkX1MACseccak000000="
+      exit
+   exit

--- a/spec/model/data/procurve#encrypt-credentials#secret.yaml
+++ b/spec/model/data/procurve#encrypt-credentials#secret.yaml
@@ -1,0 +1,32 @@
+# Secret-redaction tests for the Procurve model, encrypt-credentials scenario.
+# Run with remove_secret; strings are matched as regexps against the output.
+# pass: must remain (the redaction marker / preserved key name)
+# fail: must be gone (the dummy secret value)
+fail:
+  - 'masterpskvalue01'        # encrypt-credentials master pre-shared-key
+  - 'MGRpwManager'            # encrypted manager password blob
+  - 'MGRpwOperator'           # encrypted operator password blob
+  - '"public"'               # snmp community
+  - 'authpasshash0001'        # snmpv3 auth password
+  - 'privpasshash0001'        # snmpv3 priv password
+  - 'RADhostkey'              # radius per-host encrypted-key blob
+  - 'RADglobalkey'            # radius global encrypted-key blob
+  - 'TAChostkey'              # tacacs per-host encrypted-key blob
+  - 'TACglobalkey'            # tacacs global encrypted-key blob
+  - 'SNTPkeyvalue'            # sntp encrypted-key blob
+  - 'SUPPsecret'              # 802.1X supplicant encrypted-secret blob
+  - 'KEYchain'                # key-chain encrypted-key blob
+  - 'MACseccak'              # macsec encrypted-cak blob
+pass:
+  - 'encrypt-credentials pre-shared-key plaintext <secret hidden>'
+  - 'encrypted-password manager user-name "manager" <secret hidden>'
+  - 'encrypted-password operator user-name "operator" <secret hidden>'
+  - 'snmp-server community <secret hidden>'
+  - 'auth sha "<secret hidden>" priv aes "<secret hidden>"'
+  - 'radius-server host \S+ encrypted-key <secret hidden>'
+  - 'radius-server encrypted-key <configuration removed>'
+  - 'tacacs-server host \S+ encrypted-key <secret hidden>'
+  - 'tacacs-server encrypted-key <secret hidden>'
+  - 'encrypted-secret <secret hidden>'
+  # macsec: the ckn (key name) is preserved, only the cak (secret) is hidden
+  - 'ckn 37c9c2c45ddd encrypted-cak <secret hidden>'

--- a/spec/model/data/procurve#encrypt-credentials#simulation.yaml
+++ b/spec/model/data/procurve#encrypt-credentials#simulation.yaml
@@ -1,0 +1,86 @@
+---
+# Synthetic simulation (not a real device capture). It exercises the Procurve
+# :secret redaction rules for the credentials as they appear in a running-config
+# when `encrypt-credentials` is enabled: the cleartext keyword gains an
+# encrypted- prefix (key -> encrypted-key, secret -> encrypted-secret,
+# cak -> encrypted-cak, password -> encrypted-password) and the value becomes an
+# AES blob. The companion fixture procurve#include-credentials covers the
+# cleartext/hashed forms. All secret values are obvious dummies; see
+# procurve#encrypt-credentials#secret.yaml.
+init_prompt: |-
+    Aruba synthetic switch (encrypt-credentials)\r
+    secrets-sw# \e[K
+commands:
+  - "no page\n": |-
+      no page\r
+      secrets-sw# \e[K
+  - "show version\n": |-
+      show version\r
+      Image stamp: SYNTHETIC\r
+      secrets-sw# \e[K
+  - "show modules\n": |-
+      show modules\r
+      Slot A: synthetic module\r
+      secrets-sw# \e[K
+  - "show interfaces transceiver\n": |-
+      show interfaces transceiver\r
+      No transceivers present\r
+      secrets-sw# \e[K
+  - "show flash\n": |-
+      show flash\r
+      Primary Image : synthetic\r
+      secrets-sw# \e[K
+  - "show system-information\n": |-
+      show system-information\r
+      Status and Counters - General System Information\r
+      System Name : secrets-sw\r
+      System Contact :\r
+      System Location :\r
+      MAC Age Time (sec) : 300\r
+      Time Zone : 0\r
+      Daylight Time Rule : None\r
+      Software revision : SYNTHETIC\r
+      Base MAC Addr : aaaaaa-aaaaaa\r
+      Serial Number : XXXXXXXXXX\r
+      secrets-sw# \e[K
+  - "show system information\n": |-
+      show system information\r
+      Status and Counters - General System Information\r
+      System Name : secrets-sw\r
+      secrets-sw# \e[K
+  - "show running-config\n": |-
+      show running-config\r
+      Running configuration:\r
+      \r
+      ; JL322A Configuration Editor; Created on release #WC.16.11.0028\r
+      \r
+      hostname \"secrets-sw\"\r
+      include-credentials\r
+      encrypt-credentials\r
+      encrypt-credentials pre-shared-key plaintext \"masterpskvalue01\"\r
+      encrypted-password manager user-name \"manager\" U2FsdGVkX1MGRpwManager00000=\r
+      encrypted-password operator user-name \"operator\" U2FsdGVkX1MGRpwOperator0000=\r
+      snmp-server community \"public\" operator\r
+      snmpv3 user \"snmpadmin\" auth sha \"authpasshash0001\" priv aes \"privpasshash0001\"\r
+      radius-server host 10.0.0.20 encrypted-key \"U2FsdGVkX1RADhostkey000000=\"\r
+      radius-server encrypted-key \"U2FsdGVkX1RADglobalkey0000=\"\r
+      tacacs-server host 10.0.0.21 encrypted-key \"U2FsdGVkX1TAChostkey000000=\"\r
+      tacacs-server encrypted-key \"U2FsdGVkX1TACglobalkey0000=\"\r
+      sntp authentication key-id 1 authentication-mode md5 encrypted-key \"U2FsdGVkX1SNTPkeyvalue0000=\"\r
+      aaa port-access supplicant 1 identity \"supp-user\" encrypted-secret \"U2FsdGVkX1SUPPsecret000000=\"\r
+      key-chain \"ospf-auth\"\r
+         key 1\r
+            encrypted-key \"U2FsdGVkX1KEYchain0000000=\"\r
+            exit\r
+         exit\r
+      interface A2\r
+         macsec\r
+            mode pre-shared-key ckn 37c9c2c45ddd encrypted-cak \"U2FsdGVkX1MACseccak000000=\"\r
+            exit\r
+         exit\r
+      secrets-sw# \e[K
+  - "logout\n": |-
+      logout\r
+      Do you want to log out (y/n)?
+  - "y\n": |-
+  - "n\n": |-

--- a/spec/model/data/procurve#generic#prompt.yaml
+++ b/spec/model/data/procurve#generic#prompt.yaml
@@ -1,0 +1,20 @@
+# Prompt tests for the Procurve model
+# Regex: /(^\r|\e\[24;[0-9][hH])?([\w\s.-]+[#>] )($|(\e\[24;[0-9][0-9]?[hH]){3})/
+pass:
+  # plain SSH manager and operator prompts
+  - 'ProCurve Switch 2530-24G# '
+  - 'HP-5406zl# '
+  - 'Aruba-2930F> '
+  # SSH prompt may be preceded by a carriage return
+  - "\rHP-2920-24G# "
+pass_with_expect:
+  # SSH prompt preceded by \r, repeated command terminated by \eE
+  - "\rProCurve-Switch# "
+  # telnet prompt: leading vt100, prompt, then at least 3 trailing vt100 codes
+  - "\e[24;0hProCurve-Switch# \e[24;12h\e[24;1H\e[24;42h"
+fail:
+  # no #/> terminator
+  - 'ProCurve Switch 2530-24G'
+  - 'just some output line'
+  # terminator without a name in front and no trailing space
+  - '#'

--- a/spec/model/data/procurve#include-credentials#output.txt
+++ b/spec/model/data/procurve#include-credentials#output.txt
@@ -1,0 +1,37 @@
+! Image stamp: SYNTHETIC
+! Slot A: synthetic module
+! No transceivers present
+! Primary Image : synthetic
+! Status and Counters - General System Information
+! System Name : secrets-sw
+! System Contact :
+! Status and Counters - General System Information
+! System Name : secrets-sw
+Running configuration:
+
+; JL322A Configuration Editor; Created on release #WC.16.11.0028
+
+hostname "secrets-sw"
+include-credentials
+password manager user-name "manager" sha256 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+password operator user-name "operator" plaintext "plainoperator001"
+password port-access user-name "dot1xlocal" plaintext "portaccesslocal1"
+snmp-server community "public" operator
+snmp-server host 10.0.0.10 community "public" trap-level critical
+snmpv3 user "snmpadmin" auth sha "authpasshash0001" priv aes "privpasshash0001"
+radius-server host 10.0.0.20 key "radiushostkey001"
+radius-server key "radiusglobalkey1"
+tacacs-server host 10.0.0.21 key "tacacshostkey001"
+tacacs-server key "tacacsglobalkey1"
+sntp authentication key-id 1 authentication-mode md5 key-value "sntpkeyvalue0001"
+aaa port-access supplicant 1 identity "supp-user" secret "supplicantsecret"
+key-chain "ospf-auth"
+   key 1
+      key-string "keychainstring01"
+      exit
+   exit
+interface A2
+   macsec
+      mode pre-shared-key ckn 37c9c2c45ddd cak "macseccak0000001"
+      exit
+   exit

--- a/spec/model/data/procurve#include-credentials#secret.yaml
+++ b/spec/model/data/procurve#include-credentials#secret.yaml
@@ -1,0 +1,35 @@
+# Secret-redaction tests for the Procurve model, include-credentials scenario.
+# Run with remove_secret; strings are matched as regexps against the output.
+# pass: must remain (the redaction marker / preserved key name)
+# fail: must be gone (the dummy secret value)
+fail:
+  - 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'  # manager sha256 hash
+  - 'plainoperator001'                  # operator plaintext password
+  - 'portaccesslocal1'                  # 802.1X local (port-access) password
+  - '"public"'                          # snmp community (community + host lines)
+  - 'authpasshash0001'                  # snmpv3 auth password
+  - 'privpasshash0001'                  # snmpv3 priv password
+  - 'radiushostkey001'                  # radius per-host key
+  - 'radiusglobalkey1'                  # radius global key
+  - 'tacacshostkey001'                  # tacacs per-host key
+  - 'tacacsglobalkey1'                  # tacacs global key
+  - 'sntpkeyvalue0001'                  # sntp authentication key
+  - 'supplicantsecret'                  # 802.1X supplicant secret
+  - 'keychainstring01'                  # key-chain key-string
+  - 'macseccak0000001'                  # macsec pre-shared CAK
+pass:
+  - 'sha256 "<secret hidden>"'
+  - 'operator" plaintext "<secret hidden>"'
+  - 'dot1xlocal" plaintext "<secret hidden>"'
+  - 'snmp-server community <secret hidden>'
+  - 'snmp-server host \S+ community <secret hidden>'
+  - 'auth sha "<secret hidden>" priv aes "<secret hidden>"'
+  - 'radius-server host \S+ key <secret hidden>'
+  - 'radius-server key <configuration removed>'
+  - 'tacacs-server host \S+ key <secret hidden>'
+  - 'tacacs-server key <secret hidden>'
+  - 'key-value <secret hidden>'
+  - 'secret <secret hidden>'
+  - 'key-string <secret hidden>'
+  # macsec: the ckn (key name) is preserved, only the cak (secret) is hidden
+  - 'ckn 37c9c2c45ddd cak <secret hidden>'

--- a/spec/model/data/procurve#include-credentials#simulation.yaml
+++ b/spec/model/data/procurve#include-credentials#simulation.yaml
@@ -1,0 +1,83 @@
+---
+# Synthetic simulation (not a real device capture). It exercises the Procurve
+# :secret redaction rules for the credentials that appear in a running-config
+# when `include-credentials` is enabled (cleartext/hashed forms). The companion
+# fixture procurve#encrypt-credentials covers the encrypt-credentials variants.
+# All secret values are obvious dummies; see procurve#include-credentials#secret.yaml.
+init_prompt: |-
+    Aruba synthetic switch (include-credentials)\r
+    secrets-sw# \e[K
+commands:
+  - "no page\n": |-
+      no page\r
+      secrets-sw# \e[K
+  - "show version\n": |-
+      show version\r
+      Image stamp: SYNTHETIC\r
+      secrets-sw# \e[K
+  - "show modules\n": |-
+      show modules\r
+      Slot A: synthetic module\r
+      secrets-sw# \e[K
+  - "show interfaces transceiver\n": |-
+      show interfaces transceiver\r
+      No transceivers present\r
+      secrets-sw# \e[K
+  - "show flash\n": |-
+      show flash\r
+      Primary Image : synthetic\r
+      secrets-sw# \e[K
+  - "show system-information\n": |-
+      show system-information\r
+      Status and Counters - General System Information\r
+      System Name : secrets-sw\r
+      System Contact :\r
+      System Location :\r
+      MAC Age Time (sec) : 300\r
+      Time Zone : 0\r
+      Daylight Time Rule : None\r
+      Software revision : SYNTHETIC\r
+      Base MAC Addr : aaaaaa-aaaaaa\r
+      Serial Number : XXXXXXXXXX\r
+      secrets-sw# \e[K
+  - "show system information\n": |-
+      show system information\r
+      Status and Counters - General System Information\r
+      System Name : secrets-sw\r
+      secrets-sw# \e[K
+  - "show running-config\n": |-
+      show running-config\r
+      Running configuration:\r
+      \r
+      ; JL322A Configuration Editor; Created on release #WC.16.11.0028\r
+      \r
+      hostname \"secrets-sw\"\r
+      include-credentials\r
+      password manager user-name \"manager\" sha256 \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"\r
+      password operator user-name \"operator\" plaintext \"plainoperator001\"\r
+      password port-access user-name \"dot1xlocal\" plaintext \"portaccesslocal1\"\r
+      snmp-server community \"public\" operator\r
+      snmp-server host 10.0.0.10 community \"public\" trap-level critical\r
+      snmpv3 user \"snmpadmin\" auth sha \"authpasshash0001\" priv aes \"privpasshash0001\"\r
+      radius-server host 10.0.0.20 key \"radiushostkey001\"\r
+      radius-server key \"radiusglobalkey1\"\r
+      tacacs-server host 10.0.0.21 key \"tacacshostkey001\"\r
+      tacacs-server key \"tacacsglobalkey1\"\r
+      sntp authentication key-id 1 authentication-mode md5 key-value \"sntpkeyvalue0001\"\r
+      aaa port-access supplicant 1 identity \"supp-user\" secret \"supplicantsecret\"\r
+      key-chain \"ospf-auth\"\r
+         key 1\r
+            key-string \"keychainstring01\"\r
+            exit\r
+         exit\r
+      interface A2\r
+         macsec\r
+            mode pre-shared-key ckn 37c9c2c45ddd cak \"macseccak0000001\"\r
+            exit\r
+         exit\r
+      secrets-sw# \e[K
+  - "logout\n": |-
+      logout\r
+      Do you want to log out (y/n)?
+  - "y\n": |-
+  - "n\n": |-

--- a/spec/model/model_helper.rb
+++ b/spec/model/model_helper.rb
@@ -106,8 +106,13 @@ class MockSsh
   def open_channel
     @channel = MockChannel.new @commands
     yield @channel
-    # Now simulate login with the initial @init_prompt
-    @channel.on_data_block.call(nil, @init_prompt)
+    # Queue the initial @init_prompt instead of delivering it synchronously.
+    # open_channel is called as `@ses = ssh.open_channel { ... }`, so delivering
+    # now - before that assignment returns - would leave @ses nil for any model
+    # that sends data in response to the init prompt. Procurve, for example,
+    # replies to "Press any key to continue" with a space. Queuing defers
+    # delivery to the first ssh.loop (in #login), by which time @ses is set.
+    @channel.queue_data @init_prompt
     # Return the simulated Net::SSH::Connection::Channel
     @channel
   end
@@ -147,6 +152,12 @@ class MockChannel
   # Saves the block for later use in #send_data
   def on_data(&block)
     @on_data_block = block
+  end
+
+  # Queue data for delivery to the on_data callback on the next #receive.
+  # Used to feed the init prompt once the ssh loop starts running.
+  def queue_data(data)
+    @queue << data
   end
 
   def request_pty(*)


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
- spec: queue the init prompt in `MockSsh`
- spec: add procurve model unit test
- procurve: fix snmp-server host secret redaction, redact local user password hashes (possibly fixes #3774)
- procurve: rstrip commented sections
- models: replace slice and rstrip with `cut_*` and `rstrip_lines` refinement
- docs: add @thanegill as a procurve model maintainer, note that some additional HPE Aruba switches use the procurve model
- procurve: use clean `:escape_codes` and simplify the model
