### PR TITLE
Added the ability to explicitly specify the port on which the telnet, ssh is running for each host

### DIFF
--- a/lib/oxidized/input/sshbase.rb
+++ b/lib/oxidized/input/sshbase.rb
@@ -28,6 +28,7 @@ module Oxidized
     end
 
     def make_ssh_opts
+      node_ssh_port = @node.input_port || vars(:ssh_port)
       ssh_opts = {
         number_of_password_prompts:      0,
         keepalive:                       vars(:ssh_no_keepalive) ? false : true,
@@ -35,7 +36,7 @@ module Oxidized
         append_all_supported_algorithms: true,
         password:                        @node.auth[:password],
         timeout:                         @node.timeout,
-        port:                            (vars(:ssh_port) || 22).to_i,
+        port: (node_ssh_port || 22).to_i,
         forward_agent:                   false
       }
 

--- a/lib/oxidized/input/telnet.rb
+++ b/lib/oxidized/input/telnet.rb
@@ -12,7 +12,7 @@ module Oxidized
 
       @text_debug = DebugText.new(Oxidized.config.input.debug, @node, config_name)
 
-      port = vars(:telnet_port) || 23
+      port = @node.input_port || vars(:telnet_port) || 23
 
       telnet_opts = {
         'Host'    => @node.ip,

--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -7,7 +7,7 @@ module Oxidized
   class Node
     include SemanticLogger::Loggable
 
-    attr_reader :name, :ip, :model, :input, :output, :group, :auth, :prompt, :timeout, :vars, :last, :repo
+    attr_reader :name, :ip, :model, :input, :output, :group, :auth, :prompt, :timeout, :vars, :last, :repo, :input_port
     attr_accessor :running, :user, :email, :msg, :from, :stats, :retry, :err_type, :err_reason, :nexted
     alias running? running
     alias nexted? nexted
@@ -25,6 +25,7 @@ module Oxidized
       @group = opt[:group]
       @model = resolve_model opt
       @input = resolve_input opt
+      @input_port = resolve_input_port opt
       @output = resolve_output opt
       @auth = resolve_auth opt
       @prompt = resolve_prompt opt
@@ -182,6 +183,10 @@ module Oxidized
         Oxidized.mgr.input[input]
       end
     end
+
+    def resolve_input_port(opt)
+      resolve_key :input_port, opt
+   end
 
     def resolve_output(opt)
       output = resolve_key :output, opt, Oxidized.config.output.default


### PR DESCRIPTION
Added the ability to explicitly specify the port on which the telnet  or ssh service is running for each host, i.e.

in config:
source:
  default: csv
  csv:
     file: "/home/oxidized/.config/oxidized/router.db"
     delimiter: !ruby/regexp /\:/
     map:
       name: 0
       ip: 1
       username: 2
       password: 3
       model: 4
added:       input_port: 5
       input: 6
       group: 7
     vars_map:
       enable: 8
       comware_cmdline: 9

in router.db:
router:192.168.1.1:admin:password:routeros:60022:ssh:Gateways::

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
