### PR TITLE
junos: redact cleartext passwords embedded in archive-site URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - tplink: use `\r\n` as the line terminator in pre_logout, required for the model unit tests to work (@Vantomas)
 
 ### Fixed
+- junos: redact cleartext passwords embedded in archive-site URLs. Fixes #3640 (@KalebFenley)
 - siklu: allow parenthesis in prompt. Fixes #3841 (@ytti)
 - fortios: allow parenthesis in prompt. Fixes #3846 (@ytti)
 - fortigate: prompt can contain HA cluster status. Fixes #3846 (@robertcheramy)

--- a/lib/oxidized/model/junos.rb
+++ b/lib/oxidized/model/junos.rb
@@ -19,6 +19,10 @@ class JunOS < Oxidized::Model
     cfg.gsub!(/community (\S+) {/, 'community <hidden> {')
     cfg.gsub!(/(ssh-(rsa|dsa|ecdsa|ecdsa-sk|ed25519|ed25519-sk) )".*; ## SECRET-DATA/, '<secret removed>')
     cfg.gsub!(/ "\$\d\$\S+; ## SECRET-DATA/, ' <secret removed>;')
+    # archive-site URLs may carry a cleartext password (user:pass@host) that
+    # Junos does not tag with "## SECRET-DATA", e.g. under
+    # system archival configuration archive-sites
+    cfg.gsub!(/((?:ftp|pasvftp|sftp|scp|https?):\/\/[^\/@"]+):[^@"]+@/, '\1:<secret removed>@')
     cfg
   end
 

--- a/spec/model/data/junos#srx300_22.4#output.txt
+++ b/spec/model/data/junos#srx300_22.4#output.txt
@@ -66,6 +66,15 @@ system {
             authorization info;
         }
     }
+    archival {
+        configuration {
+            transfer-on-commit;
+            archive-sites {
+                "pasvftp://demouser:CorrectHorseBattery@203.0.113.10/backup/";
+                "ftp://demouser2@203.0.113.11/backup/" password "$9$FAKEHASHDATAXXXXXXXXXXXXXXXXXXXX"; ## SECRET-DATA
+            }
+        }
+    }
     max-configurations-on-flash 5;
     max-configuration-rollbacks 5;
     license {

--- a/spec/model/data/junos#srx300_22.4#secret.yaml
+++ b/spec/model/data/junos#srx300_22.4#secret.yaml
@@ -1,0 +1,6 @@
+pass:
+  - '"pasvftp://demouser:<secret removed>@203\.0\.113\.10/backup/";'
+  - '"ftp://demouser2@203\.0\.113\.11/backup/" password <secret removed>;'
+fail:
+  - 'CorrectHorseBattery'
+  - 'FAKEHASHDATAXXXXXXXXXXXXXXXXXXXX'

--- a/spec/model/data/junos#srx300_22.4#simulation.yaml
+++ b/spec/model/data/junos#srx300_22.4#simulation.yaml
@@ -84,6 +84,15 @@ commands:
                 authorization info;
             }
         }
+        archival {
+            configuration {
+                transfer-on-commit;
+                archive-sites {
+                    \"pasvftp://demouser:CorrectHorseBattery@203.0.113.10/backup/\";
+                    \"ftp://demouser2@203.0.113.11/backup/\" password \"$9$FAKEHASHDATAXXXXXXXXXXXXXXXXXXXX\"; ## SECRET-DATA
+                }
+            }
+        }
         max-configurations-on-flash 5;
         max-configuration-rollbacks 5;
         license {


### PR DESCRIPTION
## Pre-Request Checklist
- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [x] Changes are reflected in the documentation
- [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

Junos accepts credentials directly in an archive-site URL, e.g.
`"pasvftp://user:password@host"`, and does not tag this form with
`## SECRET-DATA` the way it does the separate hashed `password "$9$..."`
clause. The existing `cmd :secret` regexes only match the SECRET-DATA
tag, so these cleartext passwords were being written to the backup
repo unredacted.

This adds a regex that matches `user:pass@host` across the archive-site
schemes (ftp, pasvftp, sftp, scp, http, https) and redacts just the
password, consistent with how the hashed form is already handled.

Added `spec/model/data/junos#srx300_22.4#secret.yaml` plus matching
archive-site fixture lines in the `srx300_22.4` simulation/output data,
covering both the cleartext-in-URL case and the existing hashed-password
case (regression guard).

Closes #3640