### PR TITLE
input/cli: raise an error when a requested login credential is missing.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - ingate: redact secrets (private keys, passwords, secrets, passphrases, pre-shared keys, tokens and the SNMP community) when remove_secret is set (@thanegill)
 
 ### Fixed
+- input/cli: raise an error when a requested login credential is missing. Fixes #3700 (@robertcheramy)
 - eos: hide the community string / v3 user in snmp-server host lines. Fixes #3882 (@FusionBrah)
 - aoscx: mask the community string in snmp-server host lines instead of the token after the host address. Fixes #3881 (@FusionBrah)
 - junos: redact cleartext passwords embedded in archive-site URLs. Fixes #3640 (@KalebFenley)

--- a/lib/oxidized/input/cli.rb
+++ b/lib/oxidized/input/cli.rb
@@ -62,10 +62,22 @@ module Oxidized
         match_re << @username if @username
         match_re << @password if @password
         until (match = expect(match_re)) == @node.prompt
-          cmd(@node.auth[:username], nil) if match == @username
-          cmd(@node.auth[:password], nil) if match == @password
+          send_credential(:username) if match == @username
+          send_credential(:password) if match == @password
           match_re.delete match
         end
+      end
+
+      private
+
+      def send_credential(type)
+        credential = @node.auth[type]
+        unless credential.is_a?(String)
+          logger.error "Missing #{type} for CLI login at #{@node.name}"
+          raise ArgumentError, "missing #{type} for CLI login"
+        end
+
+        cmd credential, nil
       end
     end
   end

--- a/spec/input/ssh_spec.rb
+++ b/spec/input/ssh_spec.rb
@@ -149,4 +149,36 @@ describe Oxidized::SSH do
       _(proc { @ssh.cmd(123) }).must_raise ArgumentError
     end
   end
+
+  describe '#login' do
+    before(:each) do
+      @ssh = Oxidized::SSH.new
+      @prompt = /^switch\#$/
+      @password_prompt = /^Password:/
+      @ssh.instance_variable_set(:@password, @password_prompt)
+    end
+
+    it "sends a configured credential" do
+      node = mock("Oxidized::Node")
+      node.stubs(name: 'switch.example.com', prompt: @prompt, auth: { password: 'secret' })
+      @ssh.instance_variable_set(:@node, node)
+      @ssh.expects(:expect).with([@prompt, @password_prompt]).returns(@password_prompt)
+      @ssh.expects(:cmd).with('secret', nil)
+      @ssh.expects(:expect).with([@prompt]).returns(@prompt)
+
+      @ssh.login
+    end
+
+    it "logs an error and raises ArgumentError when a credential is missing" do
+      node = mock("Oxidized::Node")
+      node.stubs(name: 'switch.example.com', prompt: @prompt, auth: { password: nil })
+      @ssh.instance_variable_set(:@node, node)
+      @ssh.expects(:expect).with([@prompt, @password_prompt]).returns(@password_prompt)
+      @ssh.logger.expects(:error).with('Missing password for CLI login at switch.example.com')
+      @ssh.expects(:cmd).never
+
+      error = _(proc { @ssh.login }).must_raise ArgumentError
+      _(error.message).must_equal 'missing password for CLI login'
+    end
+  end
 end


### PR DESCRIPTION
## Pre-Request Checklist
- [X] Passes rubocop code analysis (try `rubocop --auto-correct`)
- [X] Tests added or adapted (try `rake test`)
- [ ] Model changes include a [YAML simulation file](/docs/DeviceSimulation.md) and the [expected output](/docs/ModelUnitTests.md#expected-output)
- [ ] Changes are reflected in the documentation
- [X] User-visible changes appended to [CHANGELOG.md](/CHANGELOG.md)

## Description
Fixes the unclear error reported in #3700.

The original cause of the missing credential could not be reproduced. However, the stack trace shows that the CLI login attempted to send a nil password after matching a password prompt.

This change adds defensive validation before sending username or password credentials. If a requested credential is missing or is not a string, Oxidized now raises an explicit ArgumentError identifying the missing credential instead of failing later in the SSH or Telnet input implementation with an unrelated NoMethodError.

Closes issue #3700

