### PR TITLE
Fix: os6: hide snmp-server community strings when remove_secret is set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - junos: redact cleartext passwords embedded in archive-site URLs. Fixes #3640 (@KalebFenley)
 - siklu: allow parenthesis in prompt. Fixes #3841 (@ytti)
 - fortios: allow parenthesis in prompt. Fixes #3846 (@ytti)
+- os6: hide snmp-server community strings in the secret filter (@Jurgen1994)
 - fortigate: prompt can contain HA cluster status. Fixes #3846 (@robertcheramy)
 - aoscx: hide power consumption on rows where PSU output is N/A. Fixes #3864 (@FusionBrah)
 - aoscx: hide input voltage readings in "show environment power-supply input-voltage". Fixes #3864 (@FusionBrah)

--- a/lib/oxidized/model/os6.rb
+++ b/lib/oxidized/model/os6.rb
@@ -14,6 +14,7 @@ class OS6 < Oxidized::Model
 
   cmd :secret do |cfg|
     cfg.gsub! /(password )(\S+)/, '\1<secret hidden>'
+    cfg.gsub! /^(snmp-server community )\S+(.*)/, '\1<secret hidden>\2'
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist

  - [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
  - [ ] Tests added or adapted (try `rake test`)
  - [x] Changes are reflected in the documentation
  - [x] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

  ## Description

  With `remove_secret: true`, the os6 model (Dell EMC Networking OS6 / N-Series,  e.g. N1548) only masks `password <hash>` lines in its secret filter. SNMP community strings pass through unmodified, so a line like

      snmp-server community "public" rw

  is committed to the output repo in plaintext — and an `rw` community is effectively a write credential for the switch.

  This adds one substitution to the existing `cmd :secret` block:

      cfg.gsub! /^(snmp-server community )\S+(.*)/, '\1<secret hidden>\2'

  matching how `powerconnect` and `procurve` already treat `snmp-server community` lines.

  Tested against a Dell N1548 running config:

      snmp-server community "public" rw
      → snmp-server community <secret hidden> rw

  Non-secret lines are unaffected, and behavior is unchanged when `remove_secret` is not set (the `:secret` block doesn't run then).