### PR TITLE
aoscx: hide changing power-consumption and input-voltage values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - siklu: allow parenthesis in prompt. Fixes #3841 (@ytti)
 - fortios: allow parenthesis in prompt. Fixes #3846 (@ytti)
 - fortigate: prompt can contain HA cluster status. Fixes #3846 (@robertcheramy)
+- aoscx: hide power consumption on rows where PSU output is N/A. Fixes #3864 (@FusionBrah)
+- aoscx: hide input voltage readings in "show environment power-supply input-voltage". Fixes #3864 (@FusionBrah)
 
 ## [0.37.0 - 2026-05-20]
 ### Added

--- a/lib/oxidized/model/aoscx.rb
+++ b/lib/oxidized/model/aoscx.rb
@@ -52,12 +52,16 @@ class Aoscx < Oxidized::Model
     end
 
     with_section(cfg, 'power-consumption') do |content|
-      content.gsub!(/^(.*?) (?:\d+\.\d+ +)+\d+\.\d+$/, '\\1 <power hidden>')
+      content.gsub!(/^(.*?) (?:\d+\.\d+ +)+\d+\.\d+(?: +N\/A)*$/, '\\1 <power hidden>')
       content.gsub!(/^(Total Power Consumption +)\d+\.\d+$/, '\\1<power hidden>')
     end
 
     with_section(cfg, 'power-allocation') do |content|
       content.gsub!(/^(.*) \d+ W$/, '\\1 <power>')
+    end
+
+    with_section(cfg, 'power-supply input-voltage') do |content|
+      content.gsub!(/^((?:\S+ +){3}\d+-\d+ +)\d+\.\d+ +\d+\.\d+/, '\\1<voltage hidden>')
     end
 
     with_section(cfg, 'temperature') do |content|

--- a/spec/model/data/aoscx#CX10000_10.16.1020_environment#output.txt
+++ b/spec/model/data/aoscx#CX10000_10.16.1020_environment#output.txt
@@ -48,8 +48,8 @@
 ! Mbr/  Product  Input  Normal     Present    Average    Input Voltage Violations:       Recovery  Recovery
 ! PSU   Number   Type   Input (V)  Input (V)  Input (V)  Count  Most Recent Event           Count  Time
 ! -----------------------------------------------------------------------------------------------------------------------------
-! 1/1   R8R51A   AC     90-264         229.2      228.7      0  N/A                             0  N/A                         
-! 1/2   R8R51A   AC     90-264         228.2      228.0      0  N/A                             0  N/A                         
+! 1/1   R8R51A   AC     90-264         <voltage hidden>      0  N/A                             0  N/A                         
+! 1/2   R8R51A   AC     90-264         <voltage hidden>      0  N/A                             0  N/A                         
 ! 
 ! 
 ! show environment power-consumption

