### PR TITLE
Fix fortigate 7.6.7 prompt for HA Status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 - siklu: allow parenthesis in prompt. Fixes #3841 (@ytti)
 - fortios: allow parenthesis in prompt. Fixes #3846 (@ytti)
-- fortigate: make space before parenthesis optional. Fixes #3846 (@ytti)
+- fortigate: prompt can contain HA cluster status. Fixes #3846 (@robertcheramy)
 
 ## [0.37.0 - 2026-05-20]
 ### Added

--- a/lib/oxidized/model/fortigate.rb
+++ b/lib/oxidized/model/fortigate.rb
@@ -3,7 +3,14 @@ class FortiGate < Oxidized::Model
 
   comment '# '
 
-  prompt /^(\(\w\) )?([-\w.~]+(\s?[(\w\-.)]+)?~?\s?[#>$]\s?)$/
+  prompt(/
+    ^
+    (?:\(\w\)\ )?                   # optional status indicator, e.g. "(M) "
+    [-\w.~]+                        # hostname
+    (?:\((?:Primary|Secondary)\))?  # optional HA cluster status
+    (?:\s[(\w\-.)]+)?               # optional VDOM
+    ~?\s?[#>$]\s?$                  # End of prompt
+  /x)
 
   # When a post-login-banner is enabled, you have to press "a" to log in
   expect /^\(Press\s'a'\sto\saccept\):/ do |data, re|

--- a/lib/oxidized/model/fortigate.rb
+++ b/lib/oxidized/model/fortigate.rb
@@ -5,13 +5,12 @@ class FortiGate < Oxidized::Model
 
   prompt(/
     ^
-    (?:\(\w\)\ )?                   # optional status indicator, e.g. "(M) "
-    [-\w.~]+                        # hostname
-    (?:\((?:Primary|Secondary)\))?  # optional HA cluster status
-    (?:\s[(\w\-.)]+)?               # optional VDOM
-    ~?\s?[#>$]\s?$                  # End of prompt
+    (?:\(\w\)\ )?          # optional status indicator, e.g. "(M) "
+    [-\w.~]+               # hostname
+    (?:\((?:\w+)\))?       # optional HA cluster status (Primary|Secondary)
+    (?:\ [(\w\-.)]+)?      # optional VDOM
+    ~?\ ?[#>$]\ ?$         # End of prompt
   /x)
-
   # When a post-login-banner is enabled, you have to press "a" to log in
   expect /^\(Press\s'a'\sto\saccept\):/ do |data, re|
     send 'a'

--- a/spec/model/data/fortigate#generic#prompt.yaml
+++ b/spec/model/data/fortigate#generic#prompt.yaml
@@ -8,3 +8,5 @@ pass:
   - 'OXI-FW121 (global) # '
   # Issue #3846
   - 'hostname(Primary) # '
+  - 'hostname(Primary) (global) # '
+


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This PR fixes the prompt of the fortigate (not fortios) model to work with newer 7.6.7 including the HA Status.

Closes #3846 
