### PR TITLE
tmos: strip churn-only fields from all command output

### DIFF
--- a/lib/oxidized/model/tmos.rb
+++ b/lib/oxidized/model/tmos.rb
@@ -3,6 +3,12 @@ class TMOS < Oxidized::Model
 
   comment '# '
 
+  cmd :all do |cfg|
+    cfg.gsub!(/^\s*(checksum SHA1:|revision |size |create-time|last-update-time|updated-by|created-by)\b.*$/, '')
+    cfg.gsub!(/^.*\brevision\s+\d+\s*$/, '')
+    cfg
+  end
+
   cmd :secret do |cfg|
     cfg.gsub!(/^([\s\t]*)secret \S+/, '\1secret <secret removed>')
     cfg.gsub!(/^([\s\t]*\S*)password \S+/, '\1password <secret removed>')


### PR DESCRIPTION
## Pre-Request Checklist

- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description

TMOS command output includes several fields — revision counters, checksum SHA1 hashes, size, create-time/last-update time timestamps, and updated-by/created-by identities — that change on every poll without any real configuration change, producing noisy diffs.

Add a cmd :all block so these are stripped unconditionally from every command's output, rather than only when remove_secret is enabled.