--- a/spec/model/data/aoscx#CX6000-8G_10.16.1010_environment#output.txt
+++ b/spec/model/data/aoscx#CX6000-8G_10.16.1010_environment#output.txt
@@ -1,0 +1,210 @@
+! -----------------------------------------------------------------------------
+! AOS-CX
+! (c) Copyright 2017-2025 Hewlett Packard Enterprise Development LP
+! -----------------------------------------------------------------------------
+! Version      : PL.10.16.1010                                                 
+! Build Date   : 2025-11-10 17:16:36 UTC                                       
+! Build ID     : AOS-CX:PL.10.16.1010:8e02d0e3b736:202511101706                
+! Build SHA    : 8e02d0e3b73610a4383330daa86e9bddc19c3283                      
+! Hot Patches  :                                                               
+! Active Image : primary                       
+! 
+! Service OS Version : PL.01.17.0003                 
+! BIOS Version       : PL.03.0001                    
+! 
+! 
+! show environment led
+! Mbr/Name       State        Status    
+! ----------------------------------
+! 1/locator      off          ok        
+! 
+! 
+! show environment power-consumption
+! 
+! Power Consumption Averaging Period : 600 seconds
+! 
+!                                       Power Usage (W)      PSU Output (W) 
+! Name Description                     Instant   Average   Instant   Average
+! ----------------------------------------------------------------------------
+! 1    6000 8G CL4 2F 67W Sw              <power hidden>
+! 
+! 
+! show environment power-supply
+! --------------------------------------------------------------------------------
+!          Product  Serial            PSU                Input  Voltage    Wattage
+! Mbr/PSU  Number   Number            Status             Type   Range      Maximum
+! --------------------------------------------------------------------------------
+! 1/1      N/A      N/A               OK                 AC     100V-240V  90
+! 
+! 
+! 
+! show environment temperature
+! Temperature information
+! ------------------------------------------------------------------------------
+!                                                      Current
+! Mbr/Slot-Sensor                 Module Type        Temperature  Status
+! ------------------------------------------------------------------------------
+! 1/1-PHY-01-08                   line-card-module     <hidden>   normal
+! 
+! 1/1-Inlet-Air                   management-module    <hidden>   normal
+! 1/1-Switch-ASIC-Internal        management-module    <hidden>   normal
+! 1/1-Switch-CPU-1                management-module    <hidden>   normal
+! 1/1-Switch-CPU-2                management-module    <hidden>   normal
+! 
+! 
+! Management Modules
+! ==================
+! 
+!      Product                                        Serial
+! Name Number  Description                            Number     Status
+! ---- ------- -------------------------------------- ---------- ----------------
+! 1/1  S4R23A  6000 8G CL4 2F 67W Sw                  <removed>  Ready
+! 
+! 
+! Line Modules
+! ============
+! 
+!      Product                                        Serial
+! Name Number  Description                            Number     Status
+! ---- ------- -------------------------------------- ---------- ----------------
+! 1/1  S4R23A  6000 8G CL4 2F 67W Sw                  <removed>  Ready
+! 
+! 
+! No matching interfaces
+! Hostname               : sw07                          
+! System Description     : PL.10.16.1010                 
+! System Contact         : <removed>                     
+! System Location        : <removed>                          
+! 
+! Vendor                 : HPE ANW                       
+! Product Name           : S4R23A 6000 8G CL4 2F 67W Sw         
+! Chassis Serial Nbr     : <removed>                     
+! Base MAC Address       : 00c84e-000000                 
+! AOS-CX Version         : PL.10.16.1010                 
+! 
+! Time Zone              : Europe/Amsterdam              
+! 
+Current configuration:
+!
+!Version AOS-CX PL.10.16.1010
+!export-password: default
+hostname sw07
+user admin group administrators password ciphertext <removed>
+user oxidized group administrators password ciphertext <removed>
+user contose-adm group administrators password ciphertext <removed>
+clock timezone europe/amsterdam
+ntp server ntp.time.nl minpoll 4 maxpoll 4 iburst
+ntp server pool.ntp.org minpoll 4 maxpoll 4 iburst
+ntp enable
+!
+!
+!
+!
+!
+!
+user oxidized authorized-key ssh-ed25519 <removed> oxidized@<removed>
+ssh server vrf default
+vlan 1
+vlan 21
+    name Rack/Management
+vlan 51
+    name vast
+vlan 52
+    name wifi
+vlan 53
+    name 'BYOD'
+vlan 55
+    name 'MGMT'
+spanning-tree
+spanning-tree bpdu-guard timeout 300
+port-access port-security enable
+interface 1/1/1
+    description workstation
+    no shutdown
+    vlan access 51
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+    port-access port-security
+        enable
+        client-limit 2
+interface 1/1/2
+    description workstation
+    no shutdown
+    vlan access 51
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+    port-access port-security
+        enable
+        client-limit 2
+interface 1/1/3
+    description workstation
+    no shutdown
+    vlan access 51
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+    port-access port-security
+        enable
+        client-limit 2
+interface 1/1/4
+    description workstation
+    no shutdown
+    vlan access 51
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+    port-access port-security
+        enable
+        client-limit 2
+interface 1/1/5
+    description byod
+    no shutdown
+    vlan access 53
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+    port-access port-security
+        enable
+        client-limit 2
+interface 1/1/6
+    description byod
+    no shutdown
+    vlan access 53
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+    port-access port-security
+        enable
+        client-limit 2
+interface 1/1/7
+    description byod
+    no shutdown
+    vlan access 53
+    spanning-tree bpdu-guard
+    spanning-tree port-type admin-edge
+    port-access port-security
+        enable
+        client-limit 2
+interface 1/1/8
+    description uplink
+    no shutdown
+    vlan trunk native 1
+    vlan trunk allowed all
+interface 1/1/9
+    shutdown
+    vlan access 1
+interface 1/1/10
+    shutdown
+    vlan access 1
+interface vlan 1
+    no ip dhcp
+    no ipv6 dhcp
+interface vlan 55
+    ip address 192.0.2.10/24
+snmp-server vrf default
+snmp-server system-location <removed>
+snmp-server system-contact <removed>
+snmp-server community <removed>
+ip route 0.0.0.0/0 192.0.2.254 
+!
+!
+!
+!
+!
+https-server vrf default

