### PR TITLE
aoscx: mask community string in snmp-server host lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ssh: change max_window_size from 138k to 2MB to avoid triggering Mikrotik bug. Closes #3867 (@ytti)
 
 ### Fixed
+- aoscx: mask the community string in snmp-server host lines instead of the token after the host address. Fixes #3881 (@FusionBrah)
 - junos: redact cleartext passwords embedded in archive-site URLs. Fixes #3640 (@KalebFenley)
 - siklu: allow parenthesis in prompt. Fixes #3841 (@ytti)
 - fortios: allow parenthesis in prompt. Fixes #3846 (@ytti)

--- a/lib/oxidized/model/aoscx.rb
+++ b/lib/oxidized/model/aoscx.rb
@@ -24,7 +24,7 @@ class Aoscx < Oxidized::Model
   cmd :secret do |cfg|
     cfg.gsub! /^(user .* group .*(?: ciphertext)?) \S+/, '\\1 <secret hidden>'
     cfg.gsub! /^(snmp-server community) \S+(.*)/, '\\1 <secret hidden> \\2'
-    cfg.gsub! /^(snmp-server host \S+) \S+(.*)/, '\\1 <secret hidden> \\2'
+    cfg.gsub! /^(snmp-server host \S+ .*community) \S+(.*)/, '\\1 <secret hidden>\\2'
     cfg.gsub! /^(snmpv3 user).*?(auth (?:md5|sha(?:\d{1,3})?) auth-pass ciphertext).*?(priv (?:des|aes(?:\d{1,3})?) priv-pass ciphertext).*/, '\\1 <user> \\2 <auth-pass> \\3 <priv-pass>'
     cfg.gsub! /^(radius-server host \S+ key(?: ciphertext)?) \S+ (.*)/, '\\1 <secret hidden> \\2'
     cfg.gsub! /^(radius-server key).*/, '\\1 <configuration removed>'

--- a/spec/model/data/aoscx#R0X25A-6410_FL.10.10.1100#secret.yaml
+++ b/spec/model/data/aoscx#R0X25A-6410_FL.10.10.1100#secret.yaml
@@ -1,0 +1,8 @@
+fail:
+  - trapcomm
+  - readonlycom
+  - rwsnmpcom
+
+pass:
+  - snmp-server host 10\.7\.32\.31 trap version v2c community <secret hidden>
+  - snmp-server community <secret hidden>


### PR DESCRIPTION
Fixes #3881.

The `snmp-server host` secret filter masked the token directly after the host address (`trap`), leaving the actual community string exposed in backups:

```
snmp-server host 10.1.2.3 <secret hidden>  version v1 community string123
```

This changes the filter to mask the token after the `community` keyword instead:

```
snmp-server host 10.1.2.3 trap version v1 community <secret hidden>
```

Adds `aoscx#R0X25A-6410_FL.10.10.1100#secret.yaml` test data (the existing simulation already contains `snmp-server host ... community` lines). The new test fails against the old regex and passes with the fix. `rake test` and `rubocop` clean.