### PR TITLE
docker: ENV LANG=C.UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 ### Changed
+- docker: set LANG=C.UTF-8. Fixes #3690 (@ytti)
 
 ### Fixed
 - siklu: allow parenthesis in prompt. Fixes #3841 (@ytti)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM docker.io/debian:trixie-slim
 
+ENV LANG=C.UTF-8
+
 ##### Place "static" commands at the beginning to optimize image size and build speed
 
 # add non-privileged user


### PR DESCRIPTION
```shell
> ruby -e 'p Encoding.default_external'
#<Encoding:US-ASCII>

>LANG=C.UTF-8 ruby -e 'p Encoding.default_external'
#<Encoding:UTF-8>
```

Fixes: #3690

Our code assumes UTF8, and conditionally forces 8bit clean for configuration files. But we don't actually enforce the UTF8 assumption anywhere, we simply rely on OS.
Docker users have been running US-ASCII, including configuration fetched from systems, this change also affects that, not just issue mentioned.