--- a/spec/model/data/aoscx#CX6000-8G_10.16.1010_environment#simulation.yaml
+++ b/spec/model/data/aoscx#CX6000-8G_10.16.1010_environment#simulation.yaml
@@ -1,0 +1,244 @@
+---
+init_prompt: |-
+      Last login: 2026-07-08 16:20:50 from 192.0.2.1\r
+      User \"oxidized\" has logged in 1 time in the past 30 days\r
+      sw07#\x20
+commands:
+  - "no page\n": |-
+      no page\r
+      sw07#\x20
+  - "show version\n": |-
+      show version\r
+      -----------------------------------------------------------------------------\r
+      AOS-CX\r
+      (c) Copyright 2017-2025 Hewlett Packard Enterprise Development LP\r
+      -----------------------------------------------------------------------------\r
+      Version      : PL.10.16.1010                                                 \r
+      Build Date   : 2025-11-10 17:16:36 UTC                                       \r
+      Build ID     : AOS-CX:PL.10.16.1010:8e02d0e3b736:202511101706                \r
+      Build SHA    : 8e02d0e3b73610a4383330daa86e9bddc19c3283                      \r
+      Hot Patches  :                                                               \r
+      Active Image : primary                       \r
+      \r
+      Service OS Version : PL.01.17.0003                 \r
+      BIOS Version       : PL.03.0001                    \r
+      sw07#\x20
+  - "show environment\n": |-
+      show environment\r
+      \r
+      \r
+      show environment led\r
+      Mbr/Name       State        Status    \r
+      ----------------------------------\r
+      1/locator      off          ok        \r
+      \r
+      \r
+      show environment power-consumption\r
+      \r
+      Power Consumption Averaging Period : 600 seconds\r
+      \r
+                                            Power Usage (W)      PSU Output (W) \r
+      Name Description                     Instant   Average   Instant   Average\r
+      ----------------------------------------------------------------------------\r
+      1    6000 8G CL4 2F 67W Sw              7.00      6.24       N/A       N/A\r
+      \r
+      \r
+      show environment power-supply\r
+      --------------------------------------------------------------------------------\r
+               Product  Serial            PSU                Input  Voltage    Wattage\r
+      Mbr/PSU  Number   Number            Status             Type   Range      Maximum\r
+      --------------------------------------------------------------------------------\r
+      1/1      N/A      N/A               OK                 AC     100V-240V  90\r
+      \r
+      \r
+      \r
+      show environment temperature\r
+      Temperature information\r
+      ------------------------------------------------------------------------------\r
+                                                           Current\r
+      Mbr/Slot-Sensor                 Module Type        Temperature  Status\r
+      ------------------------------------------------------------------------------\r
+      1/1-PHY-01-08                   line-card-module     52.00 C    normal\r
+      \r
+      1/1-Inlet-Air                   management-module    20.62 C    normal\r
+      1/1-Switch-ASIC-Internal        management-module    59.12 C    normal\r
+      1/1-Switch-CPU-1                management-module    58.75 C    normal\r
+      1/1-Switch-CPU-2                management-module    60.62 C    normal\r
+      \r
+      sw07#\x20
+  - "show module\n": |-
+      show module\r
+      \r
+      Management Modules\r
+      ==================\r
+      \r
+           Product                                        Serial\r
+      Name Number  Description                            Number     Status\r
+      ---- ------- -------------------------------------- ---------- ----------------\r
+      1/1  S4R23A  6000 8G CL4 2F 67W Sw                  <removed>  Ready\r
+      \r
+      \r
+      Line Modules\r
+      ============\r
+      \r
+           Product                                        Serial\r
+      Name Number  Description                            Number     Status\r
+      ---- ------- -------------------------------------- ---------- ----------------\r
+      1/1  S4R23A  6000 8G CL4 2F 67W Sw                  <removed>  Ready\r
+      \r
+      \r
+      sw07#\x20
+  - "show interface transceiver\n": |-
+      show interface transceiver\r
+      No matching interfaces\r
+      sw07#\x20
+  - "show system\n": |-
+      show system\r
+      Hostname               : sw07                          \r
+      System Description     : PL.10.16.1010                 \r
+      System Contact         : <removed>                     \r
+      System Location        : <removed>                          \r
+      \r
+      Vendor                 : HPE ANW                       \r
+      Product Name           : S4R23A 6000 8G CL4 2F 67W Sw         \r
+      Chassis Serial Nbr     : <removed>                     \r
+      Base MAC Address       : 00c84e-000000                 \r
+      AOS-CX Version         : PL.10.16.1010                 \r
+      \r
+      Time Zone              : Europe/Amsterdam              \r
+      \r
+      Up Time                : 4 weeks, 19 hours, 41 minutes                               \r
+      CPU Util (%)           : 71                            \r
+      CPU Util (% avg 1 min) : 18                            \r
+      CPU Util (% avg 5 min) : 9                             \r
+      Memory Usage (%)       : 16                            \r
+      sw07#\x20
+  - "show running-config\n": |-
+      show running-config\r
+      Current configuration:\r
+      !\r
+      !Version AOS-CX PL.10.16.1010\r
+      !export-password: default\r
+      hostname sw07\r
+      user admin group administrators password ciphertext <removed>\r
+      user oxidized group administrators password ciphertext <removed>\r
+      user contose-adm group administrators password ciphertext <removed>\r
+      clock timezone europe/amsterdam\r
+      ntp server ntp.time.nl minpoll 4 maxpoll 4 iburst\r
+      ntp server pool.ntp.org minpoll 4 maxpoll 4 iburst\r
+      ntp enable\r
+      !\r
+      !\r
+      !\r
+      !\r
+      !\r
+      !\r
+      user oxidized authorized-key ssh-ed25519 <removed> oxidized@<removed>\r
+      ssh server vrf default\r
+      vlan 1\r
+      vlan 21\r
+          name Rack/Management\r
+      vlan 51\r
+          name vast\r
+      vlan 52\r
+          name wifi\r
+      vlan 53\r
+          name 'BYOD'\r
+      vlan 55\r
+          name 'MGMT'\r
+      spanning-tree\r
+      spanning-tree bpdu-guard timeout 300\r
+      port-access port-security enable\r
+      interface 1/1/1\r
+          description workstation\r
+          no shutdown\r
+          vlan access 51\r
+          spanning-tree bpdu-guard\r
+          spanning-tree port-type admin-edge\r
+          port-access port-security\r
+              enable\r
+              client-limit 2\r
+      interface 1/1/2\r
+          description workstation\r
+          no shutdown\r
+          vlan access 51\r
+          spanning-tree bpdu-guard\r
+          spanning-tree port-type admin-edge\r
+          port-access port-security\r
+              enable\r
+              client-limit 2\r
+      interface 1/1/3\r
+          description workstation\r
+          no shutdown\r
+          vlan access 51\r
+          spanning-tree bpdu-guard\r
+          spanning-tree port-type admin-edge\r
+          port-access port-security\r
+              enable\r
+              client-limit 2\r
+      interface 1/1/4\r
+          description workstation\r
+          no shutdown\r
+          vlan access 51\r
+          spanning-tree bpdu-guard\r
+          spanning-tree port-type admin-edge\r
+          port-access port-security\r
+              enable\r
+              client-limit 2\r
+      interface 1/1/5\r
+          description byod\r
+          no shutdown\r
+          vlan access 53\r
+          spanning-tree bpdu-guard\r
+          spanning-tree port-type admin-edge\r
+          port-access port-security\r
+              enable\r
+              client-limit 2\r
+      interface 1/1/6\r
+          description byod\r
+          no shutdown\r
+          vlan access 53\r
+          spanning-tree bpdu-guard\r
+          spanning-tree port-type admin-edge\r
+          port-access port-security\r
+              enable\r
+              client-limit 2\r
+      interface 1/1/7\r
+          description byod\r
+          no shutdown\r
+          vlan access 53\r
+          spanning-tree bpdu-guard\r
+          spanning-tree port-type admin-edge\r
+          port-access port-security\r
+              enable\r
+              client-limit 2\r
+      interface 1/1/8\r
+          description uplink\r
+          no shutdown\r
+          vlan trunk native 1\r
+          vlan trunk allowed all\r
+      interface 1/1/9\r
+          shutdown\r
+          vlan access 1\r
+      interface 1/1/10\r
+          shutdown\r
+          vlan access 1\r
+      interface vlan 1\r
+          no ip dhcp\r
+          no ipv6 dhcp\r
+      interface vlan 55\r
+          ip address 192.0.2.10/24\r
+      snmp-server vrf default\r
+      snmp-server system-location <removed>\r
+      snmp-server system-contact <removed>\r
+      snmp-server community <removed>\r
+      ip route 0.0.0.0/0 192.0.2.254 \r
+      !\r
+      !\r
+      !\r
+      !\r
+      !\r
+      https-server vrf default\r
+      sw07#\x20
+  - "exit\n": |-
+      exit\r

