### PR TITLE
fsos: add 'cmd :all' block to strip carriage returns and command echo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 ### Changed
+- fsos: Add `cmd :all` block to strip carriage returns and command echo/prompts
 
 ### Fixed
 - siklu: allow parenthesis in prompt. Fixes #3841 (@ytti)

--- a/lib/oxidized/model/fsos.rb
+++ b/lib/oxidized/model/fsos.rb
@@ -10,6 +10,11 @@ class FSOS < Oxidized::Model
     data.sub re, ''
   end
 
+  cmd :all do |cfg|
+    cfg = cfg.delete("\r")
+    cfg.cut_both
+  end
+
   cmd :secret do |cfg|
     cfg.gsub! /(secret \w+) (\S+).*/, '\\1 <secret hidden>'
     cfg.gsub! /(password \d+) (\S+).*/, '\\1 <secret hidden>'


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Add `cmd :all` block to strip carriage returns and command echo/prompts
from device output. Without it, `\r` characters were appearing in saved
configs and command echo/prompts were leaking into the output, causing
noisy diffs on every backup.

Tested against FS.com S5860-48SC and S5860-20SQ switches.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
