### PR TITLE
Remove additional POE status comment from routeros config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 - docker: set LANG=C.UTF-8. Fixes #3690 (@ytti)
+- routeros: remove intermittent POE `voltage_on_poe-in` comment (@hendrikbl)
 
 ### Fixed
 - siklu: allow parenthesis in prompt. Fixes #3841 (@ytti)

--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -47,7 +47,7 @@ class RouterOS < Oxidized::Model
       cfg.gsub! "# inactive time\r\n", '' # Remove time based system comment
       cfg.gsub! /# received packet from \S+ bad format\r\n/, '' # Remove intermittent VRRP/CARP collision comment
       cfg.gsub! "# poe-out status: short_circuit\r\n", '' # Remove intermittent POE short_circuit comment
-      cfg.gsub! "# poe-out status: voltage_on_poe-in\r\n", '' # Remove intermittent POE voltage_on_poe-in comment
+      cfg.gsub! /# poe-out status: voltage_on_poe-in\r?\n/, '' # Remove intermittent POE voltage_on_poe-in comment
       cfg.gsub! "# Firmware upgraded successfully, please reboot for changes to take effect!\r\n", '' # Remove transient firmware upgrade comment
       cfg.gsub! /# \S+ not ready\r\n/, '' # Remove intermittent $interface not ready comment
       cfg.gsub! /# .+ please restart the device in order to apply the new setting\r\n/, '' # Remove intermittent restart needed comment. (e.g. for ipv6 settings)

--- a/lib/oxidized/model/routeros.rb
+++ b/lib/oxidized/model/routeros.rb
@@ -47,6 +47,7 @@ class RouterOS < Oxidized::Model
       cfg.gsub! "# inactive time\r\n", '' # Remove time based system comment
       cfg.gsub! /# received packet from \S+ bad format\r\n/, '' # Remove intermittent VRRP/CARP collision comment
       cfg.gsub! "# poe-out status: short_circuit\r\n", '' # Remove intermittent POE short_circuit comment
+      cfg.gsub! "# poe-out status: voltage_on_poe-in\r\n", '' # Remove intermittent POE voltage_on_poe-in comment
       cfg.gsub! "# Firmware upgraded successfully, please reboot for changes to take effect!\r\n", '' # Remove transient firmware upgrade comment
       cfg.gsub! /# \S+ not ready\r\n/, '' # Remove intermittent $interface not ready comment
       cfg.gsub! /# .+ please restart the device in order to apply the new setting\r\n/, '' # Remove intermittent restart needed comment. (e.g. for ipv6 settings)

--- a/spec/model/data/routeros#CHR_7.16#simulation.yaml
+++ b/spec/model/data/routeros#CHR_7.16#simulation.yaml
@@ -39,6 +39,7 @@ commands:
     # serial number = XXXX
     /interface ethernet
     set [ find default-name=ether1 ] disable-running-check=no
+    # poe-out status: voltage_on_poe-in
     set [ find default-name=ether2 ] disable-running-check=no
     set [ find default-name=ether3 ] disable-running-check=no
     set [ find default-name=ether4 ] disable-running-check=no

--- a/spec/model/data/routeros#CHR_7.16#simulation.yaml
+++ b/spec/model/data/routeros#CHR_7.16#simulation.yaml
@@ -39,7 +39,6 @@ commands:
     # serial number = XXXX
     /interface ethernet
     set [ find default-name=ether1 ] disable-running-check=no
-    # poe-out status: voltage_on_poe-in
     set [ find default-name=ether2 ] disable-running-check=no
     set [ find default-name=ether3 ] disable-running-check=no
     set [ find default-name=ether4 ] disable-running-check=no