--- a/spec/model/data/aoscx#CX6200_10.16.1020_environment#output.txt
+++ b/spec/model/data/aoscx#CX6200_10.16.1020_environment#output.txt
@@ -18,7 +18,7 @@
 !                                       Power Usage (W)      PSU Output (W) 
 ! Name Description                     Instant   Average   Instant   Average
 ! ----------------------------------------------------------------------------
-! 1    6200F 12G CL4 2G/2SFP+ 139W       36.00     33.63       N/A       N/A
+! 1    6200F 12G CL4 2G/2SFP+ 139W       <power hidden>
 ! 
 ! 
 ! show environment power-redundancy

--- a/spec/model/data/aoscx#CX6300_10.16.1020_environment#output.txt
+++ b/spec/model/data/aoscx#CX6300_10.16.1020_environment#output.txt
@@ -34,8 +34,8 @@
 ! Mbr/  Product  Input  Normal     Present    Average    Input Voltage Violations:       Recovery  Recovery
 ! PSU   Number   Type   Input (V)  Input (V)  Input (V)  Count  Most Recent Event           Count  Time
 ! -----------------------------------------------------------------------------------------------------------------------------
-! 1/1   JL087A   AC     99-264         233.9      234.4      0  N/A                             0  N/A                         
-! 1/2   JL087A   AC     99-264         233.2      233.9      0  N/A                             0  N/A                         
+! 1/1   JL087A   AC     99-264         <voltage hidden>      0  N/A                             0  N/A                         
+! 1/2   JL087A   AC     99-264         <voltage hidden>      0  N/A                             0  N/A                         
 ! 
 ! 
 ! show environment power-consumption

