### PR TITLE
AosCx: Power is measured to the nearest tenth of a watt.

### DIFF
--- a/lib/oxidized/model/aoscx.rb
+++ b/lib/oxidized/model/aoscx.rb
@@ -57,7 +57,7 @@ class Aoscx < Oxidized::Model
     end
 
     with_section(cfg, 'power-allocation') do |content|
-      content.gsub!(/^(.*) \d+ W$/, '\\1 <power>')
+      content.gsub!(/^(.*) \d+\.\d+ W$/, '\\1 <power>')
     end
 
     with_section(cfg, 'power-supply input-voltage') do |content|


### PR DESCRIPTION
## Pre-Request Checklist
<!-- Not all items apply to each PR, but a great PR addresses all applicable items. -->

- [ ] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [ ] Tests added or adapted (try `rake test`)
- [ ] Changes are reflected in the documentation
- [ ] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fixes a small bug for power-allocation for HPE ANW 6410 Chassis (ArubaOS-CX FL.10.18.0001)
