### PR TITLE
Improve SixWind config collection and secret filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - vsololt: new model for VSOL GPON OLT (@Vantomas)
 - tplink: add simulation data and unit tests for the TP-Link DeltaStream DS-P7001-08 GPON OLT (@Vantomas)
 - device2yaml: add `-n`/`--newline` option to set the command line terminator (e.g. `-n "\r\n"`) for devices that submit a command only on a carriage return; the terminator is recorded as a `command_newline` key in the generated YAML (@Vantomas)
+- sixwind: support configurable hierarchical and fullpath configuration outputs (@hcaldicott)
 
 ### Changed
 - docker: set LANG=C.UTF-8. Fixes #3690 (@ytti)
@@ -24,6 +25,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - fortigate: prompt can contain HA cluster status. Fixes #3846 (@robertcheramy)
 - aoscx: hide power consumption on rows where PSU output is N/A. Fixes #3864 (@FusionBrah)
 - aoscx: hide input voltage readings in "show environment power-supply input-voltage". Fixes #3864 (@FusionBrah)
+- sixwind: preserve the `secret` keyword in RADIUS server address lines and
+  redact change-of-authorization server secrets (@hcaldicott)
 
 ## [0.37.0 - 2026-05-20]
 ### Added

--- a/docs/Model-Notes/SixWind.md
+++ b/docs/Model-Notes/SixWind.md
@@ -1,0 +1,78 @@
+# 6WIND VSR
+
+## Configuration formats
+
+The SixWind model supports two configuration formats: hierarchical and fullpath.
+It stores backups in the hierarchical format by default and collects the
+fullpath format as an alternative output. The default format can be swapped,
+and the alternative backup format disabled, if required.
+
+The behaviour can be changed with variables:
+
+```yaml
+models:
+  sixwind:
+    vars:
+      sixwind_default_storage_type: hierarchical
+      sixwind_store_alternative: true
+```
+
+`sixwind_default_storage_type` accepts `hierarchical` or `fullpath`. The default
+is `hierarchical` when undefined.
+
+`sixwind_store_alternative` accepts the YAML booleans `true` or `false`. The
+default is `true` when undefined. When set to `false`, only the default format
+is collected.
+
+| Default format | Main configuration command         | Alternative output       |
+|----------------|------------------------------------|--------------------------|
+| `hierarchical` | `show config nodefault`            | `sixwind-fullpath`       |
+| `fullpath`     | `show config nodefault fullpath`   | `sixwind-hierarchical`   |
+
+## Alternative output storage
+
+Alternative configurations use the Oxidized
+[output types](/docs/Outputs.md#output-types) feature. By default, each output
+type is stored in a separate repository alongside the main repository.
+
+Set `type_as_directory` to store both formats in the same Git repository:
+
+```yaml
+output:
+  default: git
+  git:
+    user: Oxidized
+    email: user@example.com
+    repo: "/var/lib/oxidized/devices.git"
+    type_as_directory: true
+```
+
+With this setting, alternative configurations are stored beneath the
+`sixwind-fullpath` or `sixwind-hierarchical` directory. The normal Oxidized
+fetch and Web UI download return only the configured default format. The
+alternative format must be retrieved directly from the underlying storage.
+
+## Secret removal
+
+This model uses the standard `remove_secret` variable to replace values
+following the `password` or `secret` keywords with `<secret hidden>`. It can be
+enabled globally:
+
+```yaml
+vars:
+  remove_secret: true
+```
+
+To enable secret removal for SixWind only, configure it at model scope:
+
+```yaml
+models:
+  sixwind:
+    vars:
+      remove_secret: true
+```
+
+This includes password or secret commands with an optional numeric type. Other
+sensitive values, such as private keys, are not currently removed by the model.
+
+Back to [Model-Notes](README.md)

--- a/docs/Supported-OS-Types.md
+++ b/docs/Supported-OS-Types.md
@@ -3,7 +3,7 @@
 |Vendor              |OS model                      |oxidized model                                   |model maintainers|comment / model notes|
 |--------------------|------------------------------|-------------------------------------------------|-----------------|---------------------|
 |-generic-           |Cisco-like                    |[defacto](/lib/oxidized/model/defacto.rb)        |@ytti, @robertcheramy|[The defacto model may work on cisco like CLIs](/docs/Creating-Models.md#use-the-defacto-model)|
-|6WIND               |VSR                           |[sixwind](/lib/oxidized/model/sixwind.rb)        |@hcaldicott      |
+|6WIND               |VSR                           |[sixwind](/lib/oxidized/model/sixwind.rb)        |@hcaldicott      |[6WIND VSR](Model-Notes/SixWind.md)|
 |A10 Networks        |ACOS                          |[acos](/lib/oxidized/model/acos.rb)              |                 |
 |Accedian Performance Elements (NIDs)|AEN           |[aen](/lib/oxidized/model/aen.rb)
 |Acme Packet         |ACMEPACKET                    |[acmepacket](/lib/oxidized/model/acmepacket.rb)

--- a/lib/oxidized/model/sixwind.rb
+++ b/lib/oxidized/model/sixwind.rb
@@ -9,7 +9,7 @@ class SixWind < Oxidized::Model
   end
 
   cmd :secret do |cfg|
-    cfg.gsub!(/(?<!  {1})(?:password|secret) (?:\d )?\S+/, '\\1 <secret hidden>') # double space to exclude radius password template
+    cfg.gsub!(/\b((?:password|secret)(?: \d)? )\S+/, '\\1<secret hidden>')
     cfg
   end
 
@@ -17,7 +17,51 @@ class SixWind < Oxidized::Model
     comment cfg
   end
 
-  cmd 'show config' do |cfg|
+  # Storage vars:
+  # - sixwind_default_storage_type: "hierarchical" (default) or "fullpath".
+  # - sixwind_store_alternative: true (default) stores the other format as
+  #   "sixwind-fullpath" or "sixwind-hierarchical"; false stores only the default.
+  def sixwind_storage_config
+    default_type = vars(:sixwind_default_storage_type) || 'hierarchical'
+    unless %w[hierarchical fullpath].include?(default_type)
+      raise Oxidized::InvalidConfig,
+            'sixwind_default_storage_type must be "hierarchical" or "fullpath"'
+    end
+
+    store_alternative = vars(:sixwind_store_alternative)
+    store_alternative = true if store_alternative.nil?
+
+    unless [true, false].include?(store_alternative)
+      raise Oxidized::InvalidConfig,
+            'sixwind_store_alternative must be true or false'
+    end
+
+    { default_type: default_type, store_alternative: store_alternative }
+  end
+
+  def sixwind_store_hierarchical?
+    config = sixwind_storage_config
+    config[:default_type] == 'hierarchical' || config[:store_alternative]
+  end
+
+  def sixwind_store_fullpath?
+    config = sixwind_storage_config
+    config[:default_type] == 'fullpath' || config[:store_alternative]
+  end
+
+  cmd 'show config nodefault', if: -> { sixwind_store_hierarchical? } do |cfg|
+    if sixwind_storage_config[:default_type] == 'fullpath'
+      cfg.type = 'sixwind-hierarchical'
+      cfg.name = 'hierarchical'
+    end
+    cfg
+  end
+
+  cmd 'show config nodefault fullpath', if: -> { sixwind_store_fullpath? } do |cfg|
+    if sixwind_storage_config[:default_type] == 'hierarchical'
+      cfg.type = 'sixwind-fullpath'
+      cfg.name = 'fullpath'
+    end
     cfg
   end
 


### PR DESCRIPTION
## Pre-Request Checklist

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [N/A] Tests added or adapted (try `rake test`)
- [X] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
This change consists of a small bugfix for password and secret redaction, as well as a new feature to support multiple config backup formats.

I received a request from another ISP to implement support for backups in the fullpath format, and this change adds some variables that allow this to be configured, while retaining the hierarchical human-readable format by default.

_I have also implemented some config value validation that I have not seen implemented in other models. When invalid values are entered, I raise Oxidized::InvalidConfig. Nothing mentions this being an issue in the contributing guidelines, but I would like feedback if there are concerns about this approach to variable validation._