--- a/spec/model/data/aoscx#CX8100_10.16.1020_environment#output.txt
+++ b/spec/model/data/aoscx#CX8100_10.16.1020_environment#output.txt
@@ -39,8 +39,8 @@
 ! Mbr/  Product  Input  Normal     Present    Average    Input Voltage Violations:       Recovery  Recovery
 ! PSU   Number   Type   Input (V)  Input (V)  Input (V)  Count  Most Recent Event           Count  Time
 ! -----------------------------------------------------------------------------------------------------------------------------
-! 1/1   JL600A   AC     90-264         231.0      230.6      0  N/A                             0  N/A                         
-! 1/2   JL600A   AC     90-264         230.2      230.0      0  N/A                             0  N/A                         
+! 1/1   JL600A   AC     90-264         <voltage hidden>      0  N/A                             0  N/A                         
+! 1/2   JL600A   AC     90-264         <voltage hidden>      0  N/A                             0  N/A                         
 ! 
 ! 
 ! show environment power-consumption

--- a/spec/model/data/aoscx#CX8360_10.16.1020_environment#output.txt
+++ b/spec/model/data/aoscx#CX8360_10.16.1020_environment#output.txt
@@ -47,8 +47,8 @@
 ! Mbr/  Product  Input  Normal     Present    Average    Input Voltage Violations:       Recovery  Recovery
 ! PSU   Number   Type   Input (V)  Input (V)  Input (V)  Count  Most Recent Event           Count  Time
 ! -----------------------------------------------------------------------------------------------------------------------------
