### PR TITLE
Make 'ip' field resolvable

### DIFF
--- a/lib/oxidized/node.rb
+++ b/lib/oxidized/node.rb
@@ -20,7 +20,10 @@ module Oxidized
       logger.debug 'IPADDR %s' % ip_addr.to_s
       @name = opt[:name]
       @ip = IPAddr.new(ip_addr).to_s rescue nil
-      @ip ||= Resolv.new.getaddress(@name) if Oxidized.config.resolve_dns?
+      if Oxidized.config.resolve_dns?
+        @ip ||= Resolv.new.getaddress(ip_addr) rescue nil unless ip_addr.nil? || ip_addr.empty?
+        @ip ||= Resolv.new.getaddress(@name) rescue nil
+      end
       @ip ||= @name
       @group = opt[:group]
       @model = resolve_model opt


### PR DESCRIPTION
enabled and ip_addr is present, falling back to resolving `name` only when ip_addr is nil or empty, preserving prior behavior for that case.

## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [x] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [x] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
<!-- Describe your changes here. -->

<!-- Add a text similar to "Closes issue #" if this PR relates to an existing issue. -->