--- a/spec/model/data/routeros#RB5009UPr+S+_7.18.2#output.txt
+++ b/spec/model/data/routeros#RB5009UPr+S+_7.18.2#output.txt
@@ -1,0 +1,189 @@
+#                   version: 7.18.2 (stable)
+#          factory-software: 7.8
+#              total-memory: 1024.0MiB
+#                       cpu: ARM64
+#                 cpu-count: 4
+#           total-hdd-space: 1024.0MiB
+#         architecture-name: arm64
+#                board-name: RB5009UPr+S+
+#                  platform: MikroTik
+#   installed-version: 7.18.2
+# Flags: U - UNDOABLE
+# Columns: ACTION, BY, POLICY, TIME
+#   ACTION                              BY     POLICY  TIME
+# U device changed                      admin  write   2025-03-10 15:04:16
+# U device changed                      admin  write   2025-03-10 15:04:13
+# U device changed                      admin  write   2025-03-10 15:04:11
+# U device changed                      admin  write   2025-03-10 15:04:08
+# U device changed                      admin  write   2025-03-10 15:04:04
+# U disk and smb server config changed         write   2025-03-10 11:59:20
+# U user admin changed                         write   2025-03-10 11:59:20
+#                                              policy
+# U mac winbox setting changed                 write   2025-03-10 11:59:20
+# U mac-server interface changed               write   2025-03-10 11:59:20
+# U config changed                             write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U filter6 rule added                         write   2025-03-10 11:59:20
+# U address list entry added                   write   2025-03-10 11:59:19
+# U address list entry added                   write   2025-03-10 11:59:19
+# U address list entry added                   write   2025-03-10 11:59:19
+# U address list entry added                   write   2025-03-10 11:59:19
+# U address list entry added                   write   2025-03-10 11:59:19
+# U address list entry added                   write   2025-03-10 11:59:19
+# U address list entry added                   write   2025-03-10 11:59:19
+# U address list entry added                   write   2025-03-10 11:59:19
+# U address list entry added                   write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U filter rule added                          write   2025-03-10 11:59:19
+# U nat rule added                             write   2025-03-10 11:59:19
+# U interface list member added                write   2025-03-10 11:59:19
+# U interface list member added                write   2025-03-10 11:59:19
+# U dhcp client added                          write   2025-03-10 11:59:19
+# U static dns entry added                     write   2025-03-10 11:59:19
+# U dns changed                                write   2025-03-10 11:59:19
+# U address added                              write   2025-03-10 11:59:19
+# U dhcp network added                         write   2025-03-10 11:59:19
+# U dhcp server defconf added                  write   2025-03-10 11:59:19
+# U pool default-dhcp added                    write   2025-03-10 11:59:19
+# U bridge port added                          write   2025-03-10 11:59:19
+# U bridge port added                          write   2025-03-10 11:59:19
+# U bridge port added                          write   2025-03-10 11:59:19
+# U bridge port added                          write   2025-03-10 11:59:18
+# U bridge port added                          write   2025-03-10 11:59:18
+# U bridge port added                          write   2025-03-10 11:59:18
+# U bridge port added                          write   2025-03-10 11:59:18
+# U bridge port added                          write   2025-03-10 11:59:18
+# U device changed                             write   2025-03-10 11:59:18
+# U device added                               write   2025-03-10 11:59:18
+# U interface list added                       write   2025-03-10 11:59:18
+# U interface list added                       write   2025-03-10 11:59:18
+# software id = QMLS-64F2
+#
+# model = RB5009UPr+S+
+# serial number = 123456789AB
+/interface bridge
+add admin-mac=AA:11:AA:11:AA:11 auto-mac=no comment=defconf name=bridge
+/interface ethernet
+set [ find default-name=ether2 ] mtu=1514
+set [ find default-name=ether3 ] mtu=1514
+set [ find default-name=ether4 ] mtu=1514
+set [ find default-name=ether5 ] mtu=1514
+set [ find default-name=ether6 ] mtu=1514
+/interface list
+add comment=defconf name=WAN
+add comment=defconf name=LAN
+/ip pool
+add name=default-dhcp ranges=192.168.88.10-192.168.88.254
+/disk settings
+set auto-media-interface=bridge auto-media-sharing=yes auto-smb-sharing=yes
+/interface bridge port
+add bridge=bridge comment=defconf interface=ether2
+add bridge=bridge comment=defconf interface=ether3
+add bridge=bridge comment=defconf interface=ether4
+add bridge=bridge comment=defconf interface=ether5
+add bridge=bridge comment=defconf interface=ether6
+add bridge=bridge comment=defconf interface=ether7
+add bridge=bridge comment=defconf interface=ether8
+add bridge=bridge comment=defconf interface=sfp-sfpplus1
+/ip neighbor discovery-settings
+set discover-interface-list=LAN
+/interface list member
+add comment=defconf interface=bridge list=LAN
+add comment=defconf interface=ether1 list=WAN
+/ip address
+add address=192.168.88.1/24 comment=defconf interface=bridge network=192.168.88.0
+/ip dhcp-client
+# Interface not active
+add comment=defconf interface=ether1
+/ip dhcp-server
+add address-pool=default-dhcp interface=bridge name=defconf
+/ip dhcp-server network
+add address=192.168.88.0/24 comment=defconf dns-server=192.168.88.1 gateway=192.168.88.1
+/ip dns
+set allow-remote-requests=yes
+/ip dns static
+add address=192.168.88.1 comment=defconf name=router.lan type=A
+/ip firewall filter
+add action=accept chain=input comment="defconf: accept established,related,untracked" connection-state=established,related,untracked
+add action=drop chain=input comment="defconf: drop invalid" connection-state=invalid
+add action=accept chain=input comment="defconf: accept ICMP" protocol=icmp
+add action=accept chain=input comment="defconf: accept to local loopback (for CAPsMAN)" dst-address=127.0.0.1
+add action=drop chain=input comment="defconf: drop all not coming from LAN" in-interface-list=!LAN
+add action=accept chain=forward comment="defconf: accept in ipsec policy" ipsec-policy=in,ipsec
+add action=accept chain=forward comment="defconf: accept out ipsec policy" ipsec-policy=out,ipsec
+add action=fasttrack-connection chain=forward comment="defconf: fasttrack" connection-state=established,related hw-offload=yes
+add action=accept chain=forward comment="defconf: accept established,related, untracked" connection-state=established,related,untracked
+add action=drop chain=forward comment="defconf: drop invalid" connection-state=invalid
+add action=drop chain=forward comment="defconf: drop all from WAN not DSTNATed" connection-nat-state=!dstnat connection-state=new in-interface-list=WAN
+/ip firewall nat
+add action=masquerade chain=srcnat comment="defconf: masquerade" ipsec-policy=out,none out-interface-list=WAN
+/ipv6 firewall address-list
+add address=::/128 comment="defconf: unspecified address" list=bad_ipv6
+add address=::1/128 comment="defconf: lo" list=bad_ipv6
+add address=fec0::/10 comment="defconf: site-local" list=bad_ipv6
+add address=::ffff:0.0.0.0/96 comment="defconf: ipv4-mapped" list=bad_ipv6
+add address=::/96 comment="defconf: ipv4 compat" list=bad_ipv6
+add address=100::/64 comment="defconf: discard only " list=bad_ipv6
+add address=2001:db8::/32 comment="defconf: documentation" list=bad_ipv6
+add address=2001:10::/28 comment="defconf: ORCHID" list=bad_ipv6
+add address=3ffe::/16 comment="defconf: 6bone" list=bad_ipv6
+/ipv6 firewall filter
+add action=accept chain=input comment="defconf: accept established,related,untracked" connection-state=established,related,untracked
+add action=drop chain=input comment="defconf: drop invalid" connection-state=invalid
+add action=accept chain=input comment="defconf: accept ICMPv6" protocol=icmpv6
+add action=accept chain=input comment="defconf: accept UDP traceroute" dst-port=33434-33534 protocol=udp
+add action=accept chain=input comment="defconf: accept DHCPv6-Client prefix delegation." dst-port=546 protocol=udp src-address=fe80::/10
+add action=accept chain=input comment="defconf: accept IKE" dst-port=500,4500 protocol=udp
+add action=accept chain=input comment="defconf: accept ipsec AH" protocol=ipsec-ah
+add action=accept chain=input comment="defconf: accept ipsec ESP" protocol=ipsec-esp
+add action=accept chain=input comment="defconf: accept all that matches ipsec policy" ipsec-policy=in,ipsec
+add action=drop chain=input comment="defconf: drop everything else not coming from LAN" in-interface-list=!LAN
+add action=fasttrack-connection chain=forward comment="defconf: fasttrack6" connection-state=established,related
+add action=accept chain=forward comment="defconf: accept established,related,untracked" connection-state=established,related,untracked
+add action=drop chain=forward comment="defconf: drop invalid" connection-state=invalid
+add action=drop chain=forward comment="defconf: drop packets with bad src ipv6" src-address-list=bad_ipv6
+add action=drop chain=forward comment="defconf: drop packets with bad dst ipv6" dst-address-list=bad_ipv6
+add action=drop chain=forward comment="defconf: rfc4890 drop hop-limit=1" hop-limit=equal:1 protocol=icmpv6
+add action=accept chain=forward comment="defconf: accept ICMPv6" protocol=icmpv6
+add action=accept chain=forward comment="defconf: accept HIP" protocol=139
+add action=accept chain=forward comment="defconf: accept IKE" dst-port=500,4500 protocol=udp
+add action=accept chain=forward comment="defconf: accept ipsec AH" protocol=ipsec-ah
+add action=accept chain=forward comment="defconf: accept ipsec ESP" protocol=ipsec-esp
+add action=accept chain=forward comment="defconf: accept all that matches ipsec policy" ipsec-policy=in,ipsec
+add action=drop chain=forward comment="defconf: drop everything else not coming from LAN" in-interface-list=!LAN
+/system note
+set show-at-login=no
+/tool mac-server
+set allowed-interface-list=LAN
+/tool mac-server mac-winbox
+set allowed-interface-list=LAN