-! 1/1   JL601A   AC     90-264         230.0      229.7      0  N/A                             0  N/A                         
-! 1/2   JL601A   AC     90-264         229.0      228.9      0  N/A                             0  N/A                         
+! 1/1   JL601A   AC     90-264         <voltage hidden>      0  N/A                             0  N/A                         
+! 1/2   JL601A   AC     90-264         <voltage hidden>      0  N/A                             0  N/A                         
 ! 
 ! 
 ! show environment power-consumption


### PR DESCRIPTION
## Pre-Request Checklist

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Two `show environment` sub-sections on ArubaOS-CX report values that change on
every poll, producing a spurious config diff each time Oxidized runs. This PR
filters both.

### 1. `show environment power-consumption` — rows with `N/A` PSU output (the original report)

On switches whose PSU Output columns read `N/A`, the row ends in `N/A` rather
than a decimal, so the existing filter didn't match it and the changing
"Average" watt value leaked:

```diff
-! 1    6000 8G CL4 2F 67W Sw              7.00      6.84       N/A       N/A
+! 1    6000 8G CL4 2F 67W Sw              <power hidden>
```

The regex now allows an optional trailing run of `N/A` columns, keeping the same
literal-space / `N\/A` style already used by the fan-speed filter in this model.

### 2. `show environment power-supply input-voltage` (reported by @rudybroersma)

This section wasn't filtered at all, so the present/average input voltage
changed constantly:

```diff
-! 1/1   JL601A   AC     90-264         230.0      229.7      0  N/A ...
+! 1/1   JL601A   AC     90-264         <voltage hidden>      0  N/A ...
```

The two changing voltage columns are hidden; the static input range, the
violation/recovery counts and the event fields are kept.

### Verification

- Covered by the existing YAML simulation fixtures (CX6200, CX8360, CX10000,
  CX6300, CX8100) plus a new fixture for the reported CX 6000 8G (S4R23A)
  (capture kindly provided by @systeembeheerder).
- @rudybroersma confirmed the input-voltage fix against a real switch (PSU
  JL085A): https://github.com/ytti/oxidized/issues/3864#issuecomment-4925949974
- `rake test` green, `rubocop` clean.

### Notes for the model maintainer

- The issue thread suggested `\s` in the power-consumption regex; I used literal
  ` +N\/A` instead, to match the existing style in this model (which never uses
  `\s`) and to avoid `\s` matching across line boundaries. The input-voltage
  column-skip uses `(?:\S+ +){3}` to stay consistent with the fan-speed regex.
- The input-voltage filter assumes the AC form seen on all captured devices
  (a `<min>-<max>` Normal-Input range and two numeric Present/Average columns).
  A DC PSU, or a boot state where the average hasn't populated yet (`N/A`),
  wouldn't match — happy to widen it if someone hits that with a simulation file.

Closes #3864

cc @robertcheramy (aoscx model maintainer)
