### PR TITLE
Fix system time generating changes on Fortigate

### DIFF
--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -51,7 +51,8 @@ class FortiOS < Oxidized::Model
       "Time Zone",
       "x86-64 Applications",
       "File System",
-      "Image Signature"
+      "Image Signature",
+      "System time"
     ]
     comment cfg + "\n"
   end

--- a/lib/oxidized/model/fortios.rb
+++ b/lib/oxidized/model/fortios.rb
@@ -52,7 +52,8 @@ class FortiOS < Oxidized::Model
       "x86-64 Applications",
       "File System",
       "Image Signature",
-      "System time"
+      "System time",
+      "conf_file_ver"
     ]
     comment cfg + "\n"
   end


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
I have a "System time" line on my Fortigate devices, causing constant changes. This fixes it.