--- a/spec/model/data/routeros#RB5009UPr+S+_7.18.2#simulation.yaml
+++ b/spec/model/data/routeros#RB5009UPr+S+_7.18.2#simulation.yaml
@@ -1,0 +1,261 @@
+---
+init_prompt:
+commands:
+  - "/system resource print\n": |-
+      \x20                  uptime: 3h5m54s            
+                        version: 7.18.2 (stable)    
+                     build-time: 2025-03-11 11:59:04
+               factory-software: 7.8                
+                    free-memory: 876.2MiB           
+                   total-memory: 1024.0MiB          
+                            cpu: ARM64              
+                      cpu-count: 4                  
+                  cpu-frequency: 700MHz             
+                       cpu-load: 1%                 
+                 free-hdd-space: 993.4MiB           
+                total-hdd-space: 1024.0MiB          
+        write-sect-since-reboot: 176                
+               write-sect-total: 15565              
+                     bad-blocks: 0%                 
+              architecture-name: arm64              
+                     board-name: RB5009UPr+S+       
+                       platform: MikroTik           
+      
+      
+  - "/system package update print\n": |-
+      \x20           channel: stable
+        installed-version: 7.18.2
+      
+      
+  - "/system history print without-paging\n": |-
+      Flags: U - UNDOABLE
+      Columns: ACTION, BY, POLICY, TIME
+        ACTION                              BY     POLICY  TIME               
+      U device changed                      admin  write   2025-03-10 15:04:16
+      U device changed                      admin  write   2025-03-10 15:04:13
+      U device changed                      admin  write   2025-03-10 15:04:11
+      U device changed                      admin  write   2025-03-10 15:04:08
+      U device changed                      admin  write   2025-03-10 15:04:04
+      U disk and smb server config changed         write   2025-03-10 11:59:20
+      U user admin changed                         write   2025-03-10 11:59:20
+                                                   policy                     
+      U mac winbox setting changed                 write   2025-03-10 11:59:20
+      U mac-server interface changed               write   2025-03-10 11:59:20
+      U config changed                             write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U filter6 rule added                         write   2025-03-10 11:59:20
+      U address list entry added                   write   2025-03-10 11:59:19
+      U address list entry added                   write   2025-03-10 11:59:19
+      U address list entry added                   write   2025-03-10 11:59:19
+      U address list entry added                   write   2025-03-10 11:59:19
+      U address list entry added                   write   2025-03-10 11:59:19
+      U address list entry added                   write   2025-03-10 11:59:19
+      U address list entry added                   write   2025-03-10 11:59:19
+      U address list entry added                   write   2025-03-10 11:59:19
+      U address list entry added                   write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U filter rule added                          write   2025-03-10 11:59:19
+      U nat rule added                             write   2025-03-10 11:59:19
+      U interface list member added                write   2025-03-10 11:59:19
+      U interface list member added                write   2025-03-10 11:59:19
+      U dhcp client added                          write   2025-03-10 11:59:19
+      U static dns entry added                     write   2025-03-10 11:59:19
+      U dns changed                                write   2025-03-10 11:59:19
+      U address added                              write   2025-03-10 11:59:19
+      U dhcp network added                         write   2025-03-10 11:59:19
+      U dhcp server defconf added                  write   2025-03-10 11:59:19
+      U pool default-dhcp added                    write   2025-03-10 11:59:19
+      U bridge port added                          write   2025-03-10 11:59:19
+      U bridge port added                          write   2025-03-10 11:59:19
+      U bridge port added                          write   2025-03-10 11:59:19
+      U bridge port added                          write   2025-03-10 11:59:18
+      U bridge port added                          write   2025-03-10 11:59:18
+      U bridge port added                          write   2025-03-10 11:59:18
+      U bridge port added                          write   2025-03-10 11:59:18
+      U bridge port added                          write   2025-03-10 11:59:18
+      U device changed                             write   2025-03-10 11:59:18
+      U device added                               write   2025-03-10 11:59:18
+      U interface list added                       write   2025-03-10 11:59:18
+      U interface list added                       write   2025-03-10 11:59:18
+      
+      
+  - "/export show-sensitive\n": |-
+      # 2025-03-10 15:04:33 by RouterOS 7.18.2
+      # software id = QMLS-64F2
+      #
+      # model = RB5009UPr+S+
+      # serial number = 123456789AB
+      /interface bridge
+      add admin-mac=AA:11:AA:11:AA:11 auto-mac=no comment=defconf name=bridge
+      /interface ethernet
+      set [ find default-name=ether2 ] mtu=1514
+      set [ find default-name=ether3 ] mtu=1514
+      # poe-out status: voltage_on_poe-in
+      set [ find default-name=ether4 ] mtu=1514
+      set [ find default-name=ether5 ] mtu=1514
+      set [ find default-name=ether6 ] mtu=1514
+      /interface list
+      add comment=defconf name=WAN
+      add comment=defconf name=LAN
+      /ip pool
+      add name=default-dhcp ranges=192.168.88.10-192.168.88.254
+      /disk settings
+      set auto-media-interface=bridge auto-media-sharing=yes auto-smb-sharing=yes
+      /interface bridge port
+      add bridge=bridge comment=defconf interface=ether2
+      add bridge=bridge comment=defconf interface=ether3
+      add bridge=bridge comment=defconf interface=ether4
+      add bridge=bridge comment=defconf interface=ether5
+      add bridge=bridge comment=defconf interface=ether6
+      add bridge=bridge comment=defconf interface=ether7
+      add bridge=bridge comment=defconf interface=ether8
+      add bridge=bridge comment=defconf interface=sfp-sfpplus1
+      /ip neighbor discovery-settings
+      set discover-interface-list=LAN
+      /interface list member
+      add comment=defconf interface=bridge list=LAN
+      add comment=defconf interface=ether1 list=WAN
+      /ip address
+      add address=192.168.88.1/24 comment=defconf interface=bridge network=\\
+          192.168.88.0
+      /ip dhcp-client
+      # Interface not active
+      add comment=defconf interface=ether1
+      /ip dhcp-server
+      add address-pool=default-dhcp interface=bridge name=defconf
+      /ip dhcp-server network
+      add address=192.168.88.0/24 comment=defconf dns-server=192.168.88.1 gateway=\\
+          192.168.88.1
+      /ip dns
+      set allow-remote-requests=yes
+      /ip dns static
+      add address=192.168.88.1 comment=defconf name=router.lan type=A
+      /ip firewall filter
+      add action=accept chain=input comment=\\
+          \"defconf: accept established,related,untracked\" connection-state=\\
+          established,related,untracked
+      add action=drop chain=input comment=\"defconf: drop invalid\" connection-state=\\
+          invalid
+      add action=accept chain=input comment=\"defconf: accept ICMP\" protocol=icmp
+      add action=accept chain=input comment=\\
+          \"defconf: accept to local loopback (for CAPsMAN)\" dst-address=127.0.0.1
+      add action=drop chain=input comment=\"defconf: drop all not coming from LAN\" \\
+          in-interface-list=!LAN
+      add action=accept chain=forward comment=\"defconf: accept in ipsec policy\" \\
+          ipsec-policy=in,ipsec
+      add action=accept chain=forward comment=\"defconf: accept out ipsec policy\" \\
+          ipsec-policy=out,ipsec
+      add action=fasttrack-connection chain=forward comment=\"defconf: fasttrack\" \\
+          connection-state=established,related hw-offload=yes
+      add action=accept chain=forward comment=\\
+          \"defconf: accept established,related, untracked\" connection-state=\\
+          established,related,untracked
+      add action=drop chain=forward comment=\"defconf: drop invalid\" \\
+          connection-state=invalid
+      add action=drop chain=forward comment=\\
+          \"defconf: drop all from WAN not DSTNATed\" connection-nat-state=!dstnat \\
+          connection-state=new in-interface-list=WAN
+      /ip firewall nat
+      add action=masquerade chain=srcnat comment=\"defconf: masquerade\" \\
+          ipsec-policy=out,none out-interface-list=WAN
+      /ipv6 firewall address-list
+      add address=::/128 comment=\"defconf: unspecified address\" list=bad_ipv6
+      add address=::1/128 comment=\"defconf: lo\" list=bad_ipv6
+      add address=fec0::/10 comment=\"defconf: site-local\" list=bad_ipv6
+      add address=::ffff:0.0.0.0/96 comment=\"defconf: ipv4-mapped\" list=bad_ipv6
+      add address=::/96 comment=\"defconf: ipv4 compat\" list=bad_ipv6
+      add address=100::/64 comment=\"defconf: discard only \" list=bad_ipv6
+      add address=2001:db8::/32 comment=\"defconf: documentation\" list=bad_ipv6
+      add address=2001:10::/28 comment=\"defconf: ORCHID\" list=bad_ipv6
+      add address=3ffe::/16 comment=\"defconf: 6bone\" list=bad_ipv6
+      /ipv6 firewall filter
+      add action=accept chain=input comment=\\
+          \"defconf: accept established,related,untracked\" connection-state=\\
+          established,related,untracked
+      add action=drop chain=input comment=\"defconf: drop invalid\" connection-state=\\
+          invalid
+      add action=accept chain=input comment=\"defconf: accept ICMPv6\" protocol=\\
+          icmpv6
+      add action=accept chain=input comment=\"defconf: accept UDP traceroute\" \\
+          dst-port=33434-33534 protocol=udp
+      add action=accept chain=input comment=\\
+          \"defconf: accept DHCPv6-Client prefix delegation.\" dst-port=546 protocol=\\
+          udp src-address=fe80::/10
+      add action=accept chain=input comment=\"defconf: accept IKE\" dst-port=500,4500 \\
+          protocol=udp
+      add action=accept chain=input comment=\"defconf: accept ipsec AH\" protocol=\\
+          ipsec-ah
+      add action=accept chain=input comment=\"defconf: accept ipsec ESP\" protocol=\\
+          ipsec-esp
+      add action=accept chain=input comment=\\
+          \"defconf: accept all that matches ipsec policy\" ipsec-policy=in,ipsec
+      add action=drop chain=input comment=\\
+          \"defconf: drop everything else not coming from LAN\" in-interface-list=\\
+          !LAN
+      add action=fasttrack-connection chain=forward comment=\"defconf: fasttrack6\" \\
+          connection-state=established,related
+      add action=accept chain=forward comment=\\
+          \"defconf: accept established,related,untracked\" connection-state=\\
+          established,related,untracked
+      add action=drop chain=forward comment=\"defconf: drop invalid\" \\
+          connection-state=invalid
+      add action=drop chain=forward comment=\\
+          \"defconf: drop packets with bad src ipv6\" src-address-list=bad_ipv6
+      add action=drop chain=forward comment=\\
+          \"defconf: drop packets with bad dst ipv6\" dst-address-list=bad_ipv6
+      add action=drop chain=forward comment=\"defconf: rfc4890 drop hop-limit=1\" \\
+          hop-limit=equal:1 protocol=icmpv6
+      add action=accept chain=forward comment=\"defconf: accept ICMPv6\" protocol=\\
+          icmpv6
+      add action=accept chain=forward comment=\"defconf: accept HIP\" protocol=139
+      add action=accept chain=forward comment=\"defconf: accept IKE\" dst-port=\\
+          500,4500 protocol=udp
+      add action=accept chain=forward comment=\"defconf: accept ipsec AH\" protocol=\\
+          ipsec-ah
+      add action=accept chain=forward comment=\"defconf: accept ipsec ESP\" protocol=\\
+          ipsec-esp
+      add action=accept chain=forward comment=\\
+          \"defconf: accept all that matches ipsec policy\" ipsec-policy=in,ipsec
+      add action=drop chain=forward comment=\\
+          \"defconf: drop everything else not coming from LAN\" in-interface-list=\\
+          !LAN
+      /system note
+      set show-at-login=no
+      /tool mac-server
+      set allowed-interface-list=LAN
+      /tool mac-server mac-winbox
+      set allowed-interface-list=LAN
+      
+  - "quit\n": |-
+      interrupted
+      


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

Remove additional POE status comment `voltage_on_poe-in` from routeros config.

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
